### PR TITLE
Fix Claude Code action blocked from pushing changes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
## Summary
- Change `contents: read` to `contents: write` in the Claude Code workflow so the action can commit and push changes to PR branches

## Test plan
- [ ] Mention `@claude` in a PR comment and verify it can push changes without a 403 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)