### PR TITLE
Improve handling opening balances

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -5,7 +5,7 @@ class AccountsController < ApplicationController
 
   # GET /accounts or /accounts.json
   def index
-    @accounts = current_user.accounts.includes(:currency, :opening_balance_transaction)
+    @accounts = current_user.accounts.real.includes(:currency)
   end
 
   # GET /accounts/1 or /accounts/1.json
@@ -28,7 +28,7 @@ class AccountsController < ApplicationController
 
   # GET /accounts/1/edit
   def edit
-    if @account.opening_balance_transaction.nil?
+    if @account.opening_balance_transaction.blank?
       @account.build_opening_balance_transaction
     end
   end
@@ -37,7 +37,6 @@ class AccountsController < ApplicationController
   def create
     @account = current_user.accounts.build(account_params)
     @account.simplefin_account = @simplefin_account
-    update_opening_balance_transaction
 
     respond_to do |format|
       if @account.save
@@ -53,7 +52,6 @@ class AccountsController < ApplicationController
   # PATCH/PUT /accounts/1 or /accounts/1.json
   def update
     @account.assign_attributes(account_params)
-    update_opening_balance_transaction
 
     respond_to do |format|
       if @account.save
@@ -85,25 +83,7 @@ class AccountsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def account_params
-      params.expect(account: [ :name, :kind, :currency_id, opening_balance_transaction_attributes: [ :amount_minor, :transacted_at ] ])
-    end
-
-    def update_opening_balance_transaction
-      return unless @account.opening_balance_transaction.present?
-
-      # Handle opening balance transaction
-      if @account.opening_balance_transaction.amount_minor.positive?
-        opening_balance_tx = @account.opening_balance_transaction
-        opening_balance_tx.user = current_user
-        opening_balance_tx.src_account = Account.find_or_create_by(user: current_user, name: "Opening Balances", kind: :revenue, currency: @account.currency)
-        opening_balance_tx.dest_account = @account
-        opening_balance_tx.description = "Opening balance"
-        opening_balance_tx.currency = @account.currency
-        opening_balance_tx.opening_balance = true
-        opening_balance_tx.cleared_at = opening_balance_tx.transacted_at
-      else
-        @account.opening_balance_transaction = nil
-      end
+      params.expect(account: [ :name, :kind, :currency_id, opening_balance_transaction_attributes: [ :amount, :transacted_at ] ])
     end
 
     def set_simplefin_account

--- a/app/javascript/controllers/transactions/form_controller.js
+++ b/app/javascript/controllers/transactions/form_controller.js
@@ -1,17 +1,41 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "srcAccount", "destAccount", "type", "currency", "error" ]
+  static targets = [ "srcAccount", "destAccount", "type", "amount", "currency", "error" ]
+  static values = { accountName: String, openingBalance: Boolean, targetAccountName: String }
 
   connect() {
-    this.updateEnabledAccounts(false)
-    this.updateCurrency()
-    this.updateType()
+    if (this.isOpeningBalance()) {
+      this.updateFieldsFromOpeningBalanceAmount()
+    } else {
+      this.updateEnabledAccounts(false)
+      this.updateCurrency()
+      this.updateTypeFromSelectedAccounts()
+    }
   }
 
   clearError() {
     if (this.hasErrorTarget) {
       this.errorTarget.remove()
+    }
+  }
+
+  updateFieldsFromOpeningBalanceAmount() {
+    if (!this.isOpeningBalance() || !this.hasAmountTarget) return
+
+    const amount = this.amountTarget.value
+    if (amount > 0) {
+      this.updateTypeTarget("deposit")
+      this.updateSrcAccountSpan("Opening Balance")
+      this.updateDestAccountSpan(this.targetAccountNameValue)
+    } else if (amount < 0) {
+      this.updateTypeTarget("withdrawal")
+      this.updateSrcAccountSpan(this.targetAccountNameValue)
+      this.updateDestAccountSpan("Opening Balance")
+    } else {
+      this.updateTypeTarget("")
+      this.updateSrcAccountSpan("")
+      this.updateDestAccountSpan("")
     }
   }
 
@@ -56,28 +80,22 @@ export default class extends Controller {
     this.currencyTarget.textContent = currency
   }
 
-  updateType() {
-    if (!this.hasSrcAccountTarget || !this.hasDestAccountTarget || !this.hasTypeTarget) return
+  updateTypeFromSelectedAccounts() {
+    if (!this.hasSrcAccountTarget || !this.hasDestAccountTarget) return
 
     const { kind: srcKind } = this.selectedAccount(this.srcAccountTarget)
     const { kind: destKind } = this.selectedAccount(this.destAccountTarget)
 
-    let label = ""
-    let color = "gray"
-
+    let type = undefined
     if (destKind === "expense") {
-      label = "↓ Withdrawal"
-      color = "red"
+      type = "withdrawal"
     } else if (srcKind === "revenue") {
-      label = "↑ Deposit"
-      color = "green"
+      type = "deposit"
     } else if (srcKind && destKind) {
-      label = "⇄ Transfer"
-      color = "gray"
+      type = "transfer"
     }
 
-    this.typeTarget.textContent = label
-    this.typeTarget.style.color = color
+    this.updateTypeTarget(type)
   }
 
   selectedAccount(select) {
@@ -90,5 +108,40 @@ export default class extends Controller {
       kind: option.dataset.kind || undefined,
       currency: option.dataset.currency || undefined
     }
+  }
+
+  typeLabel(type) {
+    switch (type) {
+      case "withdrawal":
+        return [ "↓ Withdrawal", "red" ]
+      case "deposit":
+        return [ "↑ Deposit", "green" ]
+      case "transfer":
+        return [ "⇄ Transfer", "gray" ]
+      default:
+        return [ "", "" ]
+    }
+  }
+
+  updateTypeTarget(type) {
+    if (!this.hasTypeTarget) return
+
+    const [ label, color ] = this.typeLabel(type)
+    this.typeTarget.textContent = label
+    this.typeTarget.style.color = color
+  }
+
+  updateSrcAccountSpan(accountName) {
+    if (!this.hasSrcAccountTarget || this.srcAccountTarget.tagName !== "SPAN") return
+    this.srcAccountTarget.textContent = accountName
+  }
+
+  updateDestAccountSpan(accountName) {
+    if (!this.hasDestAccountTarget || this.destAccountTarget.tagName !== "SPAN") return
+    this.destAccountTarget.textContent = accountName
+  }
+
+  isOpeningBalance() {
+    return this.hasOpeningBalanceValue && this.openingBalanceValue
   }
 }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,35 +1,109 @@
 class Account < ApplicationRecord
   belongs_to :user
-  belongs_to :currency
+  belongs_to :currency, optional: true
 
+  # Transactions (source, destination, opening balance)
+  before_destroy -> { opening_balance_transaction.destroy! }, if: -> { opening_balance_transaction.present? && empty? }
   has_many :src_transactions, class_name: "Transaction", foreign_key: "src_account_id", dependent: :restrict_with_error
   has_many :dest_transactions, class_name: "Transaction", foreign_key: "dest_account_id", dependent: :restrict_with_error
-  has_one :opening_balance_transaction, -> { opening_balances }, class_name: "Transaction", foreign_key: "dest_account_id", dependent: :destroy
-  accepts_nested_attributes_for :opening_balance_transaction
+  before_validation :assign_opening_balance_transaction_attributes, if: -> { opening_balance_transaction.present? }
+  validate :opening_balance_transaction_is_valid, if: -> { opening_balance_transaction.present? }
+  after_save :save_or_destroy_opening_balance_transaction, if: -> { opening_balance_transaction.present? }
 
   has_one :simplefin_account, class_name: "Simplefin::Account", foreign_key: :ledger_account_id, dependent: :nullify
 
-  enum :kind, { asset: 0, liability: 1, equity: 2, expense: 3, revenue: 4 }
-  SOURCEABLE = [ :asset, :liability, :equity, :revenue ].freeze
-  DESTINABLE = [ :asset, :liability, :equity, :expense ].freeze
+  enum :kind, %i[ asset liability equity expense revenue ]
+  SOURCEABLE = %i[ asset liability equity revenue ].freeze
+  DESTINABLE = %i[ asset liability equity expense ].freeze
+  scope :sourceable, -> { where(kind: SOURCEABLE).real }
+  scope :destinable, -> { where(kind: DESTINABLE).real }
 
+  validates :currency, presence: true, unless: :virtual?
   validates :name, presence: true
 
-  scope :assets, -> { where(kind: :asset) }
-  scope :liabilities, -> { where(kind: :liability) }
-  scope :equities, -> { where(kind: :equity) }
-  scope :expenses, -> { where(kind: :expense) }
-  scope :revenues, -> { where(kind: :revenue) }
-
-  scope :sourceable, -> { where(kind: SOURCEABLE) }
-  scope :destinable, -> { where(kind: DESTINABLE) }
-
-  scope :linkable, -> { where(kind: [ :asset, :liability ]) }
+  scope :real, -> { where(virtual: false) }
+  scope :virtual, -> { where(virtual: true) }
+  scope :linkable, -> { where(kind: %i[ asset liability ]) }
   scope :unlinked, -> { left_joins(:simplefin_account).where(simplefin_accounts: { id: nil }) }
+
+  def self.opening_balance_for(user:, kind:)
+    attributes = { user: user, kind: kind, name: "Opening Balance", virtual: true }
+    Account.find_or_create_by!(attributes)
+  rescue ActiveRecord::RecordNotUnique
+    Account.find_by(attributes) || raise
+  end
+
+  def build_opening_balance_transaction(transaction_attributes = {})
+    @opening_balance_transaction = Transaction.new({
+      user: user,
+      currency: currency,
+      opening_balance: true,
+      opening_balance_target_account: self
+    }.merge(transaction_attributes))
+  end
+
+  def opening_balance_transaction
+    @opening_balance_transaction ||= Transaction.where(src_account: self)
+      .or(Transaction.where(dest_account: self))
+      .opening_balances
+      .first
+  end
+
+  def opening_balance_transaction=(transaction)
+    @opening_balance_transaction = transaction
+  end
+
+  def opening_balance_transaction_attributes=(transaction_attributes)
+    transaction = opening_balance_transaction || build_opening_balance_transaction
+    transaction.assign_attributes(transaction_attributes)
+    @opening_balance_transaction = transaction
+  end
+
+  def empty?
+    count = Transaction.where(src_account: self).or(Transaction.where(dest_account: self)).count
+    count -= 1 if opening_balance_transaction.present?
+    count.zero?
+  end
+
+  def real?
+    !virtual?
+  end
 
   # Check if a user has access to this account
   # Currently checks ownership, but can be extended for sharing
   def accessible_by?(user)
     user_id == user.id
   end
+
+  private
+
+    def assign_opening_balance_transaction_attributes
+      opening_balance_transaction.user = user
+      opening_balance_transaction.currency = currency
+      opening_balance_transaction.opening_balance = true
+      opening_balance_transaction.opening_balance_target_account = self
+    end
+
+    def opening_balance_transaction_is_valid
+      unless opening_balance_transaction.valid?
+        opening_balance_transaction.errors.each do |error|
+          if %i[ amount amount_minor ].include?(error.attribute) && %i[ blank zero ].include?(error.type)
+            # Skip these errors as the transaction will be destroyed instead
+            next
+          end
+
+          errors.objects.append(ActiveModel::NestedError.new(opening_balance_transaction, error, attribute: :"opening_balance_transaction.#{error.attribute}"))
+        end
+      end
+    end
+
+    def save_or_destroy_opening_balance_transaction
+      if opening_balance_transaction.amount_written? && opening_balance_transaction.amount.to_d.zero?
+        opening_balance_transaction.destroy!
+      elsif !opening_balance_transaction.amount_written? && opening_balance_transaction.amount_minor.to_i.zero?
+        opening_balance_transaction.destroy!
+      else
+        opening_balance_transaction.save!
+      end
+    end
 end

--- a/app/models/concerns/minorable.rb
+++ b/app/models/concerns/minorable.rb
@@ -34,7 +34,7 @@ module Minorable
         # def amount
         define_method unminored_attribute do
           unminored = instance_variable_get("@#{unminored_attribute}")
-          return unminored if unminored.present?
+          return unminored if send("#{unminored_attribute}_written?")
 
           currency = Helpers.dig_send(self, with)
           return nil if currency.nil?
@@ -62,9 +62,14 @@ module Minorable
           instance_variable_set("@#{unminored_attribute}_written", false)
         end
 
+        # def amount_written?
+        define_method "#{unminored_attribute}_written?" do
+          !!instance_variable_get("@#{unminored_attribute}_written")
+        end
+
         # before_save :set_amount_minor_from_amount
         before_save -> {
-          return unless instance_variable_get("@#{unminored_attribute}_written")
+          return unless send("#{unminored_attribute}_written?")
 
           unminored = instance_variable_get("@#{unminored_attribute}")
           currency = Helpers.dig_send(self, with)
@@ -79,12 +84,7 @@ module Minorable
         }
 
         # Validate amount is numeric
-        validate -> {
-          unminored = instance_variable_get("@#{unminored_attribute}")
-          if unminored.present? && !Helpers.numeric?(unminored)
-            errors.add(unminored_attribute, "must be a valid number")
-          end
-        }
+        validates unminored_attribute, numericality: { if: -> { send(unminored_attribute).present? } }
 
         # Validate currency is present if amount is set
         validate -> {
@@ -111,13 +111,6 @@ module Minorable
     def self.unminor_from(amount_minor, decimal_places)
       return nil if amount_minor.nil?
       amount_minor.to_d / (10 ** decimal_places)
-    end
-
-    def self.numeric?(value)
-      BigDecimal(value)
-      true
-    rescue ArgumentError, TypeError
-      false
     end
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -8,23 +8,32 @@ class Transaction < ApplicationRecord
 
   belongs_to :category, optional: true
 
-  belongs_to :src_account, class_name: "Account"
-  belongs_to :dest_account, class_name: "Account"
+  # These are still required, but presence is validated differently to handle opening balances, which set the accounts
+  # before save based on #opening_balance_target_account
+  belongs_to :src_account, optional: true, class_name: "Account"
+  belongs_to :dest_account, optional: true, class_name: "Account"
+  validates_presence_of :src_account, :dest_account, message: :required, unless: :opening_balance?
 
-  belongs_to :currency
+  # Currency (but not FX) is required, but presence is validated differently to handle opening balances, which set the
+  # accounts before save based on #opening_balance_target_account
+  belongs_to :currency, optional: true
   belongs_to :fx_currency, class_name: "Currency", optional: true
+  validates_presence_of :currency, unless: :opening_balance?
 
   belongs_to :parent_transaction, class_name: "Transaction", optional: true
   has_many :child_transactions, class_name: "Transaction", foreign_key: "parent_transaction_id", dependent: :destroy
 
-  before_validation :set_currency_from_dest_account
-  before_validation :set_cleared_at_from_cleared
+  before_validation :assign_currency_from_dest_account, unless: :opening_balance?
+  before_validation :assign_cleared_at_from_cleared, unless: :opening_balance?
 
   after_create :mark_parent_as_split, if: :parent_transaction_id?
   after_destroy :unmark_parent_if_last_child, if: :parent_transaction_id?
 
   scope :opening_balances, -> { where(opening_balance: true) }
+  validate :opening_balance_is_valid, if: :opening_balance?
+  before_save :assign_attributes_for_opening_balance, if: :opening_balance?
 
+  validates :amount_minor, numericality: { allow_blank: true, unless: :amount_written? } # Blank is translated to 0
   validates :transacted_at, presence: true
 
   validate :src_account_accessible_to_user
@@ -47,13 +56,30 @@ class Transaction < ApplicationRecord
     fx_amount_minor.present? && fx_currency.present?
   end
 
+  def opening_balance_target_account
+    return nil unless opening_balance?
+    return @opening_balance_target_account if defined?(@opening_balance_target_account)
+
+    if src_account&.real?
+      @opening_balance_target_account = src_account
+    elsif dest_account&.real?
+      @opening_balance_target_account = dest_account
+    else
+      @opening_balance_target_account = nil
+    end
+  end
+
+  def opening_balance_target_account=(account)
+    @opening_balance_target_account = account
+  end
+
   private
 
-    def set_currency_from_dest_account
-      self.currency_id = dest_account.currency_id if dest_account.present?
+    def assign_currency_from_dest_account
+      self.currency = dest_account.currency if dest_account.present? && !dest_account.virtual?
     end
 
-    def set_cleared_at_from_cleared
+    def assign_cleared_at_from_cleared
       return unless defined?(@cleared)
 
       if @cleared
@@ -69,6 +95,47 @@ class Transaction < ApplicationRecord
 
     def unmark_parent_if_last_child
       parent_transaction.update(split: false) if parent_transaction.child_transactions.empty?
+    end
+
+    def opening_balance_is_valid
+      if opening_balance_target_account.blank?
+        errors.add(:opening_balance_target_account, :required, message: "is required for opening balance")
+      end
+
+      if amount_written?
+        if amount.blank?
+          errors.add(:amount, :blank, message: "can't be blank for opening balance")
+        elsif amount.to_d.zero?
+          begin
+            BigDecimal(amount) # Add the error only if it was a number, as to_d coerces to 0
+            errors.add(:amount, :zero, message: "can't be zero for opening balance")
+          rescue ArgumentError, TypeError
+            # amount is not a number, which Minorable validated
+          end
+        end
+      elsif amount_minor.blank?
+        errors.add(:amount_minor, :blank, message: "can't be blank for opening balance")
+      elsif amount_minor.zero?
+        errors.add(:amount_minor, :zero, message: "can't be zero for opening balance")
+      end
+    end
+
+    def assign_attributes_for_opening_balance
+      if opening_balance_target_account.blank?
+        Rails.error.report(StandardError.new("Can't save opening balance transaction without an opening balance target account"))
+        throw :abort
+      end
+
+      if amount_minor.positive?
+        self.src_account = Account.opening_balance_for(user: user, kind: :revenue)
+        self.dest_account = opening_balance_target_account
+      else
+        self.src_account = opening_balance_target_account
+        self.dest_account = Account.opening_balance_for(user: user, kind: :expense)
+      end
+
+      self.currency = opening_balance_target_account.currency
+      self.cleared_at = transacted_at
     end
 
     def src_account_accessible_to_user

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -22,18 +22,18 @@
 
   <div>
     <%= form.label :kind, style: "display: block" %>
-    <%= form.select :kind, Account.kinds.keys.map { |k| [k.humanize, k] } %>
+    <%= form.select :kind, Account.kinds.keys.map { |k| [ k.humanize, k ] } %>
   </div>
 
   <div>
     <%= form.label :currency_id, style: "display: block" %>
-    <%= form.select :currency_id, Currency.all.collect { |c| [c.code, c.id] } %>
+    <%= form.select :currency_id, Currency.all.collect { |c| [ c.code, c.id ] } %>
   </div>
 
   <%= form.fields_for :opening_balance_transaction do |opening_balance_form| %>
     <div>
-      <%= opening_balance_form.label :amount_minor, "Opening Balance Amount", style: "display: block" %>
-      <%= opening_balance_form.text_field :amount_minor %>
+      <%= opening_balance_form.label :amount, "Opening Balance Amount", style: "display: block" %>
+      <%= opening_balance_form.text_field :amount %>
     </div>
 
     <div>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_with(model: transaction, data: { controller: "transactions--form", action: "transactions--form#clearError", transactions__row_target: "form" }, html: { autocomplete: "off" }) do |form| %>
+<%= form_with(model: transaction, data: {
+  controller: "transactions--form",
+  action: "transactions--form#clearError",
+  transactions__form_opening_balance_value: transaction.opening_balance?,
+  transactions__form_target_account_name_value: transaction.opening_balance_target_account&.name,
+  transactions__row_target: "form"
+}, html: { autocomplete: "off" }) do |form| %>
   <div class="row" data-action="keydown.esc->transactions--row#cancelEdit">
     <div>
       <%= form.datetime_field :transacted_at, include_seconds: false %>
@@ -13,27 +19,36 @@
     </div>
 
     <div>
-      <%= form.select :src_account_id,
-            grouped_account_options_for_select(src_accounts, Account::SOURCEABLE, selected_key: transaction.src_account_id),
-            { include_blank: "From…" },
-            data: {
-              action: "transactions--form#updateEnabledAccounts transactions--form#updateType",
-              transactions__form_target: "srcAccount"
-            } %>
+      <% if transaction.opening_balance? %>
+        <span data-transactions--form-target="srcAccount"><%= transaction.src_account.name %></span>
+      <% else %>
+        <%= form.select :src_account_id,
+          grouped_account_options_for_select(src_accounts, Account::SOURCEABLE, selected_key: transaction.src_account_id),
+          { include_blank: "From…" },
+          data: {
+            action: "transactions--form#updateEnabledAccounts transactions--form#updateTypeFromSelectedAccounts",
+            transactions__form_target: "srcAccount"
+          } %>
+      <% end %>
+
     </div>
 
     <div>
-      <%= form.select :dest_account_id,
-            grouped_account_options_for_select(dest_accounts, Account::DESTINABLE, selected_key: transaction.dest_account_id),
-            { include_blank: "To…" },
-            data: {
-              action: "transactions--form#updateEnabledAccounts transactions--form#updateCurrency transactions--form#updateType",
-              transactions__form_target: "destAccount"
-            } %>
+      <% if transaction.opening_balance? %>
+        <span data-transactions--form-target="destAccount"><%= transaction.dest_account.name %></span>
+      <% else %>
+        <%= form.select :dest_account_id,
+          grouped_account_options_for_select(dest_accounts, Account::DESTINABLE, selected_key: transaction.dest_account_id),
+          { include_blank: "To…" },
+          data: {
+            action: "transactions--form#updateEnabledAccounts transactions--form#updateCurrency transactions--form#updateTypeFromSelectedAccounts",
+            transactions__form_target: "destAccount"
+          } %>
+      <% end %>
     </div>
 
     <div class="numeric">
-      <%= form.text_field :amount %>
+      <%= form.text_field :amount, data: { action: "transactions--form#updateFieldsFromOpeningBalanceAmount", transactions__form_target: "amount" } %>
     </div>
 
     <div data-transactions--form-target="currency">
@@ -45,7 +60,11 @@
     </div>
 
     <div class="boolean">
-      <%= form.check_box :cleared %>
+      <% if transaction.opening_balance? %>
+        ✓
+      <% else %>
+        <%= form.check_box :cleared %>
+      <% end %>
     </div>
 
     <div class="actions">

--- a/db/migrate/20260302175538_add_virtual_and_make_currency_nullable_in_accounts.rb
+++ b/db/migrate/20260302175538_add_virtual_and_make_currency_nullable_in_accounts.rb
@@ -1,0 +1,6 @@
+class AddVirtualAndMakeCurrencyNullableInAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :accounts, :virtual, :boolean, null: false, default: false
+    change_column_null :accounts, :currency_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_183216) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_02_175538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.bigint "currency_id", null: false
+    t.bigint "currency_id"
     t.integer "kind"
     t.string "name"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.boolean "virtual", default: false, null: false
     t.index ["currency_id"], name: "index_accounts_on_currency_id"
     t.index ["user_id", "kind"], name: "index_accounts_on_user_id_and_kind"
     t.index ["user_id"], name: "index_accounts_on_user_id"

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -109,15 +109,16 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
           kind: "asset",
           currency_id: @account.currency_id,
           opening_balance_transaction_attributes: {
-            amount_minor: 50000,
+            amount: "500.00",
             transacted_at: Time.current
           }
         }
       }
     end
 
-    assert_redirected_to account_url(Account.last)
-    assert_equal 50000, Account.last.opening_balance_transaction.amount_minor
+    new_account = Account.last(2).first
+    assert_redirected_to account_url(new_account)
+    assert_equal 50000, new_account.opening_balance_transaction.amount_minor
   end
 
   test "should create linked to a SimpleFIN account when given" do
@@ -241,14 +242,14 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Name", @account.name
   end
 
-  test "should update account with opening balance" do
+  test "should update account with positive opening balance" do
     patch account_url(@account), params: {
       account: {
         name: @account.name,
         kind: @account.kind,
         currency_id: @account.currency_id,
         opening_balance_transaction_attributes: {
-          amount_minor: 10000,
+          amount: "100.00",
           transacted_at: Time.current
         }
       }
@@ -257,6 +258,27 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
 
     @account.reload
     assert_equal 10000, @account.opening_balance_transaction.amount_minor
+  end
+
+  test "should create account with negative opening balance" do
+    # Account + Opening Balance Account
+    assert_difference("Account.count", 2) do
+      post accounts_url, params: {
+        account: {
+          name: "New Account with Balance",
+          kind: "asset",
+          currency_id: @account.currency_id,
+          opening_balance_transaction_attributes: {
+            amount: "-500.00",
+            transacted_at: Time.current
+          }
+        }
+      }
+    end
+
+    new_account = Account.last(2).first
+    assert_redirected_to account_url(new_account)
+    assert_equal -50000, new_account.opening_balance_transaction.amount_minor
   end
 
   test "should validate on update" do

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -47,3 +47,35 @@ unlinked_liability:
   currency: usd
   name: Unlinked Liability
   kind: liability
+
+asset_account_with_opening_balance:
+  user: two
+  currency: usd
+  name: Asset Account
+  kind: asset
+
+liability_account_with_opening_balance:
+  user: two
+  currency: usd
+  name: Liability Account
+  kind: liability
+
+expense_account_with_opening_balance:
+  user: two
+  currency: usd
+  name: Expense Account
+  kind: expense
+
+opening_balance_revenue:
+  user: two
+  currency: usd
+  name: Opening Balance
+  kind: revenue
+  virtual: true
+
+opening_balance_expense:
+  user: two
+  currency: usd
+  name: Opening Balance
+  kind: expense
+  virtual: true

--- a/test/fixtures/transactions.yml
+++ b/test/fixtures/transactions.yml
@@ -37,3 +37,23 @@ two:
   reconciled_at: <%= 4.days.ago %>
   synced_at:
   opening_balance: false
+
+opening_balance_revenue:
+  user: two
+  src_account: opening_balance_revenue
+  dest_account: asset_account_with_opening_balance
+  amount_minor: 1000
+  currency: usd
+  transacted_at: <%= 1.month.ago %>
+  cleared_at: <%= 1.month.ago %>
+  opening_balance: true
+
+opening_balance_expense:
+  user: two
+  src_account: liability_account_with_opening_balance
+  dest_account: opening_balance_expense
+  amount_minor: -1000
+  currency: usd
+  transacted_at: <%= 1.month.ago %>
+  cleared_at: <%= 1.month.ago %>
+  opening_balance: true

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,6 +1,50 @@
 require "test_helper"
 
 class AccountTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+  end
+
+  test "opening_balance_for finds existing opening balance account" do
+    account = accounts(:opening_balance_expense)
+
+    assert_no_difference("Account.count") do
+      assert_equal account, Account.opening_balance_for(user: account.user, kind: account.kind)
+    end
+  end
+
+  test "opening_balance_for creates new opening balance account it doesn't exist" do
+    assert_difference("Account.count") do
+      Account.opening_balance_for(user: users(:one), kind: :expense)
+    end
+  end
+
+  test "opening_balance_for raises RecordInvalid when invalid" do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Account.opening_balance_for(user: nil, kind: :expense)
+    end
+  end
+
+  test "opening_balance_for handles RecordNotUnique" do
+    Account.stub :find_or_create_by!, ->(_) { raise ActiveRecord::RecordNotUnique } do
+      Account.stub(:find_by, @account) do
+        assert_no_difference("Account.count") do
+          assert_equal @account, Account.opening_balance_for(user: users(:one), kind: :revenue)
+        end
+      end
+    end
+  end
+
+  test "opening_balance_for raises RecordNotUnique when both find and create fail" do
+    Account.stub :find_or_create_by!, ->(_) { raise ActiveRecord::RecordNotUnique } do
+      Account.stub(:find_by, nil) do
+        assert_raises(ActiveRecord::RecordNotUnique) do
+          Account.opening_balance_for(user: users(:one), kind: :revenue)
+        end
+      end
+    end
+  end
+
   test "linkable scope returns only asset and liability accounts" do
     linkable = Account.linkable
 
@@ -38,5 +82,209 @@ class AccountTest < ActiveSupport::TestCase
     # Non-linkable accounts should be excluded
     assert_not_includes linkable_unlinked, accounts(:expense_account)
     assert_not_includes linkable_unlinked, accounts(:revenue_account)
+  end
+
+  test "empty? is false if account contains transactions" do
+    @account.dest_transactions << transactions(:one)
+
+    assert_not @account.empty?
+  end
+
+  test "empty? is true if account has no transactions" do
+    @account.src_transactions.destroy_all
+    @account.dest_transactions.destroy_all
+
+    assert @account.empty?
+  end
+
+  test "empty? is true if account only has an opening balance transaction" do
+    @account.src_transactions.destroy_all
+    @account.dest_transactions.destroy_all
+    @account.opening_balance_transaction_attributes = { amount_minor: 1000, transacted_at: 1.month.ago }
+
+    @account.save!
+
+    assert_not_nil @account.opening_balance_transaction
+    assert_equal 1, @account.dest_transactions.count
+    assert @account.empty?
+  end
+
+  test "real? is true if account is not virtual" do
+    assert @account.real?
+  end
+
+  test "real? is false if account is virtual" do
+    @account.update!(virtual: true)
+
+    assert_not @account.real?
+  end
+
+  test "account is valid if opening_balance_transaction.amount is blank" do
+    @account.opening_balance_transaction_attributes = { amount: "", transacted_at: 1.month.ago }
+
+    assert @account.valid?
+  end
+
+  test "account is valid if opening_balance_transaction.amount is zero" do
+    @account.opening_balance_transaction_attributes = { amount: 0, transacted_at: 1.month.ago }
+
+    assert @account.valid?
+  end
+
+  test "account is invalid if opening_balance_transaction.amount is not a number" do
+    @account.opening_balance_transaction_attributes = { amount: "invalid", transacted_at: 1.month.ago }
+
+    assert @account.invalid?
+    assert_includes @account.errors["opening_balance_transaction.amount"], "is not a number"
+  end
+
+  test "account is valid if opening_balance_transaction.amount_minor is blank" do
+    @account.opening_balance_transaction_attributes = { amount_minor: "", transacted_at: 1.month.ago }
+
+    assert @account.valid?
+  end
+
+  test "account is valid if opening_balance_transaction.amount_minor is zero" do
+    @account.opening_balance_transaction_attributes = { amount_minor: 0, transacted_at: 1.month.ago }
+
+    assert @account.valid?
+  end
+
+  test "account is invalid if opening_balance_transaction.amount_minor is not a number" do
+    @account.opening_balance_transaction_attributes = { amount_minor: "invalid", transacted_at: 1.month.ago }
+
+    assert @account.invalid?
+    assert_includes @account.errors["opening_balance_transaction.amount_minor"], "is not a number"
+  end
+
+  test "account is invalid if opening_balance_transaction.transacted_at is invalid" do
+    @account.opening_balance_transaction_attributes = { amount: 1, transacted_at: nil }
+
+    assert @account.invalid?
+    assert_includes @account.errors["opening_balance_transaction.transacted_at"], "can't be blank"
+  end
+
+  test "opening balance transaction is saved on account save" do
+    @account.opening_balance_transaction_attributes = { amount: 1, transacted_at: 1.month.ago }
+    assert @account.opening_balance_transaction.new_record?
+
+    @account.save!
+
+    assert @account.opening_balance_transaction.persisted?
+  end
+
+  test "opening balance transaction is destroyed if amount is blank" do
+    @account.opening_balance_transaction_attributes = { amount: 1, transacted_at: 1.month.ago }
+
+    @account.save!
+
+    @account.opening_balance_transaction_attributes = { amount: "", transacted_at: 1.month.ago }
+
+    assert_difference("Transaction.count", -1) do
+      @account.save!
+    end
+  end
+
+  test "opening balance transaction is destroyed if amount is zero" do
+    @account.opening_balance_transaction_attributes = { amount: 1, transacted_at: 1.month.ago }
+
+    @account.save!
+
+    @account.opening_balance_transaction_attributes = { amount: 0, transacted_at: 1.month.ago }
+
+    assert_difference("Transaction.count", -1) do
+      @account.save!
+    end
+  end
+
+  test "opening balance transaction is destroyed if amount_minor is blank" do
+    @account.opening_balance_transaction_attributes = { amount_minor: 1, transacted_at: 1.month.ago }
+
+    @account.save!
+
+    @account.opening_balance_transaction_attributes = { amount_minor: "", transacted_at: 1.month.ago }
+
+    assert_difference("Transaction.count", -1) do
+      @account.save!
+    end
+  end
+
+  test "opening balance transaction is destroyed if amount_minor is zero" do
+    @account.opening_balance_transaction_attributes = { amount_minor: 1, transacted_at: 1.month.ago }
+
+    @account.save!
+
+    @account.opening_balance_transaction_attributes = { amount_minor: 0, transacted_at: 1.month.ago }
+
+    assert_difference("Transaction.count", -1) do
+      @account.save!
+    end
+  end
+
+  test "destroys account with only a revenue opening balance transaction" do
+    transaction = Transaction.create!(
+      user: @account.user,
+      currency: @account.currency,
+      amount_minor: 1000,
+      transacted_at: Time.current,
+      opening_balance: true,
+      opening_balance_target_account: @account
+    )
+
+    assert_difference("Account.count", -1) do
+      @account.destroy
+    end
+
+    assert_raises(ActiveRecord::RecordNotFound) { transaction.reload }
+  end
+
+  test "destroys account with only a expense opening balance transaction" do
+    transaction = Transaction.create!(
+      user: @account.user,
+      currency: @account.currency,
+      amount_minor: -1000,
+      transacted_at: Time.current,
+      opening_balance: true,
+      opening_balance_target_account: @account
+    )
+
+    assert_difference("Account.count", -1) do
+      @account.destroy
+    end
+
+    assert_raises(ActiveRecord::RecordNotFound) { transaction.reload }
+  end
+
+  test "does not destroy account with one non-opening src transaction" do
+    @account.src_transactions.create!(
+      user: @account.user,
+      dest_account: accounts(:expense_account),
+      amount_minor: -1000,
+      transacted_at: Time.current,
+    )
+
+    assert_no_difference("Account.count") do
+      @account.destroy
+    end
+  end
+
+  test "does not destroy account with one non-opening dest transaction" do
+    @account.dest_transactions.create!(
+      user: @account.user,
+      src_account: accounts(:revenue_account),
+      amount_minor: 1000,
+      transacted_at: Time.current,
+    )
+    @account.reload
+
+    assert_no_difference("Account.count") do
+      @account.destroy
+    end
+  end
+
+  test "does not destroy account with many transactions" do
+    assert_no_difference("Account.count") do
+      accounts(:asset_account).destroy
+    end
   end
 end

--- a/test/models/concerns/minorable_test.rb
+++ b/test/models/concerns/minorable_test.rb
@@ -20,6 +20,7 @@ class MinorableTest < ActiveSupport::TestCase
     unminorable :amount_minor
     unminorable :fx_amount_minor, with: :fx_currency
     unminorable :nested_amount_minor, with: "nested.currency"
+    validates_presence_of :amount, :nested_amount
 
     def save
       run_callbacks :save do
@@ -116,6 +117,24 @@ class MinorableTest < ActiveSupport::TestCase
     assert_equal 10000, @test_model.amount_minor
   end
 
+  test "unminorable amount= has amount_written? return true" do
+    @test_model.amount = "100.00"
+
+    assert @test_model.amount_written?
+  end
+
+  test "unminorable amount_written? is false if not written" do
+    assert_not @test_model.amount_written?
+  end
+
+  test "unminorable amount_written? is false after save" do
+    @test_model.amount = "100.00"
+
+    @test_model.save
+
+    assert_not @test_model.amount_written?
+  end
+
   test "unminorable sets nil on amount_minor if amount has changed" do
     @test_model.amount = nil
 
@@ -130,10 +149,18 @@ class MinorableTest < ActiveSupport::TestCase
     assert_not_nil @test_model.amount_minor
   end
 
-  test "resource is valid if unminorable amount is blank" do
+  test "resource is invalid if unminorable amount is nil" do
     @test_model.amount = nil
 
-    assert @test_model.valid?
+    assert_not @test_model.valid?
+    assert_includes @test_model.errors[:amount], "can't be blank"
+  end
+
+  test "resource is invalid if unminorable amount is blank" do
+    @test_model.amount = ""
+
+    assert_not @test_model.valid?
+    assert_includes @test_model.errors[:amount], "can't be blank"
   end
 
   test "resource is valid if unminorable amount is a float" do
@@ -159,11 +186,12 @@ class MinorableTest < ActiveSupport::TestCase
 
     assert @test_model.valid?
   end
+
   test "resource is invalid if unminorable amount is not numeric" do
     @test_model.amount = "invalid"
 
     assert @test_model.invalid?
-    assert_includes @test_model.errors[:amount], "must be a valid number"
+    assert_includes @test_model.errors[:amount], "is not a number"
   end
 
   test "resource is invalid if unminorable amount is changed without a currency" do
@@ -213,6 +241,24 @@ class MinorableTest < ActiveSupport::TestCase
     assert_equal 212345678, @test_model.fx_amount_minor
   end
 
+  test "unminorable fx_amount= has fx_amount_written? return true" do
+    @test_model.fx_amount = "100.00"
+
+    assert @test_model.fx_amount_written?
+  end
+
+  test "unminorable fx_amount_written? is false if not written" do
+    assert_not @test_model.fx_amount_written?
+  end
+
+  test "unminorable fx_amount_written? is false after save" do
+    @test_model.fx_amount = "100.00"
+
+    @test_model.save
+
+    assert_not @test_model.fx_amount_written?
+  end
+
   test "unminorable sets nil on fx_amount_minor if fx_amount has changed" do
     @test_model.fx_amount = nil
 
@@ -227,8 +273,14 @@ class MinorableTest < ActiveSupport::TestCase
     assert_not_nil @test_model.fx_amount_minor
   end
 
-  test "resource is valid if unminorable fx_amount is blank" do
+  test "resource is valid if unminorable fx_amount is nil" do
     @test_model.fx_amount = nil
+
+    assert @test_model.valid?
+  end
+
+  test "resource is valid if unminorable fx_amount is blank" do
+    @test_model.fx_amount = ""
 
     assert @test_model.valid?
   end
@@ -261,7 +313,7 @@ class MinorableTest < ActiveSupport::TestCase
     @test_model.fx_amount = "invalid"
 
     assert @test_model.invalid?
-    assert_includes @test_model.errors[:fx_amount], "must be a valid number"
+    assert_includes @test_model.errors[:fx_amount], "is not a number"
   end
 
   test "resource is invalid if unminorable fx_amount is changed without a currency" do
@@ -311,6 +363,24 @@ class MinorableTest < ActiveSupport::TestCase
     assert_equal 10000, @test_model.nested_amount_minor
   end
 
+  test "unminorable nested_amount= has nested_amount_written? return true" do
+    @test_model.nested_amount = "100.00"
+
+    assert @test_model.nested_amount_written?
+  end
+
+  test "unminorable nested_amount_written? is false if not written" do
+    assert_not @test_model.nested_amount_written?
+  end
+
+  test "unminorable nested_amount_written? is false after save" do
+    @test_model.nested_amount = "100.00"
+
+    @test_model.save
+
+    assert_not @test_model.nested_amount_written?
+  end
+
   test "unminorable sets nil on nested_amount_minor if nested_amount has changed" do
     @test_model.nested_amount = nil
 
@@ -325,10 +395,18 @@ class MinorableTest < ActiveSupport::TestCase
     assert_not_nil @test_model.nested_amount_minor
   end
 
-  test "resource is valid if unminorable nested_amount is blank" do
+  test "resource is invalid if unminorable nested_amount is nil" do
     @test_model.nested_amount = nil
 
-    assert @test_model.valid?
+    assert_not @test_model.valid?
+    assert_includes @test_model.errors[:nested_amount], "can't be blank"
+  end
+
+  test "resource is invalid if unminorable nested_amount is blank" do
+    @test_model.nested_amount = ""
+
+    assert_not @test_model.valid?
+    assert_includes @test_model.errors[:nested_amount], "can't be blank"
   end
 
   test "resource is valid if unminorable nested_amount is a float" do
@@ -359,7 +437,7 @@ class MinorableTest < ActiveSupport::TestCase
     @test_model.nested_amount = "invalid"
 
     assert @test_model.invalid?
-    assert_includes @test_model.errors[:nested_amount], "must be a valid number"
+    assert_includes @test_model.errors[:nested_amount], "is not a number"
   end
 
   test "resource is invalid if unminorable nested_amount is changed without a currency" do

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -1,6 +1,124 @@
 require "test_helper"
 
 class TransactionTest < ActiveSupport::TestCase
+  test "opening_balance_target_account returns nil if not opening balance transaction" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.opening_balance = false
+    transaction.opening_balance_target_account = accounts(:asset_account)
+
+    assert_nil transaction.opening_balance_target_account
+  end
+
+  test "opening_balance_target_account returns account written" do
+    transaction = Transaction.new
+    transaction.opening_balance = true
+    transaction.opening_balance_target_account = accounts(:asset_account)
+
+    assert_equal accounts(:asset_account), transaction.opening_balance_target_account
+  end
+
+  test "opening_balance_target_account returns source account" do
+    transaction = transactions(:opening_balance_expense)
+
+    assert_equal transaction.src_account, transaction.opening_balance_target_account
+  end
+
+  test "opening_balance_target_account returns destination account" do
+    transaction = transactions(:opening_balance_revenue)
+
+    assert_equal transaction.dest_account, transaction.opening_balance_target_account
+  end
+
+  test "opening balance transaction is invalid if opening_balance_target_account is blank" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.dest_account = nil # Target account
+
+    assert_not transaction.valid?
+    assert_includes transaction.errors[:opening_balance_target_account], "is required for opening balance"
+  end
+
+  test "opening balance transaction is invalid if amount is blank" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.amount = ""
+
+    assert_not transaction.valid?
+    assert_includes transaction.errors[:amount], "can't be blank for opening balance"
+  end
+
+  test "opening balance transaction is invalid if amount is zero" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.amount = 0
+
+    assert_not transaction.valid?
+    assert_includes transaction.errors[:amount], "can't be zero for opening balance"
+  end
+
+  test "opening balance transaction is invalid if amount_minor is blank" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.amount_minor = ""
+
+    assert_not transaction.valid?
+    assert_includes transaction.errors[:amount_minor], "can't be blank for opening balance"
+  end
+
+  test "opening balance transaction is invalid if amount_minor is zero" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.amount_minor = 0
+
+    assert_not transaction.valid?
+    assert_includes transaction.errors[:amount_minor], "can't be zero for opening balance"
+  end
+
+  test "does not save without a opening_balance_target_account" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.dest_account = nil # Target account
+
+    assert_error_reported(StandardError) do
+      transaction.save(validate: false)
+    end
+  end
+
+  test "updates associated accounts on positive opening balance" do
+    transaction = transactions(:opening_balance_expense)
+    new_dest_account = transaction.src_account
+    transaction.amount_minor = 1000
+
+    transaction.save!
+
+    assert_equal Account.opening_balance_for(user: transaction.user, kind: :revenue), transaction.src_account
+    assert_equal new_dest_account, transaction.dest_account
+  end
+
+  test "updates associated accounts on negative opening balance" do
+    transaction = transactions(:opening_balance_revenue)
+    new_src_account = transaction.dest_account
+    transaction.amount_minor = -1000
+
+    transaction.save!
+
+    assert_equal new_src_account, transaction.src_account
+    assert_equal Account.opening_balance_for(user: transaction.user, kind: :expense), transaction.dest_account
+  end
+
+  test "opening balance matches opening_balance_target_account's currency" do
+    transaction = transactions(:opening_balance_expense)
+    transaction.currency = nil
+
+    transaction.save!
+
+    assert_equal transaction.opening_balance_target_account.currency, transaction.currency
+  end
+
+  test "cleared_at matches transacted_at for opening balance" do
+    transaction = transactions(:opening_balance_revenue)
+    transaction.cleared_at = nil
+    transaction.transacted_at = 6.months.ago
+
+    transaction.save!
+
+    assert_equal transaction.transacted_at, transaction.cleared_at
+  end
+
   test "creating child transaction marks parent as split" do
     parent = transactions(:one)
     assert_not parent.split, "Parent should not be split initially"


### PR DESCRIPTION
- Moves handling logic to Account and Transaction models
- Negative balances are now treated as expenses
- Replaces has_one association in Account with virtual attributes
- Removes redundant scopes in Account
- Adds the concept of virtual accounts for opening balance accounts
- Makes currency optional for virtual accounts
- Account form now uses the decimal amount field
- Updates transactions form to handle opening balances
- Adds *_written? method for unminored attributes
- Fixes checking if unminored attributes are blank
- Replaces custom numeric validator in Minorable with the numericality validator provided by Rails

Fixes #50