### PR TITLE
Use PAT for Claude Code action to trigger CI on pushed commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,12 +40,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ secrets.CLAUDE_CODE_GITHUB_PAT }}
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.CLAUDE_CODE_GITHUB_PAT }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Pass `CLAUDE_CODE_GITHUB_PAT` as the token for both `actions/checkout` and `claude-code-action`
- Commits pushed via `GITHUB_TOKEN` don't trigger other workflows (GitHub's loop-prevention policy), but commits attributed to a user via PAT do

## Setup required
Add a `CLAUDE_CODE_GITHUB_PAT` repository secret containing a PAT with `repo` and `workflow` scopes.

## Test plan
- [ ] Mention `@claude` in a PR comment and ask it to make a change
- [ ] Verify CI checks run on the resulting commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)