### PR TITLE
Add a pencil shortcut to the account edit page from the sidebar

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -186,6 +186,34 @@ header h1 {
 .account__balance--positive { color: var(--color-positive); }
 .account__balance--negative { color: var(--color-negative); }
 
+.account__edit-pencil {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 0;
+  padding: 2px;
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 3px;
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+
+.sidebar nav ul li a:hover .account__edit-pencil,
+.account__edit-pencil:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.account__edit-pencil:hover {
+  background-color: var(--honey-pale);
+}
+
 .sidebar-resizer {
   width: 4px;
   cursor: col-resize;

--- a/app/javascript/controllers/edit_pencil_controller.js
+++ b/app/javascript/controllers/edit_pencil_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { url: String }
+
+  navigate(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    Turbo.visit(this.urlValue)
+  }
+}

--- a/app/views/accounts/_sidebar_link_content.html.erb
+++ b/app/views/accounts/_sidebar_link_content.html.erb
@@ -1,4 +1,14 @@
 <span class="account__name"><%= account.name %></span>
+
+<button type="button"
+        class="account__edit-pencil"
+        data-controller="edit-pencil"
+        data-edit-pencil-url-value="<%= edit_account_path(account) %>"
+        data-action="click->edit-pencil#navigate"
+        aria-label="Edit <%= account.name %>">
+  <span aria-hidden="true">✏️</span>
+</button>
+
 <% balance_minor = account.balance_minor %>
 <% modifier = if balance_minor
      balance_minor >= 0 ? "account__balance--positive" : "account__balance--negative"

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -47,7 +47,7 @@ class AccountsTest < ApplicationSystemTestCase
 
     find(link_id).hover
     within(link_id) do
-      find(".account__edit-pencil", visible: :all).click
+      find(".account__edit-pencil").click
     end
 
     assert_current_path edit_account_path(account)

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -39,6 +39,20 @@ class AccountsTest < ApplicationSystemTestCase
     end
   end
 
+  test "the sidebar pencil navigates to the account edit page" do
+    account = accounts(:asset_account)
+    link_id = "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_link)}"
+
+    visit transactions_path
+
+    find(link_id).hover
+    within(link_id) do
+      find(".account__edit-pencil", visible: :all).click
+    end
+
+    assert_current_path edit_account_path(account)
+  end
+
   test "destroying an account removes it from the sidebar live" do
     account = Account.create!(
       user: @user,


### PR DESCRIPTION
## Summary
- Hover any sidebar account row → ✏️ button appears between the name and balance.
- Click the pencil → `Turbo.visit(edit_account_path(account))` navigates to the account's edit page; the row's outer link to transactions is preserved by `preventDefault` + `stopPropagation`.
- 12-line Stimulus controller (`edit_pencil_controller.js`), CSS for hover/focus reveal, one system test.

Successor to #125 (which tried to do inline-rename and got snared in click-bubble races + system-test flakes). This is the placeholder shape until the per-row context menu / properties dialog lands and absorbs the affordance — tracked in #128.

## Test plan
- [x] `bin/rails test:system` — all green (includes the new "the sidebar pencil navigates to the account edit page" test plus existing live-sidebar tests).
- [x] `bin/rails test` — green.
- [x] `bin/rubocop` — clean.
- [x] Manual: hover any sidebar account → pencil fades in. Click → land on the edit page. Click the row anywhere else → still navigates to transactions as before. Tab through sidebar → focus reaches the pencil; pressing Enter on it navigates to edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)