### PR TITLE
Make account name uniqueness case-insensitive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Controllers that expose user-owned financial data use `before_action :authentica
 - Framework: Minitest (not RSpec). Use `test "description" do ... end` syntax.
 - Fixtures for test data; `minitest-mock` for mocking external dependencies.
 - Coverage tracked with SimpleCov, uploaded to Codecov.
+- Every item in a PR's test plan must have corresponding test coverage (unit, integration, or system test).
 
 ## CI Checks (must pass before merging)
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,7 +28,7 @@ class Account < ApplicationRecord
   validates :currency, presence: true, unless: :virtual?
   validates :kind, presence: true
   validates :name, presence: true
-  validates :name, uniqueness: { scope: [ :user_id, :kind ] }
+  validates :name, uniqueness: { scope: [ :user_id, :kind ], case_sensitive: false }
   validate :name_not_reserved, unless: :virtual?
 
   scope :real, -> { where(virtual: false) }

--- a/db/migrate/20260325063755_make_account_name_uniqueness_case_insensitive.rb
+++ b/db/migrate/20260325063755_make_account_name_uniqueness_case_insensitive.rb
@@ -1,0 +1,9 @@
+class MakeAccountNameUniquenessCaseInsensitive < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :accounts, [ :user_id, :kind, :name ], unique: true
+    add_index :accounts,
+              "user_id, kind, LOWER(name)",
+              unique: true,
+              name: "index_accounts_on_user_id_kind_lower_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_054717) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_063755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,8 +23,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_054717) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.boolean "virtual", default: false, null: false
+    t.index "user_id, kind, lower((name)::text)", name: "index_accounts_on_user_id_kind_lower_name", unique: true
     t.index ["currency_id"], name: "index_accounts_on_currency_id"
-    t.index ["user_id", "kind", "name"], name: "index_accounts_on_user_id_and_kind_and_name", unique: true
     t.index ["user_id", "kind"], name: "index_accounts_on_user_id_and_kind"
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -467,4 +467,11 @@ class AccountTest < ActiveSupport::TestCase
     account = Account.new(user: users(:one), name: "Opening Balance", kind: :expense, virtual: true)
     assert account.valid?
   end
+
+  test "rejects duplicate account name with different casing" do
+    existing = accounts(:expense_account)
+    duplicate = Account.new(user: existing.user, currency: currencies(:usd), name: existing.name.upcase, kind: existing.kind)
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:name], "has already been taken"
+  end
 end


### PR DESCRIPTION
## Summary
- Replaces the case-sensitive unique index on `[user_id, kind, name]` with a case-insensitive one using `LOWER(name)`
- Adds `case_sensitive: false` to the model uniqueness validation
- Prevents creating "Test" and "TEST" as separate accounts within the same user and kind
- Consistent with the case-insensitive reserved name check and the import rules pattern matching
- Adds CLAUDE.md rule: every PR test plan item must have corresponding test coverage

## Test plan
- [x] Existing tests pass (352 tests, 0 failures)
- [x] Verify creating an account with the same name in different casing is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)