### PR TITLE
Ignore Claude Code runtime lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@
 # Ignore coverage reports.
 /coverage
 
-# Ignore local Claude Code settings.
+# Ignore local Claude Code settings and runtime artifacts.
 /.claude/settings.local.json
+/.claude/*.lock


### PR DESCRIPTION
## Summary
\`ScheduleWakeup\` from Claude Code writes \`.claude/scheduled_tasks.lock\` into the project. It's a runtime artifact, not something to commit. Adding \`.claude/*.lock\` to \`.gitignore\` covers this and any future lock files in \`.claude/\`.

\`.claude/settings.json\` (team-shared) stays tracked. \`.claude/settings.local.json\` (personal) stays ignored. No tracked files affected.

## Test plan
- [x] Run something that creates \`.claude/scheduled_tasks.lock\`; verify \`git status\` shows it as ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)