### PR TITLE
Fix Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,17 +12,12 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

- Remove `${{ }}` wrapper from job-level `if:` condition — GitHub evaluates job `if:` as an expression natively, and wrapping causes incorrect boolean evaluation that skips the job
- Upgrade `pull-requests` permission from `read` to `write` so the action can post review comments

## Test plan

- [ ] Verify the Claude Code Review workflow runs (not skipped) on the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)