### PR TITLE
Add CodeQL workflow for code analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "Honeyledger CodeQL config"
+
+paths-ignore:
+  - test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,12 +73,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        config-file: ./.github/codeql/codeql-config.yml
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
## Summary
- Migrate CodeQL from default setup to advanced workflow for Ruby, JavaScript/TypeScript, and GitHub Actions analysis
- Exclude `test/` directory from analysis to suppress false positives where CodeQL flags test account names (e.g. "Salary") as clear-text storage of sensitive data (`rb/clear-text-storage-sensitive-data` / CWE-312)

## Test plan
- [x] CodeQL workflow passes for all three languages on this PR
- [x] Confirm previous false positives in `test/` files are no longer reported
- [x] Disable the default CodeQL setup in repo settings (Settings > Code security > Code scanning) after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)