### PR TITLE
Load Minitest plugins

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ SimpleCov.formatters = [
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+Minitest.load_plugins
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
Resolves the "Test framework quit unexpectedly" error in RubyMine.