### PR TITLE
Support excluding imported transactions

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -452,6 +452,21 @@
   display: block; /* Show edit portion when editing */
 }
 
+/* Excluded badge */
+.excluded-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--bark-light);
+  margin-left: 4px;
+  padding: 1px 5px;
+  border: 1px solid var(--bark-light);
+  border-radius: 3px;
+}
+
+.transaction:has(.excluded-badge) .row.show > div:not(.actions):not(.select) {
+  opacity: 0.5;
+}
+
 /* Merged badge */
 .merged-badge {
   font-size: 0.7rem;

--- a/app/controllers/import_rules_controller.rb
+++ b/app/controllers/import_rules_controller.rb
@@ -76,6 +76,6 @@ class ImportRulesController < ApplicationController
     end
 
     def import_rule_params
-      params.expect(import_rule: [ :match_pattern, :match_type, :account_id, :priority ])
+      params.expect(import_rule: [ :match_pattern, :match_type, :account_id, :priority, :exclude ])
     end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -209,8 +209,9 @@ class TransactionsController < ApplicationController
     end
 
     def find_preceding_transaction(transaction)
-      current_user.transactions.unmerged.unexcluded
-        .where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
+      scope = current_user.transactions.unmerged
+      scope = scope.unexcluded unless show_excluded?
+      scope.where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
         .order(transacted_at: :desc, created_at: :desc).first
     end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -7,7 +7,10 @@ class TransactionsController < ApplicationController
   def index
     @new_transaction = build_new_transaction
 
-    @transactions = current_user.transactions.unmerged.includes(:category, :src_account, :dest_account, :currency, :fx_currency, merged_sources: [ :src_account, :dest_account ]).order(transacted_at: :desc, created_at: :desc)
+    @show_excluded = params[:show_excluded] == "1"
+    scope = current_user.transactions.unmerged
+    scope = scope.unexcluded unless @show_excluded
+    @transactions = scope.includes(:category, :src_account, :dest_account, :currency, :fx_currency, merged_sources: [ :src_account, :dest_account ]).order(transacted_at: :desc, created_at: :desc)
     account_id = params.fetch(:account_id, nil)
     if account_id.present?
       @account = current_user.accounts.find(account_id)
@@ -75,7 +78,7 @@ class TransactionsController < ApplicationController
         # Find the nearest transaction that's newer (appears above in the list) to insert after.
         # This element is already in the DOM, unlike older ones which may be off-screen or absent.
         newest = @restored_transactions.first
-        @after_transaction = current_user.transactions.unmerged
+        @after_transaction = current_user.transactions.unmerged.unexcluded
           .where.not(id: @restored_transactions.map(&:id))
           .where("transacted_at > :at OR (transacted_at = :at AND created_at > :cat)",
                  at: newest.transacted_at, cat: newest.created_at)
@@ -124,6 +127,48 @@ class TransactionsController < ApplicationController
     end
   end
 
+  # POST /transactions/:id/exclude
+  def exclude
+    @transaction = current_user.transactions.find(params.expect(:id))
+    excluder = Transaction::Exclude.new(@transaction, user: current_user)
+
+    respond_to do |format|
+      if excluder.call
+        @transaction.reload
+        format.turbo_stream {
+          if show_excluded?
+            render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction })
+          else
+            render turbo_stream: turbo_stream.remove(@transaction)
+          end
+        }
+        format.html { redirect_to transactions_url, notice: "Transaction was excluded." }
+      else
+        @exclude_errors = excluder.errors
+        format.turbo_stream { render :exclude_error, status: :unprocessable_entity }
+        format.html { redirect_to transactions_url, alert: excluder.errors.first }
+      end
+    end
+  end
+
+  # POST /transactions/:id/unexclude
+  def unexclude
+    @transaction = current_user.transactions.find(params.expect(:id))
+    unexcluder = Transaction::Unexclude.new(@transaction, user: current_user)
+
+    respond_to do |format|
+      if unexcluder.call
+        @transaction.reload
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction }) }
+        format.html { redirect_to transactions_url(show_excluded: 1), notice: "Transaction was restored." }
+      else
+        @exclude_errors = unexcluder.errors
+        format.turbo_stream { render :exclude_error, status: :unprocessable_entity }
+        format.html { redirect_to transactions_url(excluded: 1), alert: unexcluder.errors.first }
+      end
+    end
+  end
+
   # DELETE /transactions/1 or /transactions/1.json
   def destroy
     @transaction.destroy!
@@ -164,7 +209,7 @@ class TransactionsController < ApplicationController
     end
 
     def find_preceding_transaction(transaction)
-      current_user.transactions.unmerged
+      current_user.transactions.unmerged.unexcluded
         .where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
         .order(transacted_at: :desc, created_at: :desc).first
     end
@@ -172,5 +217,12 @@ class TransactionsController < ApplicationController
     def set_form_collections
       @accounts = current_user.accounts.real.includes(:currency).order(:name)
       @categories = current_user.categories.order(:name)
+    end
+
+    def show_excluded?
+      referer = request.referer
+      referer.present? && URI.parse(referer).query&.include?("show_excluded=1")
+    rescue URI::InvalidURIError
+      false
     end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -142,11 +142,11 @@ class TransactionsController < ApplicationController
             render turbo_stream: turbo_stream.remove(@transaction)
           end
         }
-        format.html { redirect_to transactions_url, notice: "Transaction was excluded." }
+        format.html { redirect_back fallback_location: transactions_url, notice: "Transaction was excluded." }
       else
         @exclude_errors = excluder.errors
         format.turbo_stream { render :exclude_error, status: :unprocessable_entity }
-        format.html { redirect_to transactions_url, alert: excluder.errors.first }
+        format.html { redirect_back fallback_location: transactions_url, alert: excluder.errors.first }
       end
     end
   end
@@ -160,11 +160,11 @@ class TransactionsController < ApplicationController
       if unexcluder.call
         @transaction.reload
         format.turbo_stream { render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction }) }
-        format.html { redirect_to transactions_url(show_excluded: 1), notice: "Transaction was restored." }
+        format.html { redirect_back fallback_location: transactions_url(show_excluded: 1), notice: "Transaction was restored." }
       else
         @exclude_errors = unexcluder.errors
         format.turbo_stream { render :exclude_error, status: :unprocessable_entity }
-        format.html { redirect_to transactions_url(excluded: 1), alert: unexcluder.errors.first }
+        format.html { redirect_back fallback_location: transactions_url(show_excluded: 1), alert: unexcluder.errors.first }
       end
     end
   end

--- a/app/jobs/lunchflow/import_transactions_job.rb
+++ b/app/jobs/lunchflow/import_transactions_job.rb
@@ -13,7 +13,7 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
       .where(account_id: lunchflow_account_id)
       .includes(account: { connection: :user })
       .left_joins(:ledger_transaction)
-      .where("transactions.id IS NULL OR (transactions.merged_into_id IS NULL AND lunchflow_transactions.synced_at > COALESCE(transactions.synced_at, '1970-01-01'))")
+      .where("transactions.id IS NULL OR (transactions.merged_into_id IS NULL AND transactions.excluded_at IS NULL AND lunchflow_transactions.synced_at > COALESCE(transactions.synced_at, '1970-01-01'))")
 
     transactions.find_each do |lft|
       user = lft.account.connection.user
@@ -52,7 +52,11 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
       transaction.synced_at = Time.current
       transaction.save!
 
-      Transaction::AutoMerge.call(transaction, rule_account: bs_rule_account)
+      if rule&.exclude?
+        Transaction::Exclude.new(transaction, user: user).call
+      else
+        Transaction::AutoMerge.call(transaction, rule_account: bs_rule_account)
+      end
     end
   end
 end

--- a/app/jobs/simplefin/import_transactions_job.rb
+++ b/app/jobs/simplefin/import_transactions_job.rb
@@ -13,7 +13,7 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
       .where(account_id: simplefin_account_id)
       .includes(account: { connection: :user })
       .left_joins(:ledger_transaction)
-      .where("transactions.id IS NULL OR (transactions.merged_into_id IS NULL AND simplefin_transactions.synced_at > COALESCE(transactions.synced_at, '1970-01-01'))")
+      .where("transactions.id IS NULL OR (transactions.merged_into_id IS NULL AND transactions.excluded_at IS NULL AND simplefin_transactions.synced_at > COALESCE(transactions.synced_at, '1970-01-01'))")
 
     transactions.find_each do |sft|
       user = sft.account.connection.user
@@ -51,7 +51,11 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
       transaction.synced_at = Time.current
       transaction.save!
 
-      Transaction::AutoMerge.call(transaction, rule_account: bs_rule_account)
+      if rule&.exclude?
+        Transaction::Exclude.new(transaction, user: user).call
+      else
+        Transaction::AutoMerge.call(transaction, rule_account: bs_rule_account)
+      end
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -92,8 +92,8 @@ class Account < ApplicationRecord
   def reset_balance
     return false if virtual?
 
-    deposits = Transaction.where(dest_account: self).sum(:amount_minor)
-    withdrawals = Transaction.where(src_account: self).sum("COALESCE(fx_amount_minor, amount_minor)")
+    deposits = Transaction.unexcluded.where(dest_account: self).sum(:amount_minor)
+    withdrawals = Transaction.unexcluded.where(src_account: self).sum("COALESCE(fx_amount_minor, amount_minor)")
     update_column(:balance_minor, deposits - withdrawals)
   end
 

--- a/app/models/import_rule.rb
+++ b/app/models/import_rule.rb
@@ -1,6 +1,6 @@
 class ImportRule < ApplicationRecord
   belongs_to :user
-  belongs_to :account
+  belongs_to :account, optional: true
 
   enum :match_type, %i[ contains exact starts_with ends_with ]
 
@@ -8,8 +8,9 @@ class ImportRule < ApplicationRecord
 
   validates :match_pattern, presence: true
   validates :match_pattern, uniqueness: { scope: [ :user_id, :match_type ], case_sensitive: false }
-  validate :account_must_not_be_virtual
-  validate :account_must_belong_to_user
+  validates :account_id, presence: true, unless: :exclude?
+  validate :account_must_not_be_virtual, unless: :exclude?
+  validate :account_must_belong_to_user, unless: :exclude?
 
   scope :for_description, ->(description) {
     downcased = description.to_s.strip.downcase

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -30,6 +30,12 @@ class Transaction < ApplicationRecord
 
   scope :opening_balances, -> { where(opening_balance: true) }
   scope :unmerged, -> { where(merged_into_id: nil) }
+  scope :excluded, -> { where.not(excluded_at: nil) }
+  scope :unexcluded, -> { where(excluded_at: nil) }
+
+  def excluded?
+    excluded_at.present?
+  end
 
   validates :amount_minor, numericality: { allow_blank: true, unless: :amount_written? } # Blank is translated to 0
   validates :transacted_at, presence: true
@@ -85,6 +91,7 @@ class Transaction < ApplicationRecord
     end
 
     def transfer_account_balances
+      return if excluded?
       return unless saved_change_to_amount_minor? || saved_change_to_fx_amount_minor? ||
                     saved_change_to_src_account_id? || saved_change_to_dest_account_id?
 
@@ -116,6 +123,7 @@ class Transaction < ApplicationRecord
     end
 
     def reverse_account_balances
+      return if excluded?
       # Use persisted (_was) values so reassigning associations in-memory before destroy! doesn't reverse the wrong accounts
       return if amount_minor_was.nil?
 

--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -1,5 +1,5 @@
 class ImportRule::RetroactiveApply
-  Change = Struct.new(:transaction, :old_account, :new_account, :direction, :merge_candidate, keyword_init: true)
+  Change = Struct.new(:transaction, :old_account, :new_account, :direction, :merge_candidate, :action, keyword_init: true)
 
   attr_reader :changes, :errors
 
@@ -21,7 +21,9 @@ class ImportRule::RetroactiveApply
     applied = 0
     ActiveRecord::Base.transaction do
       @changes.each do |change|
-        if change.new_account.balance_sheet?
+        if change.action == :exclude
+          Transaction::Exclude.new(change.transaction, user: @user).call
+        elsif change.new_account.balance_sheet?
           Transaction::AutoMerge.call(change.transaction, rule_account: change.new_account)
         elsif change.direction == :expense
           change.transaction.update!(dest_account: change.new_account)
@@ -48,6 +50,19 @@ class ImportRule::RetroactiveApply
 
         rule = find_matching_rule(transaction.description)
         next unless rule
+
+        if rule.exclude?
+          changes << Change.new(
+            transaction: transaction,
+            old_account: counterpart,
+            new_account: nil,
+            direction: direction,
+            merge_candidate: nil,
+            action: :exclude
+          )
+          next
+        end
+
         next if rule.account_id == counterpart.id
 
         merge_candidate = if rule.account.balance_sheet?
@@ -59,7 +74,8 @@ class ImportRule::RetroactiveApply
           old_account: counterpart,
           new_account: rule.account,
           direction: direction,
-          merge_candidate: merge_candidate
+          merge_candidate: merge_candidate,
+          action: :reassign
         )
       end
 
@@ -69,7 +85,7 @@ class ImportRule::RetroactiveApply
     def candidate_transactions
       @user.transactions
         .where.not(sourceable_type: nil)
-        .where(merged_into_id: nil, split: false, opening_balance: false, parent_transaction_id: nil)
+        .where(merged_into_id: nil, excluded_at: nil, split: false, opening_balance: false, parent_transaction_id: nil)
         .includes(:src_account, :dest_account)
     end
 
@@ -95,6 +111,7 @@ class ImportRule::RetroactiveApply
     def find_merge_candidate(transaction, rule_account)
       candidates = @user.transactions
         .unmerged
+        .unexcluded
         .includes(:src_account, :dest_account)
         .where.not(id: transaction.id)
         .where(amount_minor: transaction.amount_minor, currency_id: transaction.currency_id)

--- a/app/services/transaction/auto_merge.rb
+++ b/app/services/transaction/auto_merge.rb
@@ -9,7 +9,8 @@ class Transaction::AutoMerge
   end
 
   def call
-    return if @transaction.merged_into_id? || @transaction.opening_balance? ||
+    return if @transaction.merged_into_id? || @transaction.excluded? ||
+              @transaction.opening_balance? ||
               @transaction.split? || @transaction.parent_transaction_id? ||
               @transaction.has_fx? || @transaction.amount_minor == 0 ||
               @transaction.merged_sources.exists?
@@ -89,6 +90,7 @@ class Transaction::AutoMerge
     def base_candidates
       @transaction.user.transactions
         .unmerged
+        .unexcluded
         .includes(:src_account, :dest_account)
         .where.not(id: @transaction.id)
         .where(amount_minor: @transaction.amount_minor, currency_id: @transaction.currency_id)

--- a/app/services/transaction/exclude.rb
+++ b/app/services/transaction/exclude.rb
@@ -1,0 +1,59 @@
+class Transaction::Exclude
+  attr_reader :errors
+
+  def initialize(transaction, user:)
+    @transaction = transaction
+    @user = user
+    @errors = []
+  end
+
+  def call
+    validate!
+    return false if @errors.any?
+
+    ActiveRecord::Base.transaction do
+      reverse_account_balances
+      @transaction.update!(excluded_at: Time.current)
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.message
+    false
+  end
+
+  private
+
+    def validate!
+      unless @transaction.user_id == @user.id
+        @errors << "Transaction must belong to you"
+      end
+
+      if @transaction.excluded?
+        @errors << "Transaction is already excluded"
+      end
+
+      if @transaction.merged_into_id?
+        @errors << "Merged transactions cannot be excluded"
+      end
+
+      if @transaction.opening_balance?
+        @errors << "Opening balance transactions cannot be excluded"
+      end
+
+      if @transaction.split? || @transaction.parent_transaction_id?
+        @errors << "Split transactions cannot be excluded"
+      end
+
+      if @transaction.merged_sources.any?
+        @errors << "Merged transfer transactions cannot be excluded"
+      end
+    end
+
+    def reverse_account_balances
+      src_amount = @transaction.fx_amount_minor.nil? ? @transaction.amount_minor : @transaction.fx_amount_minor
+
+      Account.update_counters(@transaction.src_account_id, balance_minor: src_amount) if @transaction.src_account&.real?
+      Account.update_counters(@transaction.dest_account_id, balance_minor: -@transaction.amount_minor) if @transaction.dest_account&.real?
+    end
+end

--- a/app/services/transaction/unexclude.rb
+++ b/app/services/transaction/unexclude.rb
@@ -1,0 +1,43 @@
+class Transaction::Unexclude
+  attr_reader :errors
+
+  def initialize(transaction, user:)
+    @transaction = transaction
+    @user = user
+    @errors = []
+  end
+
+  def call
+    validate!
+    return false if @errors.any?
+
+    ActiveRecord::Base.transaction do
+      apply_account_balances
+      @transaction.update!(excluded_at: nil)
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.message
+    false
+  end
+
+  private
+
+    def validate!
+      unless @transaction.user_id == @user.id
+        @errors << "Transaction must belong to you"
+      end
+
+      unless @transaction.excluded?
+        @errors << "Transaction is not excluded"
+      end
+    end
+
+    def apply_account_balances
+      src_amount = @transaction.fx_amount_minor.nil? ? @transaction.amount_minor : @transaction.fx_amount_minor
+
+      Account.update_counters(@transaction.src_account_id, balance_minor: -src_amount) if @transaction.src_account&.real?
+      Account.update_counters(@transaction.dest_account_id, balance_minor: @transaction.amount_minor) if @transaction.dest_account&.real?
+    end
+end

--- a/app/views/import_rules/_form.html.erb
+++ b/app/views/import_rules/_form.html.erb
@@ -21,11 +21,21 @@
     <%= form.select :match_type, ImportRule.match_types.keys.map { |t| [ t.humanize, t ] } %>
   </div>
 
-  <div>
-    <%= form.label :account_id, "Account", style: "display: block" %>
-    <%= form.select :account_id,
-      grouped_account_options_for_select(current_user.accounts.real.order(:kind, :name), Account.kinds.keys, selected_key: import_rule.account_id),
-      include_blank: "Select an account..." %>
+  <div data-controller="toggle-field">
+    <div style="margin-top: 0.5em">
+      <label for="<%= form.field_id(:exclude) %>">
+        <%= form.check_box :exclude, id: form.field_id(:exclude), data: { toggle_field_target: "checkbox", action: "change->toggle-field#toggle" } %>
+        Exclude matching transactions from calculations instead of assigning them to an account.
+      </label>
+    </div>
+
+    <div>
+      <%= form.label :account_id, "Account", style: "display: block" %>
+      <%= form.select :account_id,
+        grouped_account_options_for_select(current_user.accounts.real.order(:kind, :name), Account.kinds.keys, selected_key: import_rule.account_id),
+        { include_blank: "Select an account..." },
+        data: { toggle_field_target: "field" } %>
+    </div>
   </div>
 
   <div>

--- a/app/views/import_rules/_preview_table.html.erb
+++ b/app/views/import_rules/_preview_table.html.erb
@@ -1,12 +1,17 @@
+<% has_reassigns = changes.any? { |c| c.action != :exclude } %>
 <table>
   <thead>
     <tr>
       <th>Description</th>
       <th>Date</th>
       <th>Amount</th>
-      <th>Current Account</th>
-      <th></th>
-      <th>New Account</th>
+      <% if has_reassigns %>
+        <th>Current Account</th>
+        <th></th>
+        <th>New Account</th>
+      <% else %>
+        <th>Action</th>
+      <% end %>
     </tr>
   </thead>
   <tbody>
@@ -15,14 +20,22 @@
         <td><%= change.transaction.description %></td>
         <td><%= change.transaction.transacted_at&.strftime("%Y-%m-%d") %></td>
         <td class="numeric"><%= transaction_amount_with_currency(change.transaction) %></td>
-        <td><%= change.old_account.name %> (<%= change.old_account.kind %>)</td>
-        <td>&rarr;</td>
-        <td>
-          <%= change.new_account.name %> (<%= change.new_account.kind %>)
-          <% if change.merge_candidate %>
-            <br><small>Will merge with: <%= change.merge_candidate.description %> (<%= change.merge_candidate.transacted_at&.strftime("%Y-%m-%d") %>, <%= transaction_amount_with_currency(change.merge_candidate) %>)</small>
-          <% end %>
-        </td>
+        <% if has_reassigns %>
+          <td><%= change.old_account.name %> (<%= change.old_account.kind %>)</td>
+          <td>&rarr;</td>
+          <td>
+            <% if change.action == :exclude %>
+              <em>Exclude</em>
+            <% else %>
+              <%= change.new_account.name %> (<%= change.new_account.kind %>)
+              <% if change.merge_candidate %>
+                <br><small>Will merge with: <%= change.merge_candidate.description %> (<%= change.merge_candidate.transacted_at&.strftime("%Y-%m-%d") %>, <%= transaction_amount_with_currency(change.merge_candidate) %>)</small>
+              <% end %>
+            <% end %>
+          </td>
+        <% else %>
+          <td><em>Exclude</em></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/import_rules/index.html.erb
+++ b/app/views/import_rules/index.html.erb
@@ -9,7 +9,7 @@
     <tr>
       <th>Pattern</th>
       <th>Match Type</th>
-      <th>Account</th>
+      <th>Action</th>
       <th>Priority</th>
       <th>Actions</th>
     </tr>
@@ -19,7 +19,7 @@
       <tr>
         <td><%= rule.match_pattern %></td>
         <td><%= rule.match_type.humanize %></td>
-        <td><%= rule.account.name %> (<%= rule.account.kind %>)</td>
+        <td><%= rule.exclude? ? "Exclude" : "Assign to #{rule.account.name} (#{rule.account.kind})" %></td>
         <td><%= rule.priority %></td>
         <td>
           <%= link_to "Preview", preview_import_rule_path(rule) %>

--- a/app/views/import_rules/preview.html.erb
+++ b/app/views/import_rules/preview.html.erb
@@ -3,7 +3,7 @@
 <h1>Preview Rule: <%= @import_rule.match_pattern %></h1>
 
 <% if @changes.any? %>
-  <p><%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be reassigned by this rule.</p>
+  <p><%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be <%= @import_rule.exclude? ? "excluded" : "reassigned" %> by this rule.</p>
 
   <%= render "preview_table", changes: @changes %>
 <% else %>

--- a/app/views/import_rules/preview_apply.html.erb
+++ b/app/views/import_rules/preview_apply.html.erb
@@ -3,7 +3,14 @@
 <h1>Preview Rule Application</h1>
 
 <% if @changes.any? %>
-  <p><%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be reassigned to different accounts.</p>
+  <% exclude_count = @changes.count { |c| c.action == :exclude } %>
+  <% reassign_count = @changes.size - exclude_count %>
+  <p>
+    <% parts = [] %>
+    <% parts << "#{reassign_count} reassigned" if reassign_count > 0 %>
+    <% parts << "#{exclude_count} excluded" if exclude_count > 0 %>
+    <%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be updated (<%= parts.join(", ") %>).
+  </p>
 
   <%= render "preview_table", changes: @changes %>
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -15,7 +15,7 @@
 
     <div class="row show">
       <div class="select">
-        <% unless transaction.opening_balance? %>
+        <% unless transaction.opening_balance? || transaction.excluded? %>
           <input type="checkbox"
                  class="merge-checkbox"
                  data-transactions--merge-target="checkbox"
@@ -26,7 +26,9 @@
       <div data-label="Date"><%= transaction.transacted_at&.strftime("%Y-%m-%d %I:%M %p") %></div>
       <div data-label="Type">
         <%= transaction_type_indicator(transaction) %>
-        <% if transaction.merged_sources.any? %>
+        <% if transaction.excluded? %>
+          <span class="excluded-badge" title="Excluded from calculations">Excluded</span>
+        <% elsif transaction.merged_sources.any? %>
           <a href="#" class="merged-badge" data-action="transactions--row#toggleMergedDetails">Merged</a>
         <% end %>
       </div>
@@ -44,6 +46,11 @@
           <a href="#" data-action="transactions--row#edit">Edit</a>
         <% end %>
         <%= link_to "Delete", transaction, data: { turbo_method: :delete, turbo_confirm: "Delete this transaction?", turbo_frame: dom_id(transaction) } %>
+        <% if transaction.excluded? %>
+          <%= link_to "Restore", unexclude_transaction_path(transaction), data: { turbo_method: :post } %>
+        <% elsif transaction.sourceable_type.present? && !transaction.opening_balance? && !transaction.merged_sources.any? %>
+          <%= link_to "Exclude", exclude_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
+        <% end %>
         <% if transaction.merged_sources.any? %>
           <%= link_to "Unmerge", unmerge_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Unmerge this transfer back into the original transactions?" } %>
         <% end %>

--- a/app/views/transactions/exclude_error.turbo_stream.erb
+++ b/app/views/transactions/exclude_error.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.prepend :transactions do %>
+  <div class="merge-error" id="exclude_error" data-controller="error">
+    <strong>Could not update transaction:</strong>
+    <ul>
+      <% @exclude_errors.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+    <button type="button" data-action="error#close">Dismiss</button>
+  </div>
+<% end %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -2,6 +2,15 @@
 
 <h1 class="sr-only">Transactions</h1>
 
+<% base_path = @account ? account_transactions_path(@account) : transactions_path %>
+<div class="transactions-filter">
+  <% if @show_excluded %>
+    <%= link_to "Hide excluded transactions", base_path %>
+  <% else %>
+    <%= link_to "Show excluded transactions", "#{base_path}?show_excluded=1" %>
+  <% end %>
+</div>
+
 <div data-controller="transactions--merge" data-transactions--merge-merge-url-value="<%= merge_transactions_path %>">
   <div class="transactions">
     <div class="row header">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   resources :transactions do
     member do
       post :unmerge
+      post :exclude
+      post :unexclude
     end
     collection do
       post :merge

--- a/db/migrate/20260402173250_add_exclusion_support.rb
+++ b/db/migrate/20260402173250_add_exclusion_support.rb
@@ -1,0 +1,9 @@
+class AddExclusionSupport < ActiveRecord::Migration[8.1]
+  def change
+    add_column :transactions, :excluded_at, :datetime
+    add_index :transactions, :excluded_at, where: "excluded_at IS NOT NULL", name: "index_transactions_on_excluded_at"
+
+    add_column :import_rules, :exclude, :boolean, default: false, null: false
+    change_column_null :import_rules, :account_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_230603) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_173250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,8 +55,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_230603) do
   end
 
   create_table "import_rules", force: :cascade do |t|
-    t.bigint "account_id", null: false
+    t.bigint "account_id"
     t.datetime "created_at", null: false
+    t.boolean "exclude", default: false, null: false
     t.string "match_pattern", null: false
     t.integer "match_type", default: 0, null: false
     t.integer "priority", default: 0, null: false
@@ -162,6 +163,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_230603) do
     t.bigint "currency_id", null: false
     t.string "description", default: "", null: false
     t.bigint "dest_account_id", null: false
+    t.datetime "excluded_at"
     t.integer "fx_amount_minor"
     t.bigint "fx_currency_id"
     t.bigint "merged_into_id"
@@ -180,6 +182,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_230603) do
     t.index ["category_id"], name: "index_transactions_on_category_id"
     t.index ["currency_id"], name: "index_transactions_on_currency_id"
     t.index ["dest_account_id"], name: "index_transactions_on_dest_account_id"
+    t.index ["excluded_at"], name: "index_transactions_on_excluded_at", where: "(excluded_at IS NOT NULL)"
     t.index ["fx_currency_id"], name: "index_transactions_on_fx_currency_id"
     t.index ["merged_into_id"], name: "index_transactions_on_merged_into_id"
     t.index ["parent_transaction_id"], name: "index_transactions_on_parent_transaction_id"

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -345,6 +345,173 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "exclude removes transaction from index via turbo_stream" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Exclude Ctrl Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Exclude me",
+      transacted_at: Time.current, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    post exclude_transaction_url(imported), as: :turbo_stream
+    assert_response :success
+
+    imported.reload
+    assert imported.excluded?
+  end
+
+  test "unexclude removes transaction from excluded list via turbo_stream" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Unexclude Ctrl Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Restore me",
+      transacted_at: Time.current, sourceable: simplefin_transactions(:transaction_two)
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    post unexclude_transaction_url(imported), as: :turbo_stream
+    assert_response :success
+
+    imported.reload
+    assert_not imported.excluded?
+  end
+
+  test "index hides excluded transactions by default" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Hidden Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "This should be hidden",
+      transacted_at: Time.current
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    get transactions_url
+    assert_response :success
+    assert_not_includes response.body, "This should be hidden"
+  end
+
+  test "index shows excluded transactions with show_excluded param" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Excluded Indicator Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Excluded but visible",
+      transacted_at: Time.current
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    get transactions_url(show_excluded: 1)
+    assert_response :success
+    assert_includes response.body, "Excluded but visible"
+    assert_includes response.body, "excluded-badge"
+  end
+
+  test "account-scoped index hides excluded by default" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Scoped Hidden Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Scoped hidden txn",
+      transacted_at: Time.current
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    get account_transactions_url(bank)
+    assert_response :success
+    assert_not_includes response.body, "Scoped hidden txn"
+  end
+
+  test "account-scoped index shows excluded with show_excluded param" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Scoped Excluded Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Scoped excluded txn",
+      transacted_at: Time.current
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    get account_transactions_url(bank, show_excluded: 1)
+    assert_response :success
+    assert_includes response.body, "Scoped excluded txn"
+    assert_includes response.body, "excluded-badge"
+  end
+
+  test "exclude handles malformed referer gracefully" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Bad Referer Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Bad referer",
+      transacted_at: Time.current, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    post exclude_transaction_url(imported), as: :turbo_stream,
+      headers: { "HTTP_REFERER" => "http://[invalid" }
+    assert_response :success
+
+    imported.reload
+    assert imported.excluded?
+  end
+
+  test "exclude replaces in-place when show_excluded is active" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Replace Exclude Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Replace in place",
+      transacted_at: Time.current, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    post exclude_transaction_url(imported), as: :turbo_stream,
+      headers: { "HTTP_REFERER" => transactions_url(show_excluded: 1) }
+    assert_response :success
+    assert_includes response.body, "replace"
+
+    imported.reload
+    assert imported.excluded?
+  end
+
+  test "exclude on already excluded transaction returns error" do
+    currency = currencies(:usd)
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, name: "Double Exclude Expense", kind: :expense, currency: currency)
+
+    imported = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      amount_minor: 500, currency: currency, description: "Already excluded",
+      transacted_at: Time.current, sourceable: simplefin_transactions(:transaction_one)
+    )
+    Transaction::Exclude.new(imported, user: @user).call
+
+    post exclude_transaction_url(imported), as: :turbo_stream
+    assert_response :unprocessable_entity
+  end
+
+  test "unexclude on non-excluded transaction returns error" do
+    post unexclude_transaction_url(@transaction), as: :turbo_stream
+    assert_response :unprocessable_entity
+  end
+
   test "merge with wrong number of transaction IDs returns error" do
     post merge_transactions_url, params: {
       transaction_ids: [ @transaction.id ]

--- a/test/jobs/lunchflow/import_transactions_job_test.rb
+++ b/test/jobs/lunchflow/import_transactions_job_test.rb
@@ -173,6 +173,60 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_equal 50000, merged.amount_minor
   end
 
+  test "skips excluded transactions during reimport" do
+    lf_account, _ = create_linked_lunchflow_account
+
+    lf_transaction = Lunchflow::Transaction.create!(
+      account: lf_account,
+      remote_id: 999,
+      amount: "-50.00",
+      currency: "USD",
+      description: "Excluded Transaction",
+      merchant: "Excluded Merchant",
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+    transaction = Transaction.find_by(sourceable: lf_transaction)
+
+    Transaction::Exclude.new(transaction, user: @user).call
+    original_synced_at = transaction.reload.synced_at
+
+    travel 2.seconds
+    lf_transaction.update!(synced_at: Time.current)
+
+    assert_no_difference "Transaction.count" do
+      Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+    end
+
+    assert_equal original_synced_at, transaction.reload.synced_at
+  end
+
+  test "exclude rule auto-excludes imported transaction" do
+    lf_account, _ = create_linked_lunchflow_account
+
+    ImportRule.create!(user: @user, match_pattern: "SPAM", match_type: :contains, exclude: true)
+
+    lf_transaction = Lunchflow::Transaction.create!(
+      account: lf_account,
+      remote_id: 998,
+      amount: "-10.00",
+      currency: "USD",
+      description: "SPAM Transaction",
+      merchant: "SPAM Merchant",
+      pending: false,
+      date: 1.day.ago.to_date
+    )
+
+    assert_difference "Transaction.count", 1 do
+      Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+    end
+
+    transaction = Transaction.find_by(sourceable: lf_transaction)
+    assert transaction.excluded?
+  end
+
   private
 
     def create_linked_lunchflow_account(remote_id: 901, name: "LF Test Checking")

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -460,6 +460,64 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_nil merged.sourceable # Merge result has no sourceable
   end
 
+  test "skips excluded transactions during reimport" do
+    sf_account, _ = create_linked_simplefin_account
+
+    sf_transaction = Simplefin::Transaction.create!(
+      account: sf_account,
+      remote_id: "txn_excluded",
+      amount: "-50.00",
+      description: "Excluded Transaction",
+      posted: 2.days.ago,
+      transacted_at: 2.days.ago,
+      pending: false
+    )
+
+    # First import
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+    transaction = Transaction.find_by(sourceable: sf_transaction)
+    assert_not_nil transaction
+
+    # Exclude it
+    Transaction::Exclude.new(transaction, user: @user).call
+    original_synced_at = transaction.reload.synced_at
+
+    # Update sf transaction to simulate refresh
+    travel 2.seconds
+    sf_transaction.update!(synced_at: Time.current)
+
+    # Reimport should skip excluded transaction
+    assert_no_difference "Transaction.count" do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+    end
+
+    # synced_at should not have changed
+    assert_equal original_synced_at, transaction.reload.synced_at
+  end
+
+  test "exclude rule auto-excludes imported transaction" do
+    sf_account, _ = create_linked_simplefin_account
+
+    ImportRule.create!(user: @user, match_pattern: "SPAM", match_type: :contains, exclude: true)
+
+    sf_transaction = Simplefin::Transaction.create!(
+      account: sf_account,
+      remote_id: "txn_auto_exclude",
+      amount: "-10.00",
+      description: "SPAM Transaction",
+      posted: 1.day.ago,
+      transacted_at: 1.day.ago,
+      pending: false
+    )
+
+    assert_difference "Transaction.count", 1 do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+    end
+
+    transaction = Transaction.find_by(sourceable: sf_transaction)
+    assert transaction.excluded?
+  end
+
   test "falls back to exact name match when no rule matches" do
     sf_account, _ = create_linked_simplefin_account
 

--- a/test/models/import_rule_test.rb
+++ b/test/models/import_rule_test.rb
@@ -143,6 +143,25 @@ class ImportRuleTest < ActiveSupport::TestCase
     assert_equal low, results.second
   end
 
+  # exclude rules
+
+  test "exclude rule valid without account" do
+    rule = ImportRule.new(user: @user, match_pattern: "SPAM", match_type: :contains, exclude: true)
+    assert rule.valid?
+  end
+
+  test "non-exclude rule requires account" do
+    rule = ImportRule.new(user: @user, match_pattern: "Test", match_type: :contains, exclude: false)
+    assert_not rule.valid?
+    assert_includes rule.errors[:account_id], "can't be blank"
+  end
+
+  test "exclude rule skips virtual account validation" do
+    rule = ImportRule.new(user: @user, match_pattern: "SPAM", match_type: :contains, exclude: true)
+    assert rule.valid?
+    assert_empty rule.errors[:account]
+  end
+
   # for_kind scope
 
   test "for_kind filters by account kind" do

--- a/test/services/import_rule/retroactive_apply_test.rb
+++ b/test/services/import_rule/retroactive_apply_test.rb
@@ -363,4 +363,44 @@ class ImportRule::RetroactiveApplyTest < ActiveSupport::TestCase
     assert_equal 5000, transfer_out.amount_minor
     assert_nil transfer_out.merged_into_id
   end
+
+  test "preview shows exclude action for exclude rule" do
+    @rule.destroy!
+    exclude_rule = ImportRule.create!(
+      user: @user, match_pattern: "GROCERY", match_type: :contains, exclude: true
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: exclude_rule)
+    changes = service.preview
+
+    assert_equal 1, changes.size
+    assert_equal :exclude, changes.first.action
+    assert_nil changes.first.new_account
+  end
+
+  test "apply excludes transaction with exclude rule" do
+    @rule.destroy!
+    exclude_rule = ImportRule.create!(
+      user: @user, match_pattern: "GROCERY", match_type: :contains, exclude: true
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: exclude_rule)
+    count = service.apply
+
+    assert_equal 1, count
+    assert @imported_transaction.reload.excluded?
+  end
+
+  test "apply skips already excluded transactions" do
+    @rule.destroy!
+    exclude_rule = ImportRule.create!(
+      user: @user, match_pattern: "GROCERY", match_type: :contains, exclude: true
+    )
+
+    Transaction::Exclude.new(@imported_transaction, user: @user).call
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: exclude_rule)
+    changes = service.preview
+    assert_equal 0, changes.size
+  end
 end

--- a/test/services/transaction/exclude_test.rb
+++ b/test/services/transaction/exclude_test.rb
@@ -1,0 +1,135 @@
+require "test_helper"
+
+class Transaction::ExcludeTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @bank = accounts(:linked_asset)
+    @expense = Account.create!(user: @user, name: "Exclude Expense", kind: :expense, currency: @currency)
+
+    @transaction = Transaction.create!(
+      user: @user,
+      src_account: @bank,
+      dest_account: @expense,
+      amount_minor: 1000,
+      currency: @currency,
+      description: "Test exclusion",
+      transacted_at: 1.day.ago,
+      sourceable: simplefin_transactions(:transaction_one)
+    )
+  end
+
+  test "excludes a transaction" do
+    excluder = Transaction::Exclude.new(@transaction, user: @user)
+    assert excluder.call
+
+    @transaction.reload
+    assert @transaction.excluded?
+    assert_not_nil @transaction.excluded_at
+    assert_equal 1000, @transaction.amount_minor # amounts unchanged
+  end
+
+  test "reverses account balances on exclude" do
+    @bank.reset_balance
+    @expense.reset_balance
+    bank_before = @bank.reload.balance_minor
+    expense_before = @expense.reload.balance_minor
+
+    excluder = Transaction::Exclude.new(@transaction, user: @user)
+    excluder.call
+
+    @bank.reload
+    @expense.reload
+    assert_equal bank_before + 1000, @bank.balance_minor
+    assert_equal expense_before - 1000, @expense.balance_minor
+  end
+
+  test "excluded transactions are filtered from unexcluded scope" do
+    Transaction::Exclude.new(@transaction, user: @user).call
+
+    assert_not_includes @user.transactions.unexcluded, @transaction.reload
+    assert_includes @user.transactions.excluded, @transaction
+  end
+
+  test "rejects already excluded transaction" do
+    Transaction::Exclude.new(@transaction, user: @user).call
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Transaction is already excluded"
+  end
+
+  test "rejects merged transaction" do
+    @transaction.update_columns(merged_into_id: @transaction.id)
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Merged transactions cannot be excluded"
+  end
+
+  test "rejects opening balance transaction" do
+    @transaction.update_columns(opening_balance: true)
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Opening balance transactions cannot be excluded"
+  end
+
+  test "rejects split transactions" do
+    @transaction.update_columns(split: true)
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Split transactions cannot be excluded"
+  end
+
+  test "rejects other user's transaction" do
+    other_user = users(:two)
+    excluder = Transaction::Exclude.new(@transaction, user: other_user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Transaction must belong to you"
+  end
+
+  test "rejects transaction with merged sources" do
+    # Create a merged transaction scenario
+    revenue = Account.create!(user: @user, name: "Exclude Revenue", kind: :revenue, currency: @currency)
+    bank_b = accounts(:asset_account)
+
+    deposit = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: bank_b,
+      amount_minor: 1000, currency: @currency, description: "Deposit",
+      transacted_at: 1.day.ago
+    )
+
+    merger = Transaction::Merge.new(@transaction, deposit, user: @user)
+    merger.call
+    merged = merger.merged_transaction
+
+    excluder = Transaction::Exclude.new(merged, user: @user)
+    assert_not excluder.call
+    assert_includes excluder.errors, "Merged transfer transactions cannot be excluded"
+  end
+
+  test "returns false with error when RecordInvalid is raised" do
+    @transaction.update_columns(src_account_id: @transaction.dest_account_id)
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert_not excluder.call
+    assert excluder.errors.any?
+  end
+
+  test "handles FX transaction exclusion" do
+    eur = currencies(:eur)
+    @transaction.update!(fx_amount_minor: 900, fx_currency: eur)
+
+    @bank.reset_balance
+    bank_before = @bank.reload.balance_minor
+
+    excluder = Transaction::Exclude.new(@transaction.reload, user: @user)
+    assert excluder.call
+
+    @bank.reload
+    # Src side uses fx_amount_minor
+    assert_equal bank_before + 900, @bank.balance_minor
+  end
+end

--- a/test/services/transaction/unexclude_test.rb
+++ b/test/services/transaction/unexclude_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class Transaction::UnexcludeTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @bank = accounts(:linked_asset)
+    @expense = Account.create!(user: @user, name: "Unexclude Expense", kind: :expense, currency: @currency)
+
+    @transaction = Transaction.create!(
+      user: @user,
+      src_account: @bank,
+      dest_account: @expense,
+      amount_minor: 1000,
+      currency: @currency,
+      description: "Test unexclude",
+      transacted_at: 1.day.ago,
+      sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    Transaction::Exclude.new(@transaction, user: @user).call
+    @transaction.reload
+  end
+
+  test "unexcludes a transaction" do
+    unexcluder = Transaction::Unexclude.new(@transaction, user: @user)
+    assert unexcluder.call
+
+    @transaction.reload
+    assert_not @transaction.excluded?
+    assert_nil @transaction.excluded_at
+    assert_equal 1000, @transaction.amount_minor
+  end
+
+  test "re-applies account balances on unexclude" do
+    @bank.reset_balance
+    @expense.reset_balance
+    bank_before = @bank.reload.balance_minor
+    expense_before = @expense.reload.balance_minor
+
+    Transaction::Unexclude.new(@transaction, user: @user).call
+
+    @bank.reload
+    @expense.reload
+    assert_equal bank_before - 1000, @bank.balance_minor
+    assert_equal expense_before + 1000, @expense.balance_minor
+  end
+
+  test "unexcluded transaction appears in unexcluded scope" do
+    Transaction::Unexclude.new(@transaction, user: @user).call
+
+    assert_includes @user.transactions.unexcluded, @transaction.reload
+    assert_not_includes @user.transactions.excluded, @transaction
+  end
+
+  test "rejects non-excluded transaction" do
+    plain = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense,
+      amount_minor: 500, currency: @currency, description: "Plain",
+      transacted_at: Time.current
+    )
+
+    unexcluder = Transaction::Unexclude.new(plain, user: @user)
+    assert_not unexcluder.call
+    assert_includes unexcluder.errors, "Transaction is not excluded"
+  end
+
+  test "rejects other user's transaction" do
+    other_user = users(:two)
+    unexcluder = Transaction::Unexclude.new(@transaction, user: other_user)
+    assert_not unexcluder.call
+    assert_includes unexcluder.errors, "Transaction must belong to you"
+  end
+
+  test "returns false with error when RecordInvalid is raised" do
+    @transaction.update_columns(src_account_id: @transaction.dest_account_id)
+
+    unexcluder = Transaction::Unexclude.new(@transaction.reload, user: @user)
+    assert_not unexcluder.call
+    assert unexcluder.errors.any?
+  end
+
+  test "handles FX transaction unexclusion" do
+    # Create a fresh FX transaction and exclude it
+    eur = currencies(:eur)
+    fx_transaction = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense,
+      amount_minor: 1000, fx_amount_minor: 900, fx_currency: eur,
+      currency: @currency, description: "FX unexclude",
+      transacted_at: 1.day.ago
+    )
+
+    Transaction::Exclude.new(fx_transaction, user: @user).call
+    fx_transaction.reload
+
+    @bank.reset_balance
+    bank_before = @bank.reload.balance_minor
+
+    Transaction::Unexclude.new(fx_transaction, user: @user).call
+
+    @bank.reload
+    # Src side uses fx_amount_minor
+    assert_equal bank_before - 900, @bank.balance_minor
+  end
+end


### PR DESCRIPTION
## Summary
- Add transaction exclusion so imported transactions can be hidden from calculations without being reimported on the next aggregator refresh
- Excluded transactions are hidden by default with a "Show excluded transactions" toggle; when shown, they display an "Excluded" badge and dimmed row
- Exclude/restore updates the row in-place via Turbo Streams
- Import rules support an "exclude" action to auto-exclude matching transactions during import
- Hard delete remains available for intentional reimport

## Test plan
- [x] Exclude an imported transaction — verify it disappears from the default list and account balance updates
- [x] Toggle "Show excluded transactions" — verify excluded transactions appear with the "Excluded" badge
- [x] Restore an excluded transaction — verify the badge disappears and balance is re-applied
- [x] Verify excluded transactions are not reimported on aggregator refresh
- [x] Create an import rule with "Exclude" checked — verify new imports matching the pattern are auto-excluded
- [x] Preview & apply exclude rules retroactively — verify preview shows "Exclude" action and apply excludes transactions
- [x] Verify hard delete of an excluded transaction still works
- [x] Verify account-scoped transaction drill-downs respect the show/hide excluded toggle
- [x] 565 tests pass, 100% line coverage, rubocop clean, brakeman clean

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)