### PR TITLE
Add unique constraint on account names per user and kind

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,4 +1,6 @@
 class Account < ApplicationRecord
+  RESERVED_NAMES = [ "Opening Balance" ].freeze
+
   belongs_to :user
   belongs_to :currency, optional: true
 
@@ -24,8 +26,10 @@ class Account < ApplicationRecord
   scope :destinable, -> { where(kind: DESTINABLE).real }
 
   validates :currency, presence: true, unless: :virtual?
+  validates :kind, presence: true
   validates :name, presence: true
   validates :name, uniqueness: { scope: [ :user_id, :kind ] }
+  validate :name_not_reserved, unless: :virtual?
 
   scope :real, -> { where(virtual: false) }
   scope :virtual, -> { where(virtual: true) }
@@ -104,6 +108,12 @@ class Account < ApplicationRecord
   end
 
   private
+
+    def name_not_reserved
+      if RESERVED_NAMES.any? { |reserved| name&.casecmp?(reserved) }
+        errors.add(:name, "is reserved")
+      end
+    end
 
     def opening_balance_not_allowed_for_kind
       # Only block when the user is actively supplying an amount — existing

--- a/db/migrate/20260325054717_add_account_name_kind_constraints.rb
+++ b/db/migrate/20260325054717_add_account_name_kind_constraints.rb
@@ -1,0 +1,8 @@
+class AddAccountNameKindConstraints < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :accounts, :name, false
+    change_column_null :accounts, :kind, false
+
+    add_index :accounts, [ :user_id, :kind, :name ], unique: true
+  end
+end

--- a/db/migrate/20260325054717_add_unique_index_to_account_names.rb
+++ b/db/migrate/20260325054717_add_unique_index_to_account_names.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToAccountNames < ActiveRecord::Migration[8.1]
-  def change
-    add_index :accounts, [ :user_id, :name, :kind ], unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,14 +18,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_054717) do
     t.bigint "balance_minor"
     t.datetime "created_at", null: false
     t.bigint "currency_id"
-    t.integer "kind"
-    t.string "name"
+    t.integer "kind", null: false
+    t.string "name", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.boolean "virtual", default: false, null: false
     t.index ["currency_id"], name: "index_accounts_on_currency_id"
+    t.index ["user_id", "kind", "name"], name: "index_accounts_on_user_id_and_kind_and_name", unique: true
     t.index ["user_id", "kind"], name: "index_accounts_on_user_id_and_kind"
-    t.index ["user_id", "name", "kind"], name: "index_accounts_on_user_id_and_name_and_kind", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -443,4 +443,28 @@ class AccountTest < ActiveSupport::TestCase
       accounts(:asset_account).destroy
     end
   end
+
+  test "rejects duplicate account name within same user and kind" do
+    existing = accounts(:expense_account)
+    duplicate = Account.new(user: existing.user, currency: currencies(:usd), name: existing.name, kind: existing.kind)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:name], "has already been taken"
+  end
+
+  test "allows same account name with different kind" do
+    existing = accounts(:expense_account)
+    different_kind = Account.new(user: existing.user, currency: currencies(:usd), name: existing.name, kind: :revenue)
+    assert different_kind.valid?
+  end
+
+  test "rejects reserved name for real accounts" do
+    account = Account.new(user: users(:one), currency: currencies(:usd), name: "Opening Balance", kind: :asset)
+    assert_not account.valid?
+    assert_includes account.errors[:name], "is reserved"
+  end
+
+  test "allows reserved name for virtual accounts" do
+    account = Account.new(user: users(:one), name: "Opening Balance", kind: :expense, virtual: true)
+    assert account.valid?
+  end
 end


### PR DESCRIPTION
## Summary
- Adds NOT NULL constraints on `name` and `kind` columns
- Adds `kind` presence validation in the model
- Adds unique index on `[user_id, kind, name]` to prevent duplicate account names within the same user and kind
- Reserves "Opening Balance" name for virtual accounts only
- Aligns with `TransactionImportJob#find_or_create_by!` which already assumes name uniqueness

Related: #75

## Test plan
- [x] Existing tests pass
- [x] Verify creating an account with a duplicate name and kind is rejected
- [x] Verify same name with different kind is allowed
- [x] Verify "Opening Balance" is rejected for real accounts
- [x] Verify "Opening Balance" is allowed for virtual accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)