### PR TITLE
Upgrade SimpleFIN integration to protocol v2

### DIFF
--- a/app/jobs/simplefin/refresh_job.rb
+++ b/app/jobs/simplefin/refresh_job.rb
@@ -12,12 +12,15 @@ class Simplefin::RefreshJob < ApplicationJob
       simplefin_client = simplefin_connection.client
       simplefin_accounts = simplefin_client.accounts(start_date: 1.month.ago.to_i)
 
+      connections_by_id = (simplefin_accounts["connections"] || []).index_by { |c| c["conn_id"] }
+
       simplefin_accounts["accounts"].each do |sf_account_data|
         sf_account = Simplefin::Account.find_or_initialize_by(
           connection: simplefin_connection,
           remote_id: sf_account_data["id"],
         )
-        sf_account.org = sf_account_data["org"]
+        sf_account.conn_id = sf_account_data["conn_id"]
+        sf_account.org = connections_by_id[sf_account_data["conn_id"]]
         sf_account.name = sf_account_data["name"]
         sf_account.currency = sf_account_data["currency"]
         sf_account.balance = sf_account_data["balance"]
@@ -42,7 +45,7 @@ class Simplefin::RefreshJob < ApplicationJob
         end
       end
 
-      simplefin_connection.account_errors = simplefin_accounts["errors"] || []
+      simplefin_connection.errlist = simplefin_accounts["errlist"] || []
       simplefin_connection.update!(refreshed_at: Time.current)
     end
   end

--- a/app/views/simplefin/connections/show.html.erb
+++ b/app/views/simplefin/connections/show.html.erb
@@ -5,12 +5,12 @@
   at: <%= @simplefin_connection.refreshed_at ? @simplefin_connection.refreshed_at.strftime("%B %d, %Y %I:%M %p") : "Never" %></p>
 <p><%= button_to "Enqueue Refresh", refresh_simplefin_connection_path %></p>
 
-<% if @simplefin_connection.account_errors.any? %>
-  <h2>Account Errors</h2>
+<% if @simplefin_connection.errlist.any? %>
+  <h2>Errors</h2>
   <p>SimpleFIN reported the following errors during the last refresh:</p>
   <ul>
-    <% @simplefin_connection.account_errors.each do |error| %>
-      <li><%= error %></li>
+    <% @simplefin_connection.errlist.each do |error| %>
+      <li><strong><%= error["code"] %></strong>: <%= error["msg"] %></li>
     <% end %>
   </ul>
   <p>Head to <a href="https://beta-bridge.simplefin.org/my-account">My Account on SimpleFIN</a> to resolve

--- a/db/migrate/20260328171036_upgrade_simplefin_to_v2.rb
+++ b/db/migrate/20260328171036_upgrade_simplefin_to_v2.rb
@@ -1,0 +1,7 @@
+class UpgradeSimplefinToV2 < ActiveRecord::Migration[8.1]
+  def change
+    add_column :simplefin_accounts, :conn_id, :string
+    remove_column :simplefin_connections, :account_errors, :string, default: [], null: false, array: true
+    add_column :simplefin_connections, :errlist, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_063755) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_171036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,6 +68,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_063755) do
     t.string "available_balance"
     t.string "balance"
     t.datetime "balance_date", precision: nil
+    t.string "conn_id"
     t.bigint "connection_id", null: false
     t.datetime "created_at", null: false
     t.string "currency"
@@ -82,8 +83,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_063755) do
   end
 
   create_table "simplefin_connections", force: :cascade do |t|
-    t.string "account_errors", default: [], null: false, array: true
     t.datetime "created_at", null: false
+    t.jsonb "errlist", default: [], null: false
     t.datetime "refreshed_at", precision: nil
     t.datetime "updated_at", null: false
     t.string "url"

--- a/lib/simplefin_client.rb
+++ b/lib/simplefin_client.rb
@@ -31,7 +31,8 @@ class SimplefinClient
       'end-date': end_date,
       pending: pending ? 1 : 0,
       account: account,
-      'balances-only': balances_only ? 1 : 0
+      'balances-only': balances_only ? 1 : 0,
+      version: 2
     }.compact)
   end
 

--- a/test/jobs/simplefin_refresh_job_test.rb
+++ b/test/jobs/simplefin_refresh_job_test.rb
@@ -15,14 +15,20 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
 
     def mock_client.accounts(start_date:)
       {
-        "errors" => [],
+        "errlist" => [],
+        "connections" => [
+          {
+            "conn_id" => "conn_1",
+            "name" => "Test Bank - User",
+            "org_id" => "testbank",
+            "org_url" => "testbank.com",
+            "sfin_url" => "https://sfin.testbank.com"
+          }
+        ],
         "accounts" => [
           {
             "id" => "acc_123",
-            "org" => {
-              "domain" => "testbank.com",
-              "sfin-url" => "https://sfin.testbank.com"
-            },
+            "conn_id" => "conn_1",
             "name" => "Checking",
             "currency" => "USD",
             "balance" => "1000.00",
@@ -54,14 +60,20 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
 
     def mock_client.accounts(start_date:)
       {
-        "errors" => [],
+        "errlist" => [],
+        "connections" => [
+          {
+            "conn_id" => "conn_2",
+            "name" => "Test Bank - User",
+            "org_id" => "testbank",
+            "org_url" => "testbank.com",
+            "sfin_url" => "https://sfin.testbank.com"
+          }
+        ],
         "accounts" => [
           {
             "id" => "acc_456",
-            "org" => {
-              "domain" => "testbank.com",
-              "sfin-url" => "https://sfin.testbank.com"
-            },
+            "conn_id" => "conn_2",
             "name" => "Savings",
             "currency" => "USD",
             "balance" => "5000.00",
@@ -83,6 +95,7 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
     account = Simplefin::Account.find_by(remote_id: "acc_456")
     assert_equal "Savings", account.name
     assert_equal "5000.00", account.balance
+    assert_equal "conn_2", account.conn_id
   end
 
   test "creates transactions from account data" do
@@ -90,14 +103,20 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
 
     def mock_client.accounts(start_date:)
       {
-        "errors" => [],
+        "errlist" => [],
+        "connections" => [
+          {
+            "conn_id" => "conn_3",
+            "name" => "Test Bank - User",
+            "org_id" => "testbank",
+            "org_url" => "testbank.com",
+            "sfin_url" => "https://sfin.testbank.com"
+          }
+        ],
         "accounts" => [
           {
             "id" => "acc_789",
-            "org" => {
-              "domain" => "testbank.com",
-              "sfin-url" => "https://sfin.testbank.com"
-            },
+            "conn_id" => "conn_3",
             "name" => "Credit Card",
             "currency" => "USD",
             "balance" => "-500.00",
@@ -132,32 +151,40 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
     assert_equal false, transaction.pending
   end
 
-  test "clears account errors when API has no errors" do
+  test "clears errlist when API has no errors" do
     mock_client = Minitest::Mock.new
 
     def mock_client.accounts(start_date:)
-      { "accounts" => [] }
+      { "accounts" => [], "connections" => [] }
     end
 
     SimplefinClient.stub :new, mock_client do
-      @simplefin_connection.update!(account_errors: [ "Previous API Error" ])
+      @simplefin_connection.update!(errlist: [ { "code" => "con.auth", "msg" => "Previous Error" } ])
       Simplefin::RefreshJob.perform_now(@simplefin_connection.id)
       @simplefin_connection.reload
-      assert_equal [], @simplefin_connection.account_errors
+      assert_equal [], @simplefin_connection.errlist
     end
   end
 
-  test "sets account errors on connection when API returns errors" do
+  test "sets errlist on connection when API returns errors" do
     mock_client = Minitest::Mock.new
 
     def mock_client.accounts(start_date:)
-      { "errors" => [ "Account Error" ], "accounts" => [] }
+      {
+        "errlist" => [
+          { "code" => "con.auth", "msg" => "Login failed", "conn_id" => "conn_1" }
+        ],
+        "accounts" => [],
+        "connections" => []
+      }
     end
 
     SimplefinClient.stub :new, mock_client do
       Simplefin::RefreshJob.perform_now(@simplefin_connection.id)
       @simplefin_connection.reload
-      assert_equal [ "Account Error" ], @simplefin_connection.account_errors
+      assert_equal 1, @simplefin_connection.errlist.length
+      assert_equal "con.auth", @simplefin_connection.errlist.first["code"]
+      assert_equal "Login failed", @simplefin_connection.errlist.first["msg"]
     end
   end
 
@@ -166,10 +193,6 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
     existing_account = Simplefin::Account.create!(
       connection: @simplefin_connection,
       remote_id: "acc_existing",
-      org: {
-        "domain" => "oldbank.com",
-        "sfin-url" => "https://sfin.oldbank.com"
-      },
       name: "Old Name",
       currency: "USD",
       balance: "100.00"
@@ -179,14 +202,20 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
 
     def mock_client.accounts(start_date:)
       {
-        "errors" => [],
+        "errlist" => [],
+        "connections" => [
+          {
+            "conn_id" => "conn_new",
+            "name" => "New Bank - User",
+            "org_id" => "newbank",
+            "org_url" => "newbank.com",
+            "sfin_url" => "https://sfin.newbank.com"
+          }
+        ],
         "accounts" => [
           {
             "id" => "acc_existing",
-            "org" => {
-              "domain" => "newbank.com",
-              "sfin-url" => "https://sfin.newbank.com"
-            },
+            "conn_id" => "conn_new",
             "name" => "New Name",
             "currency" => "USD",
             "balance" => "200.00",
@@ -206,8 +235,51 @@ class Simplefin::RefreshJobTest < ActiveJob::TestCase
     end
 
     existing_account.reload
-    assert_equal "newbank.com", existing_account.org["domain"]
+    assert_equal "newbank.com", existing_account.org["org_url"]
     assert_equal "New Name", existing_account.name
     assert_equal "200.00", existing_account.balance
+    assert_equal "conn_new", existing_account.conn_id
+  end
+
+  test "populates org from connections array by conn_id" do
+    mock_client = Minitest::Mock.new
+
+    def mock_client.accounts(start_date:)
+      {
+        "errlist" => [],
+        "connections" => [
+          {
+            "conn_id" => "conn_abc",
+            "name" => "My Bank - Jeff",
+            "org_id" => "mybank",
+            "org_url" => "mybank.com",
+            "sfin_url" => "https://sfin.mybank.com"
+          }
+        ],
+        "accounts" => [
+          {
+            "id" => "acc_org_test",
+            "conn_id" => "conn_abc",
+            "name" => "Checking",
+            "currency" => "USD",
+            "balance" => "100.00",
+            "available-balance" => "100.00",
+            "balance-date" => Time.current.to_i,
+            "transactions" => [],
+            "extra" => {}
+          }
+        ]
+      }
+    end
+
+    SimplefinClient.stub :new, mock_client do
+      Simplefin::RefreshJob.perform_now(@simplefin_connection.id)
+    end
+
+    account = Simplefin::Account.find_by(remote_id: "acc_org_test")
+    assert_equal "conn_abc", account.conn_id
+    assert_equal "My Bank - Jeff", account.org["name"]
+    assert_equal "mybank", account.org["org_id"]
+    assert_equal "mybank.com", account.org["org_url"]
   end
 end

--- a/test/lib/simplefin_client_test.rb
+++ b/test/lib/simplefin_client_test.rb
@@ -75,6 +75,7 @@ class SimplefinClientTest < ActiveSupport::TestCase
       assert_equal 1000, opts[:query][:"start-date"]
       assert_equal 1, opts[:query][:pending]
       assert_equal 1, opts[:query][:"balances-only"]
+      assert_equal 2, opts[:query][:version]
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adopts SimpleFIN protocol v2 ([spec](https://www.simplefin.org/protocol.html#v2.0.0---2026-03-19)), which is live on SimpleFIN Bridge
- **Structured errors**: Replaces `account_errors` (string array) with `errlist` (jsonb) storing `{code, msg, conn_id}` objects for better error diagnostics
- **Connection object**: Stores `conn_id` on SimpleFIN accounts and populates `org` from the new top-level `connections` array
- **v2 opt-in**: Adds `version=2` query param to `/accounts` requests

v1 continues to work for 1+ year, but v2 gives us structured error codes (knowing which connection/account failed and why) and proper multi-login support.

## Test plan
- [x] `bin/rails test` — 365 tests, 818 assertions, 0 failures
- [x] 100% line coverage maintained
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings
- [x] Manual: triggered SimpleFIN refresh, verified `conn_id` populated on accounts, `errlist` populated with structured errors from BECU and Fidelity connections
- [x] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)