### PR TITLE
Adopt cross-aggregator orphans on relink

### DIFF
--- a/app/jobs/lunchflow/import_transactions_job.rb
+++ b/app/jobs/lunchflow/import_transactions_job.rb
@@ -29,9 +29,7 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
             amount_minor: lft.amount_minor.abs,
             currency_id: ledger_account.currency_id,
             transacted_at: lft.date || Time.current,
-            description: description,
-            sourceable_type: "Lunchflow::Transaction",
-            aggregator_account_class: Lunchflow::Account
+            description: description
           )
 
           if orphan

--- a/app/jobs/simplefin/import_transactions_job.rb
+++ b/app/jobs/simplefin/import_transactions_job.rb
@@ -28,9 +28,7 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
             amount_minor: sft.amount_minor.abs,
             currency_id: ledger_account.currency_id,
             transacted_at: sft.transacted_at || sft.posted || Time.current,
-            description: sft.description,
-            sourceable_type: "Simplefin::Transaction",
-            aggregator_account_class: Simplefin::Account
+            description: sft.description
           )
 
           if orphan

--- a/app/models/concerns/aggregator_linkable.rb
+++ b/app/models/concerns/aggregator_linkable.rb
@@ -1,0 +1,26 @@
+module AggregatorLinkable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :ledger_account, class_name: "Account", as: :sourceable, dependent: :nullify
+    belongs_to :connection
+
+    AggregatorLinkable.register(self)
+  end
+
+  class_methods do
+    def transaction_class
+      "#{name.deconstantize}::Transaction".constantize
+    end
+  end
+
+  class << self
+    def register(klass)
+      registry << klass unless registry.include?(klass)
+    end
+
+    def registry
+      @registry ||= []
+    end
+  end
+end

--- a/app/models/concerns/aggregator_linkable.rb
+++ b/app/models/concerns/aggregator_linkable.rb
@@ -15,12 +15,23 @@ module AggregatorLinkable
   end
 
   class << self
+    # Store class names (stable strings) rather than class objects so the registry
+    # stays correct across Zeitwerk reloads. After a reload, redefined classes
+    # become new objects; if we held the old objects we'd either leak them or
+    # generate stale references in queries. Resolving via `constantize` on each
+    # read always returns the current class.
     def register(klass)
-      registry << klass unless registry.include?(klass)
+      registry_names << klass.name unless registry_names.include?(klass.name)
     end
 
     def registry
-      @registry ||= []
+      registry_names.map(&:constantize)
     end
+
+    private
+
+      def registry_names
+        @registry_names ||= []
+      end
   end
 end

--- a/app/models/lunchflow/account.rb
+++ b/app/models/lunchflow/account.rb
@@ -1,10 +1,9 @@
 class Lunchflow::Account < ApplicationRecord
   include Minorable
+  include AggregatorLinkable
+
   minorable :balance, with: :ledger_currency
 
-  has_one :ledger_account, class_name: "Account", as: :sourceable, dependent: :nullify
-
-  belongs_to :connection
   has_many :transactions, dependent: :destroy
 
   validates :remote_id, uniqueness: { scope: :connection_id }

--- a/app/models/simplefin/account.rb
+++ b/app/models/simplefin/account.rb
@@ -1,10 +1,9 @@
 class Simplefin::Account < ApplicationRecord
   include Minorable
+  include AggregatorLinkable
+
   minorable :balance, with: :ledger_currency
 
-  has_one :ledger_account, class_name: "Account", as: :sourceable, dependent: :nullify
-
-  belongs_to :connection
   has_many :transactions, dependent: :destroy
 
   def linked?

--- a/app/services/transaction/adopt_orphan.rb
+++ b/app/services/transaction/adopt_orphan.rb
@@ -66,12 +66,20 @@ class Transaction::AdoptOrphan
     # description on the value-starts-with-column side, where the stored value
     # would otherwise be interpolated into the LIKE pattern. LEFT(...) = ...
     # avoids pattern semantics entirely.
+    #
+    # The reverse branch (value-starts-with-column) requires an explicit
+    # non-empty-column guard. Without it, `LEFT(value, 0) = ''` would always
+    # equal `LOWER('')`, so a single blank stored description with the same
+    # amount/day/account would be adopted under any nonblank importing
+    # description. The forward branch is unaffected: `LEFT('', N) = ''` cannot
+    # equal a nonblank importing value (we early-return on blank @description).
     def prefix_match(column, value)
       column_lower = lower_col(column)
       value_lower = lower_quoted(value)
 
       column_starts_with_value = left_function(column_lower, value.length).eq(value_lower)
-      value_starts_with_column = left_function(value_lower, length_function(column_lower)).eq(column_lower)
+      value_starts_with_column = length_function(column_lower).gt(0)
+        .and(left_function(value_lower, length_function(column_lower)).eq(column_lower))
 
       column_starts_with_value.or(value_starts_with_column)
     end

--- a/app/services/transaction/adopt_orphan.rb
+++ b/app/services/transaction/adopt_orphan.rb
@@ -3,17 +3,17 @@ class Transaction::AdoptOrphan
     new(**kwargs).call
   end
 
-  def initialize(ledger_account:, amount_minor:, currency_id:, transacted_at:, description:, sourceable_type:, aggregator_account_class:)
+  def initialize(ledger_account:, amount_minor:, currency_id:, transacted_at:, description:)
     @ledger_account = ledger_account
     @amount_minor = amount_minor
     @currency_id = currency_id
     @transacted_at = transacted_at
     @description = description
-    @sourceable_type = sourceable_type
-    @aggregator_account_class = aggregator_account_class
   end
 
   def call
+    return nil if @description.blank?
+
     candidates = candidate_query.limit(2).to_a
     candidates.size == 1 ? candidates.first : nil
   end
@@ -26,43 +26,77 @@ class Transaction::AdoptOrphan
         .where("transactions.src_account_id = :id OR transactions.dest_account_id = :id", id: @ledger_account.id)
         .where(amount_minor: @amount_minor, currency_id: @currency_id)
         .where(transacted_at: @transacted_at.beginning_of_day..@transacted_at.end_of_day)
-        .where(description: @description)
         .where(opening_balance: false, split: false, parent_transaction_id: nil)
         .where(merged_into_id: nil, fx_amount_minor: nil)
         .where.missing(:merged_sources)
-        .where(orphan_sourceable_clause)
+        .where(orphan_with_description_clause)
     end
 
-    def orphan_sourceable_clause
+    # Manual-entry orphans (sourceable_id IS NULL) require an exact case-insensitive
+    # description match — preserves #117 safety so a user's manual placeholder cannot
+    # be scooped up by an unrelated long aggregator description that happens to share
+    # a short prefix.
+    #
+    # Stale-aggregator orphans (sourceable points into any aggregator's stale-account
+    # transaction set) use a bidirectional case-insensitive prefix match — covers the
+    # cross-aggregator truncation case (e.g. Lunch Flow's 32-char merchant truncation
+    # of a longer SimpleFIN description).
+    def orphan_with_description_clause
       table = Transaction.arel_table
-      table[:sourceable_id].eq(nil).or(
-        table[:sourceable_type].eq(@sourceable_type).and(
-          table[:sourceable_id].in(stale_aggregator_transactions.arel)
-        )
-      )
+
+      manual_entry = table[:sourceable_id].eq(nil)
+        .and(case_insensitive_eq(table[:description], @description))
+
+      aggregator_clauses = AggregatorLinkable.registry.map do |account_class|
+        table[:sourceable_type].eq(account_class.transaction_class.name)
+          .and(table[:sourceable_id].in(stale_transactions_for(account_class).arel))
+      end
+      stale_aggregator = aggregator_clauses.reduce(:or)
+        &.and(prefix_match(table[:description], @description))
+
+      stale_aggregator ? manual_entry.or(stale_aggregator) : manual_entry
     end
 
-    def stale_aggregator_transactions
-      aggregator_transaction_class
-        .where(account_id: stale_aggregator_accounts.select(:id))
+    def case_insensitive_eq(column, value)
+      lower_col(column).eq(lower_quoted(value))
+    end
+
+    def prefix_match(column, value)
+      column_lower = lower_col(column)
+      value_lower = lower_quoted(value)
+      column_starts_with_value = column_lower.matches("#{escape_like(value)}%".downcase)
+      value_starts_with_column = value_lower.matches(
+        Arel::Nodes::Concat.new(column_lower, Arel::Nodes::Quoted.new("%"))
+      )
+      column_starts_with_value.or(value_starts_with_column)
+    end
+
+    def lower_col(column)
+      Arel::Nodes::NamedFunction.new("LOWER", [ column ])
+    end
+
+    def lower_quoted(value)
+      Arel::Nodes::NamedFunction.new("LOWER", [ Arel::Nodes::Quoted.new(value) ])
+    end
+
+    def escape_like(s)
+      s.gsub(/[\\%_]/) { |c| "\\#{c}" }
+    end
+
+    def stale_transactions_for(account_class)
+      account_class.transaction_class
+        .where(account_id: stale_accounts_for(account_class).select(:id))
         .select(:id)
     end
 
-    def stale_aggregator_accounts
-      @aggregator_account_class
+    def stale_accounts_for(account_class)
+      account_class
         .where.missing(:ledger_account)
-        .where(connection_id: user_aggregator_connections.select(:id))
+        .where(connection_id: connections_for(account_class).select(:id))
     end
 
-    def user_aggregator_connections
-      aggregator_connection_class.where(user_id: @ledger_account.user_id)
-    end
-
-    def aggregator_transaction_class
-      @sourceable_type.constantize
-    end
-
-    def aggregator_connection_class
-      @aggregator_account_class.reflect_on_association(:connection).klass
+    def connections_for(account_class)
+      account_class.reflect_on_association(:connection).klass
+        .where(user_id: @ledger_account.user_id)
     end
 end

--- a/app/services/transaction/adopt_orphan.rb
+++ b/app/services/transaction/adopt_orphan.rb
@@ -61,14 +61,28 @@ class Transaction::AdoptOrphan
       lower_col(column).eq(lower_quoted(value))
     end
 
+    # Bidirectional case-insensitive "starts with" using LEFT/LENGTH instead of
+    # LIKE. LIKE would require escaping `%`, `_`, and `\` from the stored
+    # description on the value-starts-with-column side, where the stored value
+    # would otherwise be interpolated into the LIKE pattern. LEFT(...) = ...
+    # avoids pattern semantics entirely.
     def prefix_match(column, value)
       column_lower = lower_col(column)
       value_lower = lower_quoted(value)
-      column_starts_with_value = column_lower.matches("#{escape_like(value)}%".downcase)
-      value_starts_with_column = value_lower.matches(
-        Arel::Nodes::Concat.new(column_lower, Arel::Nodes::Quoted.new("%"))
-      )
+
+      column_starts_with_value = left_function(column_lower, value.length).eq(value_lower)
+      value_starts_with_column = left_function(value_lower, length_function(column_lower)).eq(column_lower)
+
       column_starts_with_value.or(value_starts_with_column)
+    end
+
+    def left_function(node, length)
+      length_node = length.is_a?(Integer) ? Arel::Nodes::Quoted.new(length) : length
+      Arel::Nodes::NamedFunction.new("LEFT", [ node, length_node ])
+    end
+
+    def length_function(node)
+      Arel::Nodes::NamedFunction.new("LENGTH", [ node ])
     end
 
     def lower_col(column)
@@ -77,10 +91,6 @@ class Transaction::AdoptOrphan
 
     def lower_quoted(value)
       Arel::Nodes::NamedFunction.new("LOWER", [ Arel::Nodes::Quoted.new(value) ])
-    end
-
-    def escape_like(s)
-      s.gsub(/[\\%_]/) { |c| "\\#{c}" }
     end
 
     def stale_transactions_for(account_class)

--- a/config/initializers/aggregator_linkable.rb
+++ b/config/initializers/aggregator_linkable.rb
@@ -1,4 +1,6 @@
-Rails.application.config.to_prepare do
-  Simplefin::Account
-  Lunchflow::Account
+unless Rails.application.config.eager_load
+  Rails.application.config.to_prepare do
+    Simplefin::Account
+    Lunchflow::Account
+  end
 end

--- a/config/initializers/aggregator_linkable.rb
+++ b/config/initializers/aggregator_linkable.rb
@@ -1,0 +1,4 @@
+Rails.application.config.to_prepare do
+  Simplefin::Account
+  Lunchflow::Account
+end

--- a/test/jobs/lunchflow/import_transactions_job_test.rb
+++ b/test/jobs/lunchflow/import_transactions_job_test.rb
@@ -359,6 +359,75 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_equal reissued_lunchflow_transaction, original_ledger_transaction.sourceable
   end
 
+  test "adopts a stale Simplefin orphan with a longer description when importing a truncated Lunchflow merchant" do
+    full_description = "Recurring vendor charge with extended detail in the description"
+    truncated_description = full_description[0, 32]
+
+    bank_account = Account.create!(
+      user: @user, currency: @currency, name: "Cross-aggregator Checking", kind: :asset
+    )
+
+    stale_sf_account = Simplefin::Account.create!(
+      connection: simplefin_connections(:one),
+      remote_id: "acc_stale_for_lf",
+      name: "Old SF Checking",
+      currency: "USD",
+      balance: "1000.00"
+    )
+    stale_sf_transaction = Simplefin::Transaction.create!(
+      account: stale_sf_account,
+      remote_id: "txn_stale_full",
+      amount: "-20.00",
+      description: full_description,
+      posted: 2.days.ago,
+      transacted_at: 2.days.ago,
+      pending: false
+    )
+    expense_account = Account.create!(
+      user: @user, currency: @currency, name: full_description, kind: :expense
+    )
+    original_ledger_transaction = Transaction.create!(
+      user: @user, src_account: bank_account, dest_account: expense_account,
+      amount_minor: 2000, currency: @currency, description: full_description,
+      transacted_at: 2.days.ago, sourceable: stale_sf_transaction, synced_at: 2.days.ago
+    )
+
+    # User now relinks to a fresh Lunch Flow account whose merchant text is the 32-char
+    # truncation of the SimpleFIN description we already imported.
+    new_lf_account = Lunchflow::Account.create!(
+      connection: lunchflow_connections(:one),
+      remote_id: 8888,
+      name: "Cross-aggregator Checking",
+      institution_name: "Test Bank",
+      provider: "finicity",
+      currency: "USD",
+      status: "ACTIVE",
+      balance: "1000.00"
+    )
+    bank_account.update!(sourceable: new_lf_account)
+    new_lf_transaction = Lunchflow::Transaction.create!(
+      account: new_lf_account,
+      remote_id: "txn_lf_truncated",
+      amount: "-20.00",
+      currency: "USD",
+      description: "",
+      merchant: truncated_description,
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+
+    assert_no_difference -> {
+      Transaction.unmerged.where("src_account_id = :id OR dest_account_id = :id", id: bank_account.id).count
+    } do
+      Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: new_lf_account.id)
+    end
+
+    original_ledger_transaction.reload
+    assert_equal new_lf_transaction, original_ledger_transaction.sourceable
+    assert_equal expense_account, original_ledger_transaction.dest_account
+    assert_equal full_description, original_ledger_transaction.description, "user-facing description should be preserved on the adopted row"
+  end
+
   private
 
     def create_linked_lunchflow_account(remote_id: 901, name: "LF Test Checking")

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -719,6 +719,76 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_equal targets.uniq.size, targets.size
   end
 
+  test "adopts a stale Lunchflow orphan when its description is a prefix of an importing Simplefin description" do
+    full_description = "Long aggregator description that exceeds thirty-two characters by quite a lot"
+    truncated_description = full_description[0, 32]
+
+    bank_account = Account.create!(
+      user: @user, currency: @currency, name: "Cross-aggregator Checking", kind: :asset
+    )
+
+    stale_lf_account = Lunchflow::Account.create!(
+      connection: lunchflow_connections(:one),
+      remote_id: 7777,
+      name: "Old LF Checking",
+      institution_name: "Test Bank",
+      provider: "finicity",
+      currency: "USD",
+      status: "DISCONNECTED",
+      balance: "1000.00"
+    )
+    stale_lf_transaction = Lunchflow::Transaction.create!(
+      account: stale_lf_account,
+      remote_id: "stale_lf_truncated",
+      amount: "-500.00",
+      currency: "USD",
+      description: "",
+      merchant: truncated_description,
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+    expense_account = Account.create!(
+      user: @user, currency: @currency, name: truncated_description, kind: :expense
+    )
+    original_ledger_transaction = Transaction.create!(
+      user: @user, src_account: bank_account, dest_account: expense_account,
+      amount_minor: 50000, currency: @currency, description: truncated_description,
+      transacted_at: 2.days.ago, sourceable: stale_lf_transaction, synced_at: 2.days.ago
+    )
+
+    # User now relinks the same ledger account to a fresh SimpleFIN account whose history
+    # overlaps with the stale Lunch Flow data. The SimpleFIN description for this transaction
+    # is the un-truncated form of the Lunch Flow merchant text.
+    new_sf_account = Simplefin::Account.create!(
+      connection: simplefin_connections(:one),
+      remote_id: "acc_after_relink",
+      name: "Cross-aggregator Checking",
+      currency: "USD",
+      balance: "1000.00"
+    )
+    bank_account.update!(sourceable: new_sf_account)
+    new_sf_transaction = Simplefin::Transaction.create!(
+      account: new_sf_account,
+      remote_id: "txn_full_desc",
+      amount: "-500.00",
+      description: full_description,
+      posted: 2.days.ago,
+      transacted_at: 2.days.ago,
+      pending: false
+    )
+
+    assert_no_difference -> {
+      Transaction.unmerged.where("src_account_id = :id OR dest_account_id = :id", id: bank_account.id).count
+    } do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: new_sf_account.id)
+    end
+
+    original_ledger_transaction.reload
+    assert_equal new_sf_transaction, original_ledger_transaction.sourceable
+    assert_equal expense_account, original_ledger_transaction.dest_account
+    assert_equal truncated_description, original_ledger_transaction.description, "user-facing description should be preserved on the adopted row"
+  end
+
   private
 
     def create_linked_simplefin_account(remote_id: "acc_test", name: "SF Test Checking")

--- a/test/models/concerns/aggregator_linkable_test.rb
+++ b/test/models/concerns/aggregator_linkable_test.rb
@@ -30,4 +30,22 @@ class AggregatorLinkableTest < ActiveSupport::TestCase
       assert_equal :nullify, reflection.options[:dependent]
     end
   end
+
+  test "registry resolves to the current class object even after the class is redefined" do
+    # Simulates Zeitwerk reload: register a stand-in class under a name, then
+    # redefine the class under the same name. Registry should resolve to the
+    # current (redefined) class, not retain a reference to the old object.
+    Object.const_set(:ReloadFixture, Class.new)
+    AggregatorLinkable.register(ReloadFixture)
+    original = ReloadFixture
+    Object.send(:remove_const, :ReloadFixture)
+    Object.const_set(:ReloadFixture, Class.new)
+
+    resolved = AggregatorLinkable.registry.find { |klass| klass.name == "ReloadFixture" }
+    assert_equal ReloadFixture, resolved
+    refute_same original, resolved
+  ensure
+    AggregatorLinkable.send(:registry_names).delete("ReloadFixture")
+    Object.send(:remove_const, :ReloadFixture) if defined?(ReloadFixture)
+  end
 end

--- a/test/models/concerns/aggregator_linkable_test.rb
+++ b/test/models/concerns/aggregator_linkable_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class AggregatorLinkableTest < ActiveSupport::TestCase
+  test "registry contains every aggregator account class" do
+    assert_includes AggregatorLinkable.registry, Simplefin::Account
+    assert_includes AggregatorLinkable.registry, Lunchflow::Account
+  end
+
+  test "transaction_class derives the namespaced transaction class" do
+    assert_equal Simplefin::Transaction, Simplefin::Account.transaction_class
+    assert_equal Lunchflow::Transaction, Lunchflow::Account.transaction_class
+  end
+
+  test "register is idempotent under repeated inclusion" do
+    starting_size = AggregatorLinkable.registry.size
+
+    AggregatorLinkable.register(Simplefin::Account)
+    AggregatorLinkable.register(Simplefin::Account)
+    AggregatorLinkable.register(Lunchflow::Account)
+
+    assert_equal starting_size, AggregatorLinkable.registry.size
+  end
+
+  test "ledger_account association is wired with the polymorphic sourceable name" do
+    AggregatorLinkable.registry.each do |account_class|
+      reflection = account_class.reflect_on_association(:ledger_account)
+      assert_not_nil reflection, "#{account_class} should have a ledger_account association"
+      assert_equal :sourceable, reflection.options[:as]
+      assert_equal "Account", reflection.options[:class_name]
+      assert_equal :nullify, reflection.options[:dependent]
+    end
+  end
+end

--- a/test/services/transaction/adopt_orphan_test.rb
+++ b/test/services/transaction/adopt_orphan_test.rb
@@ -618,20 +618,26 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
     assert_nil candidate
   end
 
-  test "treats LIKE metacharacters in the importing description literally" do
-    description_with_metacharacters = "Refund 100% guaranteed_X"
+  test "treats LIKE metacharacters in stored descriptions literally (no false-positive prefix match)" do
+    # Stored orphan description contains `%` and `_`. If those are interpreted
+    # as LIKE wildcards in the prefix-match clause, an importing description
+    # whose static text happens to coincide around those positions could be
+    # erroneously adopted. The shape "X%Y_Z" + a value matching that LIKE
+    # pattern is the classic false-positive.
+    orphan_description = "Refund 100% guaranteed_X"
+    importing_description = "Refund 100abc guaranteed_X with extras"
 
     stale_simplefin_transaction = Simplefin::Transaction.create!(
       account: @stale_simplefin_account,
       remote_id: "metachar_remote",
       amount: "-12.34",
-      description: "Different transaction entirely",
+      description: orphan_description,
       transacted_at: 2.days.ago,
       posted: 2.days.ago
     )
     Transaction.create!(
       user: @user, src_account: @ledger_account, dest_account: @counterpart,
-      amount_minor: 1234, currency: @currency, description: "Different transaction entirely",
+      amount_minor: 1234, currency: @currency, description: orphan_description,
       transacted_at: 2.days.ago, sourceable: stale_simplefin_transaction
     )
 
@@ -640,7 +646,7 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       amount_minor: 1234,
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
-      description: description_with_metacharacters
+      description: importing_description
     )
 
     assert_nil candidate

--- a/test/services/transaction/adopt_orphan_test.rb
+++ b/test/services/transaction/adopt_orphan_test.rb
@@ -39,8 +39,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_equal orphan, candidate
@@ -59,8 +57,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_equal orphan, candidate
@@ -84,8 +80,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 1.day.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -98,8 +92,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 1.day.ago,
       description: "Nothing Like This Exists",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -126,8 +118,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -147,8 +137,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -170,8 +158,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -200,8 +186,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     # The originals are zeroed (amount_minor=0, merged_into populated) and the synthetic
@@ -227,8 +211,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -248,8 +230,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -269,8 +249,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: Time.zone.parse("2026-04-24 23:30:00"),
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_not_nil candidate
@@ -289,8 +267,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: Time.zone.parse("2026-04-24 00:30:00"),
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -335,8 +311,6 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Simplefin::Transaction",
-      aggregator_account_class: Simplefin::Account
     )
 
     assert_nil candidate
@@ -376,10 +350,299 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
       currency_id: @currency.id,
       transacted_at: 2.days.ago,
       description: "Coffee Shop",
-      sourceable_type: "Lunchflow::Transaction",
-      aggregator_account_class: Lunchflow::Account
     )
 
     assert_equal orphan, candidate
+  end
+
+  test "adopts a stale Simplefin orphan when importing a Lunchflow transaction with a prefix description" do
+    full_description = "Long aggregator description that exceeds thirty-two characters by quite a lot"
+    truncated_description = full_description[0, 32]
+
+    stale_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "stale_long_desc",
+      amount: "-500.00",
+      description: full_description,
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    orphan = Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 50000, currency: @currency, description: full_description,
+      transacted_at: 2.days.ago, sourceable: stale_simplefin_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 50000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: truncated_description
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "adopts a stale Lunchflow orphan when importing a Simplefin transaction with the longer description" do
+    lunchflow_account = accounts(:lunchflow_linked_asset)
+    full_description = "Recurring vendor charge with extended detail in the description"
+    truncated_description = full_description[0, 32]
+
+    stale_lunchflow_account = Lunchflow::Account.create!(
+      connection: lunchflow_connections(:one),
+      remote_id: 5550,
+      name: "Stale LF",
+      institution_name: "Test Bank",
+      provider: "finicity",
+      currency: "USD",
+      status: "DISCONNECTED",
+      balance: "1000.00"
+    )
+    stale_lunchflow_transaction = Lunchflow::Transaction.create!(
+      account: stale_lunchflow_account,
+      remote_id: "stale_truncated",
+      amount: "-20.00",
+      currency: "USD",
+      description: "",
+      merchant: truncated_description,
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+    orphan = Transaction.create!(
+      user: @user, src_account: lunchflow_account, dest_account: @counterpart,
+      amount_minor: 2000, currency: @currency, description: truncated_description,
+      transacted_at: 2.days.ago, sourceable: stale_lunchflow_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: lunchflow_account,
+      amount_minor: 2000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: full_description
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "disambiguates between same-amount same-day transactions by description prefix (preauth vs posted)" do
+    posted_description = "Posted form long description with much additional detail appended"
+    preauth_description = "Preauth form long description for the same underlying charge"
+    importing_description = "Posted form long description w"
+
+    preauth_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "preauth_remote",
+      amount: "-18.99",
+      description: preauth_description,
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    posted_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "posted_remote",
+      amount: "-18.99",
+      description: posted_description,
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 1899, currency: @currency, description: preauth_description,
+      transacted_at: 2.days.ago, sourceable: preauth_simplefin_transaction
+    )
+    posted_orphan = Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 1899, currency: @currency, description: posted_description,
+      transacted_at: 2.days.ago, sourceable: posted_simplefin_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 1899,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: importing_description
+    )
+
+    assert_equal posted_orphan, candidate
+  end
+
+  test "manual-entry orphans require an exact description match (rejects prefix overlap)" do
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 5000, currency: @currency, description: "X",
+      transacted_at: 2.days.ago
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "Xtra long description from API"
+    )
+
+    assert_nil candidate
+  end
+
+  test "manual-entry orphans match case-insensitively on exact description" do
+    orphan = Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 5000, currency: @currency, description: "Manual Entry",
+      transacted_at: 2.days.ago
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "manual entry"
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "abstains when two stale-aggregator orphans both prefix-match the importing description" do
+    full_a = "Common prefix variant A with extra suffix detail"
+    full_b = "Common prefix variant B with extra suffix detail"
+    importing = "Common prefix variant"
+
+    stale_a = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account, remote_id: "stale_a",
+      amount: "-500.00", description: full_a,
+      transacted_at: 2.days.ago, posted: 2.days.ago
+    )
+    stale_b = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account, remote_id: "stale_b",
+      amount: "-500.00", description: full_b,
+      transacted_at: 2.days.ago, posted: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 50000, currency: @currency, description: full_a,
+      transacted_at: 2.days.ago, sourceable: stale_a
+    )
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 50000, currency: @currency, description: full_b,
+      transacted_at: 2.days.ago, sourceable: stale_b
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 50000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: importing
+    )
+
+    assert_nil candidate
+  end
+
+  test "adopts a same-aggregator stale orphan whose description is a prefix of the importing description" do
+    short_description = "Short stored description"
+    long_description = "Short stored description with extra detail"
+
+    stale_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "old_short",
+      amount: "-500.00",
+      description: short_description,
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    orphan = Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 50000, currency: @currency, description: short_description,
+      transacted_at: 2.days.ago, sourceable: stale_simplefin_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 50000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: long_description
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "ignores stale aggregator transactions on the other aggregator type when belonging to a different user" do
+    other_user = users(:two)
+    other_user_currency = currencies(:eur)
+
+    other_user_stale_lf_account = Lunchflow::Account.create!(
+      connection: lunchflow_connections(:two),
+      remote_id: 99999,
+      name: "Other LF",
+      institution_name: "Test Bank",
+      provider: "finicity",
+      currency: "EUR",
+      status: "DISCONNECTED",
+      balance: "1000.00"
+    )
+    other_user_stale_lf_transaction = Lunchflow::Transaction.create!(
+      account: other_user_stale_lf_account,
+      remote_id: "other_user_lf",
+      amount: "-50.00",
+      currency: "EUR",
+      description: "",
+      merchant: "Coffee Shop",
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+    other_user_account = Account.create!(
+      user: other_user, currency: other_user_currency, name: "Other User Bank", kind: :asset
+    )
+    other_user_expense = Account.create!(
+      user: other_user, currency: other_user_currency, name: "Other User Coffee", kind: :expense
+    )
+    Transaction.create!(
+      user: other_user, src_account: other_user_account, dest_account: other_user_expense,
+      amount_minor: 5000, currency: other_user_currency, description: "Coffee Shop",
+      transacted_at: 2.days.ago, sourceable: other_user_stale_lf_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "Coffee Shop with extra detail"
+    )
+
+    assert_nil candidate
+  end
+
+  test "treats LIKE metacharacters in the importing description literally" do
+    description_with_metacharacters = "Refund 100% guaranteed_X"
+
+    stale_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "metachar_remote",
+      amount: "-12.34",
+      description: "Different transaction entirely",
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 1234, currency: @currency, description: "Different transaction entirely",
+      transacted_at: 2.days.ago, sourceable: stale_simplefin_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 1234,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: description_with_metacharacters
+    )
+
+    assert_nil candidate
   end
 end

--- a/test/services/transaction/adopt_orphan_test.rb
+++ b/test/services/transaction/adopt_orphan_test.rb
@@ -618,6 +618,37 @@ class Transaction::AdoptOrphanTest < ActiveSupport::TestCase
     assert_nil candidate
   end
 
+  test "does not adopt a stale-aggregator orphan whose stored description is blank" do
+    # The DB has no constraint preventing empty descriptions on Transaction or
+    # on aggregator transactions. Without an explicit guard, the bidirectional
+    # prefix predicate `LEFT(value, LENGTH(column)) = column` degenerates to
+    # `'' = ''` whenever column is empty, and a single blank-description orphan
+    # on the same amount/day/account would silently swallow any importing row.
+    blank_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account,
+      remote_id: "blank_remote",
+      amount: "-12.34",
+      description: "",
+      transacted_at: 2.days.ago,
+      posted: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 1234, currency: @currency, description: "",
+      transacted_at: 2.days.ago, sourceable: blank_simplefin_transaction
+    )
+
+    candidate = Transaction::AdoptOrphan.call(
+      ledger_account: @ledger_account,
+      amount_minor: 1234,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "Some unrelated importing description"
+    )
+
+    assert_nil candidate
+  end
+
   test "treats LIKE metacharacters in stored descriptions literally (no false-positive prefix match)" do
     # Stored orphan description contains `%` and `_`. If those are interpreted
     # as LIKE wildcards in the prefix-match clause, an importing description


### PR DESCRIPTION
## Summary

- Closes #115. Extends `Transaction::AdoptOrphan` to handle the cross-aggregator case (e.g. SimpleFIN ↔ Lunch Flow), in addition to the within-aggregator reconnect case shipped in #117.
- New concern `AggregatorLinkable` lifts the duplicated `has_one :ledger_account, as: :sourceable` and `belongs_to :connection` macros from both aggregator account models and self-registers each including class as a registry of aggregator types. `transaction_class` derives the namespaced sibling by convention. Adding a third aggregator now only requires including the concern.
- `AdoptOrphan`'s orphan clause splits into two disjuncts so its safety profile differs by candidate kind:
  - **Manual-entry orphans** (`sourceable_id IS NULL`) require an exact, case-insensitive description match. Preserves #117's behavior — a user's manual placeholder like `"X"` cannot be scooped up by an aggregator import of `"Xtra long real description"`.
  - **Stale-aggregator orphans** (sourceable on any aggregator's stale account, unioned across all registered types) use a bidirectional case-insensitive prefix match. Covers the cross-aggregator truncation pattern observed in the dev data, where one aggregator stores a 32-character prefix of the other's longer description for the same real-world transaction.
- `AdoptOrphan.call`'s public API simplifies: the `sourceable_type:` and `aggregator_account_class:` keyword arguments are dropped because the registry tells the service which aggregator types to consider. Both import jobs are updated.
- An initializer (`config/initializers/aggregator_linkable.rb`) touches both aggregator account classes via `to_prepare` so the registry is populated on boot/reload even when Zeitwerk would otherwise leave it empty until first reference.
- Same-aggregator semantics relax slightly: a stale Simplefin orphan whose description is a non-equal prefix of the importing Simplefin description (e.g. `"shorter description"` vs `"shorter description with extra detail"`) now adopts where #117 would have created a duplicate. In practice the same upstream emits the same string for reconnects, so this is rarely-exercised; tested explicitly.

## Why prefix matching, not fuzzy similarity

Direct probe of one aggregator's API confirmed its description field is hard-truncated to 32 characters with no fuller field, no verbose flag, and no detail endpoint to fetch. Across the available cross-aggregator dev data, every overlapping pair fits a deterministic prefix relationship — same calendar day, same `amount_minor`, one description a prefix of the other. `pg_trgm` similarity would handle the same cases but introduces a tunable threshold and a Postgres extension for no measurable gain on observed data. Documented as a deferred fallback if a future institution surfaces uncaught duplicates.

## Test plan

- [x] `bin/rails test test/services/transaction/adopt_orphan_test.rb` — all 14 existing cases continue to pass; 9 new cases added: cross-aggregator adoption (both directions), bidirectional prefix on stale-aggregator orphans, pending-vs-posted preauth disambiguation, manual-entry orphan rejected on prefix overlap (safety regression), manual-entry orphan adopted on case-insensitive exact match, multi-candidate abstention on the stale-aggregator side, same-aggregator non-exact-prefix relaxation, cross-user safety extended to the cross-aggregator case, LIKE-metacharacter escaping
- [x] `bin/rails test test/jobs/simplefin/import_transactions_job_test.rb` — added an integration test for a stale Lunchflow orphan adopted by an importing Simplefin transaction with a longer (un-truncated) description
- [x] `bin/rails test test/jobs/lunchflow/import_transactions_job_test.rb` — symmetric: stale Simplefin orphan adopted by an importing Lunchflow transaction with a truncated merchant
- [x] `bin/rails test test/models/concerns/aggregator_linkable_test.rb` — registry contains both aggregator account classes, `transaction_class` derives the right namespace, registration is idempotent under repeat inclusion (Zeitwerk reload safety), each registered class has the polymorphic `:sourceable` ledger-account association
- [x] `bin/rails test` — full unit + integration suite (638 runs, 0 failures)
- [x] `bin/rails test:system` — system suite (26 runs, 0 failures)
- [x] `bin/rubocop` — clean
- [x] `bin/brakeman --no-pager` — 0 warnings
- [x] `bin/bundler-audit` — 0 vulnerabilities
- [x] `bin/importmap audit` — 0 vulnerable packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)