### PR TITLE
Enforce indented_internal_methods rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: indented_internal_methods


### PR DESCRIPTION
## Summary
- Enables `Layout/IndentationConsistency` with `indented_internal_methods` style
- Enforces 4-space indentation under `private`/`protected`, matching Rails conventions
- No code changes needed — existing codebase already follows this style

🤖 Generated with [Claude Code](https://claude.com/claude-code)