### PR TITLE
Fix Dev Container config and document development environment setup

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-      - ../../honeyledger:/workspaces/honeyledger:cached
+      - ..:/workspaces/honeyledger:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "honeyledger",
   "dockerComposeFile": "compose.yaml",
   "service": "rails-app",
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/workspaces/honeyledger",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The development server can be started with:
 bin/rails server
 ```
 
-Tests can be ran with:
+Tests can be run with:
 ```
 bin/rails test
 ```


### PR DESCRIPTION
Using a container volume on Linux resulted in a user ownership mismatch that was thought to have been resolved in 25dc89420332b2aaaca0b6442eec13d590839a90 when working on Windows.

This approach rolls back to the initial config provided by `rails-new app --devcontainer`, while also correcting the PostgreSQL port to forward to the right container and removing the assumption that the local workspace directory is named `honeyledger`.

Instructions for setting up the development environment have also been added to the readme.

This configuration should now work on Windows (WSL), Linux, and Mac without any additional changes.