### PR TITLE
Update sidebar live on account create, rename, and delete

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -132,6 +132,9 @@ header h1 {
   margin: 0;
 }
 
+.sidebar-kind-group { display: none; }
+.sidebar-kind-group:has(li) { display: block; }
+
 .sidebar nav ul li a {
   display: flex;
   align-items: center;

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,7 +1,7 @@
 module AccountsHelper
   def account_sidebar_link(account, active_path: nil)
     target = account_transactions_path(account)
-    is_active = path_active?(active_path, account_path(account))
+    is_active = prefix_active?(active_path, account_path(account))
 
     link_to target, id: dom_id(account, :sidebar_link), class: ("active" if is_active) do
       render("accounts/sidebar_link_content", account: account)

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,10 +1,10 @@
 module AccountsHelper
-  def account_nav_link_to(account)
+  def account_sidebar_link(account, active_path: nil)
     target = account_transactions_path(account)
+    is_active = path_active?(active_path, account_path(account))
 
-    nav_link_to target, { active: account_path(account) } do
-      content_tag(:span, account.name, class: "account__name") +
-        render("accounts/sidebar_balance", account: account)
+    link_to target, id: dom_id(account, :sidebar_link), class: ("active" if is_active) do
+      render("accounts/sidebar_link_content", account: account)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,21 +4,12 @@ module ApplicationHelper
       (current_path == target_path || current_path.start_with?("#{target_path}/"))
   end
 
-  def nav_link_to(name = nil, url = nil, options = {}, &block)
-    if block_given?
-      # nav_link_to(url, options) { content }
-      options = url || {}
-      url = name
-      active = options.delete(:active)
-    else
-      active = options.delete(:active)
-    end
+  def nav_link_to(name, url, options = {})
+    active = options.delete(:active)
 
     is_active = case active
     when :prefix
       path_active?(request.path, url)
-    when String
-      path_active?(request.path, active)
     else
       current_page?(url)
     end
@@ -27,10 +18,6 @@ module ApplicationHelper
       options[:class] = class_names(options[:class], "active")
     end
 
-    if block_given?
-      link_to url, options, &block
-    else
-      link_to name, url, options
-    end
+    link_to name, url, options
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def path_active?(current_path, target_path)
+    current_path.present? && target_path.present? &&
+      (current_path == target_path || current_path.start_with?("#{target_path}/"))
+  end
+
   def nav_link_to(name = nil, url = nil, options = {}, &block)
     if block_given?
       # nav_link_to(url, options) { content }
@@ -11,9 +16,9 @@ module ApplicationHelper
 
     is_active = case active
     when :prefix
-      request.path == url || request.path.start_with?("#{url}/")
+      path_active?(request.path, url)
     when String
-      request.path == active || request.path.start_with?("#{active}/")
+      path_active?(request.path, active)
     else
       current_page?(url)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def path_active?(current_path, target_path)
+  def prefix_active?(current_path, target_path)
     current_path.present? && target_path.present? &&
       (current_path == target_path || current_path.start_with?("#{target_path}/"))
   end
@@ -9,7 +9,7 @@ module ApplicationHelper
 
     is_active = case active
     when :prefix
-      path_active?(request.path, url)
+      prefix_active?(request.path, url)
     else
       current_page?(url)
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -20,6 +20,10 @@ class Account < ApplicationRecord
   belongs_to :sourceable, polymorphic: true, optional: true
   after_save_commit :enqueue_source_import, if: :should_enqueue_source_import?
 
+  after_create_commit  :broadcast_sidebar_insert, if: :real?
+  after_update_commit  :broadcast_sidebar_change, if: :real?
+  after_destroy_commit :broadcast_sidebar_remove, if: :real?
+
   enum :kind, %i[ asset liability equity expense revenue ]
 
   validates :currency, presence: true, unless: :virtual?
@@ -122,16 +126,42 @@ class Account < ApplicationRecord
     user_id == user.id
   end
 
-  def broadcast_sidebar_replace
-    broadcast_replace_to(
+  def self.sidebar_kind_target_id(kind)
+    "sidebar_accounts_#{kind}"
+  end
+
+  def broadcast_sidebar_update
+    broadcast_update_to(
       user, :sidebar,
-      target: [ self, :sidebar_balance ],
-      partial: "accounts/sidebar_balance",
+      target: [ self, :sidebar_link ],
+      partial: "accounts/sidebar_link_content",
       locals: { account: self }
     )
   end
 
+  def broadcast_sidebar_insert
+    broadcast_append_to(
+      user, :sidebar,
+      target: self.class.sidebar_kind_target_id(kind),
+      partial: "accounts/sidebar_item",
+      locals: { account: self }
+    )
+  end
+
+  def broadcast_sidebar_remove
+    broadcast_remove_to(user, :sidebar, target: [ self, :sidebar_item ])
+  end
+
   private
+
+    def broadcast_sidebar_change
+      if saved_change_to_kind?
+        broadcast_sidebar_remove
+        broadcast_sidebar_insert
+      elsif saved_change_to_name?
+        broadcast_sidebar_update
+      end
+    end
 
     def should_enqueue_source_import?
       return false unless sourceable_id?

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -39,7 +39,7 @@ class Transaction < ApplicationRecord
     previous = sidebar_broadcast_collector
     self.sidebar_broadcast_collector = Set.new
     yield
-    Account.real.where(id: sidebar_broadcast_collector).includes(:currency).find_each(&:broadcast_sidebar_replace)
+    Account.real.where(id: sidebar_broadcast_collector).includes(:currency).find_each(&:broadcast_sidebar_update)
   ensure
     self.sidebar_broadcast_collector = previous
   end
@@ -151,7 +151,7 @@ class Transaction < ApplicationRecord
         return
       end
 
-      Account.real.where(id: ids).includes(:currency).find_each(&:broadcast_sidebar_replace)
+      Account.real.where(id: ids).includes(:currency).find_each(&:broadcast_sidebar_update)
     end
 
     def reverse_account_balances

--- a/app/views/accounts/_sidebar_item.html.erb
+++ b/app/views/accounts/_sidebar_item.html.erb
@@ -1,0 +1,3 @@
+<li id="<%= dom_id(account, :sidebar_item) %>" class="account">
+  <%= account_sidebar_link(account, active_path: local_assigns[:active_path]) %>
+</li>

--- a/app/views/accounts/_sidebar_link_content.html.erb
+++ b/app/views/accounts/_sidebar_link_content.html.erb
@@ -1,7 +1,8 @@
+<span class="account__name"><%= account.name %></span>
 <% balance_minor = account.balance_minor %>
 <% modifier = if balance_minor
      balance_minor >= 0 ? "account__balance--positive" : "account__balance--negative"
    end %>
-<span id="<%= dom_id(account, :sidebar_balance) %>" class="account__balance <%= modifier %>">
+<span class="account__balance <%= modifier %>">
   <%= amount_to_currency(balance_minor, account.currency) if balance_minor %>
 </span>

--- a/app/views/accounts/_sidebar_nav.html.erb
+++ b/app/views/accounts/_sidebar_nav.html.erb
@@ -1,16 +1,15 @@
 <%= turbo_stream_from current_user, :sidebar %>
 
 <h3>Accounts</h3>
-<% @accounts_by_kind.each do |kind, accounts| %>
-  <% next if kind.blank? %>
-  <h4><%= kind.humanize.pluralize %></h4>
-  <ul>
-    <% accounts.each do |account| %>
-      <li class="account">
-        <%= account_nav_link_to account %>
-      </li>
-    <% end %>
-  </ul>
+<% Account.kinds.keys.each do |kind| %>
+  <div class="sidebar-kind-group">
+    <h4><%= kind.humanize.pluralize %></h4>
+    <ul id="<%= Account.sidebar_kind_target_id(kind) %>">
+      <% (@accounts_by_kind[kind] || []).each do |account| %>
+        <%= render "accounts/sidebar_item", account: account, active_path: request.path %>
+      <% end %>
+    </ul>
+  </div>
 <% end %>
 
 <ul>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -538,15 +538,15 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     end
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
 
   test "destroy broadcasts sidebar replaces for affected accounts" do
-    src_id = ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_balance)
-    dest_id = ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_balance)
+    src_id = ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_link)
+    dest_id = ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_link)
 
     streams = capture_turbo_stream_broadcasts([ @user, :sidebar ]) do
       delete transaction_url(@transaction), as: :turbo_stream
@@ -602,8 +602,8 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     end
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(@transaction.src_account, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(@transaction.dest_account, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end

--- a/test/helpers/accounts_helper_test.rb
+++ b/test/helpers/accounts_helper_test.rb
@@ -5,100 +5,97 @@ class AccountsHelperTest < ActionView::TestCase
   include ApplicationHelper
   include CurrenciesHelper
 
-  # Provide a controllable request for helpers that call request.path
-  def request
-    @mock_request ||= ActionDispatch::TestRequest.create
-  end
+  # account_sidebar_link
 
-  def with_path(path)
-    request.env["PATH_INFO"] = path
-  end
-
-  setup do
-    with_path("/")
-  end
-
-  # account_nav_link_to
-
-  test "account_nav_link_to renders link to account transactions path" do
+  test "account_sidebar_link renders link to account transactions path" do
     account = accounts(:asset_account)
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_match account_transactions_path(account), result
   end
 
-  test "account_nav_link_to includes account name" do
+  test "account_sidebar_link includes account name" do
     account = accounts(:asset_account)
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_match account.name, result
   end
 
-  test "account_nav_link_to shows positive balance class for zero balance" do
+  test "account_sidebar_link gives the link a stable dom id for broadcast updates" do
+    account = accounts(:asset_account)
+    result = account_sidebar_link(account)
+
+    assert_match(/id="#{ActionView::RecordIdentifier.dom_id(account, :sidebar_link)}"/, result)
+  end
+
+  test "account_sidebar_link shows positive balance class for zero balance" do
     account = accounts(:asset_account)
     account.balance_minor = 0
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_match(/account__balance--positive/, result)
     assert_no_match(/account__balance--negative/, result)
   end
 
-  test "account_nav_link_to shows positive balance class for positive balance" do
+  test "account_sidebar_link shows positive balance class for positive balance" do
     account = accounts(:asset_account)
     account.balance_minor = 1500
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_match(/account__balance--positive/, result)
     assert_no_match(/account__balance--negative/, result)
   end
 
-  test "account_nav_link_to shows negative balance class for negative balance" do
+  test "account_sidebar_link shows negative balance class for negative balance" do
     account = accounts(:asset_account)
     account.balance_minor = -500
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_match(/account__balance--negative/, result)
     assert_no_match(/account__balance--positive/, result)
   end
 
-  test "account_nav_link_to omits balance when balance_minor is nil" do
+  test "account_sidebar_link omits balance when balance_minor is nil" do
     account = accounts(:asset_account)
     account.balance_minor = nil
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account)
 
     assert_no_match(/account__balance--positive/, result)
     assert_no_match(/account__balance--negative/, result)
   end
 
-  test "account_nav_link_to has active class on exact transactions path" do
+  test "account_sidebar_link has active class on exact transactions path" do
     account = accounts(:asset_account)
-    with_path(account_transactions_path(account))
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account, active_path: account_transactions_path(account))
 
     assert_match(/\bactive\b/, result)
   end
 
-  test "account_nav_link_to has active class on sub-path of account" do
+  test "account_sidebar_link has active class on sub-path of account" do
     account = accounts(:asset_account)
-    with_path("#{account_path(account)}/something")
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account, active_path: "#{account_path(account)}/something")
 
     assert_match(/\bactive\b/, result)
   end
 
-  test "account_nav_link_to has no active class on a different account path" do
+  test "account_sidebar_link has no active class on a different account path" do
     account = accounts(:asset_account)
     other = accounts(:liability_account)
-    with_path(account_transactions_path(other))
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account, active_path: account_transactions_path(other))
 
     assert_no_match(/\bactive\b/, result)
   end
 
-  test "account_nav_link_to has no active class on unrelated path" do
+  test "account_sidebar_link has no active class on unrelated path" do
     account = accounts(:asset_account)
-    with_path("/categories")
-    result = account_nav_link_to(account)
+    result = account_sidebar_link(account, active_path: "/categories")
+
+    assert_no_match(/\bactive\b/, result)
+  end
+
+  test "account_sidebar_link has no active class when active_path is nil (broadcast render)" do
+    account = accounts(:asset_account)
+    result = account_sidebar_link(account)
 
     assert_no_match(/\bactive\b/, result)
   end

--- a/test/jobs/lunchflow/import_transactions_job_test.rb
+++ b/test/jobs/lunchflow/import_transactions_job_test.rb
@@ -249,10 +249,10 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
       Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
     end
 
-    targets = streams.map { |s| s["target"] }.sort
+    targets = streams.select { |s| s["action"] == "update" }.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(lf_bank_account, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(expense_account, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(lf_bank_account, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(expense_account, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -260,9 +260,11 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
   test "broadcasts nothing when there are no aggregator transactions to import" do
     lf_account, _ = create_linked_lunchflow_account
 
-    assert_no_turbo_stream_broadcasts([ @user, :sidebar ]) do
+    streams = capture_turbo_stream_broadcasts([ @user, :sidebar ]) do
       Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
     end
+
+    assert_empty streams
   end
 
   test "auto-merge broadcasts include counterparty accounts from merged candidates" do
@@ -300,13 +302,13 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
       Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account_a.id)
     end
 
-    targets = streams.map { |s| s["target"] }
+    targets = streams.select { |s| s["action"] == "update" }.map { |s| s["target"] }
     # Broadcasts must cover every real account whose balance moved during the job:
     # the two bank accounts from the final transfer, plus the revenue counterparty
     # whose balance was reversed when its transaction was absorbed into the merge.
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_a, :sidebar_balance)
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_b, :sidebar_balance)
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(revenue_counterparty, :sidebar_balance)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_a, :sidebar_link)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_b, :sidebar_link)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(revenue_counterparty, :sidebar_link)
     # Each affected account should appear exactly once (aggregation).
     assert_equal targets.uniq.size, targets.size
   end

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -564,10 +564,10 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
       Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
     end
 
-    targets = streams.map { |s| s["target"] }.sort
+    targets = streams.select { |s| s["action"] == "update" }.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(bank_account, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(expense_account, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(bank_account, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(expense_account, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -575,9 +575,11 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
   test "broadcasts nothing when there are no aggregator transactions to import" do
     sf_account, _ = create_linked_simplefin_account
 
-    assert_no_turbo_stream_broadcasts([ @user, :sidebar ]) do
+    streams = capture_turbo_stream_broadcasts([ @user, :sidebar ]) do
       Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
     end
+
+    assert_empty streams
   end
 
   test "auto-merge broadcasts include counterparty accounts from merged candidates" do
@@ -615,13 +617,13 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
       Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account_a.id)
     end
 
-    targets = streams.map { |s| s["target"] }
+    targets = streams.select { |s| s["action"] == "update" }.map { |s| s["target"] }
     # Broadcasts must cover every real account whose balance moved during the job:
     # the two bank accounts from the final transfer, plus the revenue counterparty
     # whose balance was reversed when its transaction was absorbed into the merge.
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_a, :sidebar_balance)
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_b, :sidebar_balance)
-    assert_includes targets, ActionView::RecordIdentifier.dom_id(revenue_counterparty, :sidebar_balance)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_a, :sidebar_link)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank_b, :sidebar_link)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(revenue_counterparty, :sidebar_link)
     # Each affected account should appear exactly once (aggregation).
     assert_equal targets.uniq.size, targets.size
   end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -546,20 +546,21 @@ class AccountTest < ActiveSupport::TestCase
     assert_includes duplicate.errors[:name], "has already been taken"
   end
 
-  test "broadcast_sidebar_replace emits a replace turbo stream targeting the account's sidebar dom id" do
+  test "broadcast_sidebar_update emits an update turbo stream targeting the account's sidebar link" do
     account = accounts(:asset_account)
 
     streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
-      account.broadcast_sidebar_replace
+      account.broadcast_sidebar_update
     end
 
     assert_equal 1, streams.size
     stream = streams.first
-    assert_equal "replace", stream["action"]
-    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_balance), stream["target"]
+    assert_equal "update", stream["action"]
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_link), stream["target"]
     template = stream.at("template").inner_html
-    assert_includes template, ActionView::RecordIdentifier.dom_id(account, :sidebar_balance)
+    assert_includes template, "account__name"
     assert_includes template, "account__balance"
+    assert_includes template, account.name
   end
 
   test "setting an opening balance broadcasts only the real account's sidebar" do
@@ -571,7 +572,7 @@ class AccountTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, streams.size
-    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_balance), streams.first["target"]
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_link), streams.first["target"]
   end
 
   test "changing an opening balance broadcasts the real account's sidebar" do
@@ -582,7 +583,7 @@ class AccountTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, streams.size
-    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_balance), streams.first["target"]
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_link), streams.first["target"]
   end
 
   test "clearing an opening balance broadcasts the real account's sidebar" do
@@ -593,6 +594,106 @@ class AccountTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, streams.size
-    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_balance), streams.first["target"]
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_link), streams.first["target"]
+  end
+
+  test "renaming a real account emits a single update turbo stream with the new name" do
+    account = accounts(:asset_account)
+
+    streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
+      account.update!(name: "Renamed Asset")
+    end
+
+    assert_equal 1, streams.size
+    stream = streams.first
+    assert_equal "update", stream["action"]
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_link), stream["target"]
+    assert_includes stream.at("template").inner_html, "Renamed Asset"
+  end
+
+  test "touching an unrelated attribute on a real account does not broadcast a sidebar update" do
+    account = accounts(:asset_account)
+
+    streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
+      account.touch
+    end
+
+    assert_empty streams
+  end
+
+  test "creating a real account emits an append turbo stream to the kind's ul" do
+    user = users(:one)
+
+    streams = capture_turbo_stream_broadcasts([ user, :sidebar ]) do
+      @new_account = Account.create!(user: user, currency: currencies(:usd), name: "Brand New", kind: :asset)
+    end
+
+    append = streams.find { |s| s["action"] == "append" }
+    assert append, "expected an append stream for the new account"
+    assert_equal Account.sidebar_kind_target_id("asset"), append["target"]
+    template = append.at("template").inner_html
+    assert_includes template, ActionView::RecordIdentifier.dom_id(@new_account, :sidebar_item)
+    assert_includes template, "Brand New"
+  end
+
+  test "creating a virtual account does not broadcast a sidebar append" do
+    user = users(:one)
+
+    streams = capture_turbo_stream_broadcasts([ user, :sidebar ]) do
+      Account.opening_balance_for(user: user, kind: :asset)
+    end
+
+    assert_empty streams.select { |s| s["action"] == "append" }
+  end
+
+  test "destroying a real account emits a remove turbo stream for the sidebar item" do
+    account = Account.create!(user: users(:one), currency: currencies(:usd), name: "Throwaway", kind: :asset)
+
+    streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
+      account.destroy!
+    end
+
+    remove = streams.find { |s| s["action"] == "remove" }
+    assert remove, "expected a remove stream"
+    assert_equal ActionView::RecordIdentifier.dom_id(account, :sidebar_item), remove["target"]
+  end
+
+  test "changing an account's kind emits remove + append to the new kind's ul" do
+    account = Account.create!(user: users(:one), currency: currencies(:usd), name: "Shiftable", kind: :asset)
+
+    streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
+      account.update!(kind: :liability)
+    end
+
+    removes = streams.select { |s| s["action"] == "remove" && s["target"] == ActionView::RecordIdentifier.dom_id(account, :sidebar_item) }
+    appends = streams.select { |s| s["action"] == "append" && s["target"] == Account.sidebar_kind_target_id("liability") }
+    updates = streams.select { |s| s["action"] == "update" }
+    assert_equal 1, removes.size
+    assert_equal 1, appends.size
+    assert_empty updates, "rename broadcast should not fire when kind changes"
+  end
+
+  test "simultaneous name and kind change emits only the move broadcasts" do
+    account = Account.create!(user: users(:one), currency: currencies(:usd), name: "Original", kind: :asset)
+
+    streams = capture_turbo_stream_broadcasts([ account.user, :sidebar ]) do
+      account.update!(name: "Moved", kind: :liability)
+    end
+
+    removes = streams.select { |s| s["action"] == "remove" }
+    appends = streams.select { |s| s["action"] == "append" }
+    updates = streams.select { |s| s["action"] == "update" }
+    assert_equal 1, removes.size
+    assert_equal 1, appends.size
+    assert_empty updates, "rename broadcast should not fire alongside a move"
+    assert_includes appends.first.at("template").inner_html, "Moved"
+  end
+
+  test "broadcast_sidebar_insert renders without raising when no request is in scope" do
+    account = accounts(:asset_account)
+
+    assert_nothing_raised do
+      account.broadcast_sidebar_insert
+    end
   end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -619,11 +619,11 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(accounts(:asset_account), :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(accounts(:expense_account), :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(accounts(:asset_account), :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(accounts(:expense_account), :sidebar_link)
     ].sort
     assert_equal expected, targets
-    assert streams.all? { |s| s["action"] == "replace" }
+    assert streams.all? { |s| s["action"] == "update" }
   end
 
   test "creating an opening balance transaction broadcasts only the real account" do
@@ -643,7 +643,7 @@ class TransactionTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, streams.size
-    assert_equal ActionView::RecordIdentifier.dom_id(real, :sidebar_balance), streams.first["target"]
+    assert_equal ActionView::RecordIdentifier.dom_id(real, :sidebar_link), streams.first["target"]
   end
 
   test "updating description-only still broadcasts sidebar" do
@@ -655,8 +655,8 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(transaction.src_account, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(transaction.dest_account, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(transaction.src_account, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(transaction.dest_account, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -673,9 +673,9 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(old_src, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(new_src, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(dest, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(old_src, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(new_src, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(dest, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -692,9 +692,9 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(src, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(old_dest, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(new_dest, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(src, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(old_dest, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(new_dest, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -710,8 +710,8 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(src, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(dest, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(src, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(dest, :sidebar_link)
     ].sort
     assert_equal expected, targets
   end
@@ -729,10 +729,10 @@ class TransactionTest < ActiveSupport::TestCase
 
     targets = streams.map { |s| s["target"] }.sort
     expected = [
-      ActionView::RecordIdentifier.dom_id(persisted_src, :sidebar_balance),
-      ActionView::RecordIdentifier.dom_id(persisted_dest, :sidebar_balance)
+      ActionView::RecordIdentifier.dom_id(persisted_src, :sidebar_link),
+      ActionView::RecordIdentifier.dom_id(persisted_dest, :sidebar_link)
     ].sort
     assert_equal expected, targets
-    refute_includes targets, ActionView::RecordIdentifier.dom_id(other_account, :sidebar_balance)
+    refute_includes targets, ActionView::RecordIdentifier.dom_id(other_account, :sidebar_link)
   end
 end

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -1,0 +1,66 @@
+require "application_system_test_case"
+
+class AccountsTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+    @user.update!(password: "password123")
+    sign_in_as(@user)
+  end
+
+  test "renaming an account updates the sidebar live and preserves the active class" do
+    account = accounts(:asset_account)
+    link_id = "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_link)}"
+    active_link_selector = "a.active[href='#{account_transactions_path(account)}']"
+
+    visit account_path(account)
+    assert_selector active_link_selector
+
+    Account.find(account.id).update!(name: "Freshly Renamed")
+
+    within(link_id) do
+      assert_text "Freshly Renamed"
+    end
+    assert_selector active_link_selector
+  end
+
+  test "creating a new account makes it appear in the sidebar live" do
+    visit transactions_path
+
+    new_account = Account.create!(
+      user: @user,
+      currency: currencies(:usd),
+      name: "Live Insert Probe",
+      kind: :liability
+    )
+
+    within("#sidebar_accounts_liability") do
+      assert_selector "##{ActionView::RecordIdentifier.dom_id(new_account, :sidebar_item)}"
+      assert_text "Live Insert Probe"
+    end
+  end
+
+  test "destroying an account removes it from the sidebar live" do
+    account = Account.create!(
+      user: @user,
+      currency: currencies(:usd),
+      name: "Live Delete Probe",
+      kind: :asset
+    )
+    visit transactions_path
+    assert_selector "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_item)}"
+
+    account.destroy!
+
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_item)}"
+  end
+
+  private
+
+  def sign_in_as(user)
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+    assert_link "Logout"
+  end
+end

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -21,10 +21,10 @@ class TransactionsTest < ApplicationSystemTestCase
     fill_in "transaction[amount]", with: "12.34"
     click_button "Create"
 
-    within("##{ActionView::RecordIdentifier.dom_id(src, :sidebar_balance)}") do
+    within("##{ActionView::RecordIdentifier.dom_id(src, :sidebar_link)}") do
       assert_text "-$12.34"
     end
-    within("##{ActionView::RecordIdentifier.dom_id(dest, :sidebar_balance)}") do
+    within("##{ActionView::RecordIdentifier.dom_id(dest, :sidebar_link)}") do
       assert_text "$12.34"
     end
   end
@@ -37,7 +37,7 @@ class TransactionsTest < ApplicationSystemTestCase
 
     visit account_path(account)
 
-    balance_id = "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_balance)}"
+    balance_id = "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_link)}"
     active_link_selector = "a.active[href='#{account_transactions_path(account)}']"
     assert_selector active_link_selector
 


### PR DESCRIPTION
## Summary
- Extends the balance live-update pattern from #110 to cover account CRUD (rename, create, destroy, kind change).
- Renames broadcast a Turbo Stream `update` targeting the account's `<a>` so its `active` class survives without re-computing `request.path` during the broadcast render.
- Creates `append` a new `<li>` into a per-kind `<ul>`; destroys `remove` by id; kind changes `remove` + `append`.
- Combines the old `_sidebar_balance` partial into `_sidebar_link_content` (name + balance together) so one broadcast path handles both rename and balance updates.
- Sidebar now renders all five `Account.kinds` so each kind's `<ul>` always exists as an append target; empty groups are hidden via `.sidebar-kind-group:has(li)` CSS.
- Extracts a shared `path_active?` helper used by both `nav_link_to` and the new `account_sidebar_link` helper.

## Design notes
- Broadcasts must never render anything that calls `request.path`. The `<a>` wrapper is only rendered during real HTTP requests (where active-state can be computed); broadcasts only ever update its innerHTML or append/remove `<li>` elements whose active-state doesn't apply.
- Kind changes currently append to the new group's end. Once drag-and-drop reordering lands, positioning becomes user-controlled — appending is the correct default.
- Renames update in place and do not reorder; preserving the active class on the current account is more important than alphabetical ordering, and drag-and-drop will make manual ordering explicit anyway.

## Test plan
- [x] `bin/rails test` — 599 unit tests pass (new coverage: rename, create real + virtual guard, destroy, kind change, simultaneous name + kind, broadcast-without-request regression guard).
- [x] `bin/rails test:system` — 23 system tests pass, including new coverage for live rename (preserves active class), live create, and live destroy.
- [x] `bin/rubocop` — clean.
- [x] Manual smoke test in two browser tabs: rename, create, destroy, and kind-change each replicate across tabs without losing the active link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)