### PR TITLE
Unify From/To columns into Account + Counterparty + signed Amount

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -22,7 +22,7 @@
   white-space: nowrap;
 }
 
-/* Table row */
+/* Table row — unfiltered view: 11 cols (Account + Counterparty) */
 .transactions .row {
   display: grid;
   grid-template-columns:
@@ -30,8 +30,8 @@
     minmax(140px, 2fr)        /* Date */
     minmax(90px,  1.2fr)      /* Type */
     minmax(80px,  2fr)        /* Description */
-    minmax(90px,  1.5fr)      /* From */
-    minmax(90px,  1.5fr)      /* To */
+    minmax(90px,  1.5fr)      /* Account */
+    minmax(90px,  1.5fr)      /* Counterparty */
     minmax(75px,  1.2fr)      /* Amount */
     minmax(60px,  0.8fr)      /* Currency */
     minmax(80px,  1.3fr)      /* Category */
@@ -39,6 +39,21 @@
     minmax(120px, 1.6fr);     /* Actions */
   gap: 0;
   align-items: stretch;
+}
+
+/* Scoped view: 10 cols (no Account column — it's the page context) */
+.transactions .row.row--scoped {
+  grid-template-columns:
+    32px                      /* Select */
+    minmax(140px, 2fr)        /* Date */
+    minmax(90px,  1.2fr)      /* Type */
+    minmax(80px,  2fr)        /* Description */
+    minmax(90px,  1.5fr)      /* Counterparty */
+    minmax(75px,  1.2fr)      /* Amount */
+    minmax(60px,  0.8fr)      /* Currency */
+    minmax(80px,  1.3fr)      /* Category */
+    minmax(60px,  0.7fr)      /* Cleared */
+    minmax(120px, 1.6fr);     /* Actions */
 }
 
 
@@ -50,8 +65,8 @@
       minmax(140px, 2fr)        /* Date */
       minmax(90px,  1.2fr)      /* Type */
                                 /* Description — hidden */
-      minmax(90px,  1.5fr)      /* From */
-      minmax(90px,  1.5fr)      /* To */
+      minmax(90px,  1.5fr)      /* Account */
+      minmax(90px,  1.5fr)      /* Counterparty */
       minmax(75px,  1.2fr)      /* Amount */
                                 /* Currency — hidden */
                                 /* Category — hidden */
@@ -59,10 +74,33 @@
       minmax(120px, 1.6fr);     /* Actions */
   }
 
-  .transactions .row > div:nth-child(4),
-  .transactions .row > div:nth-child(8),
-  .transactions .row > div:nth-child(9),
-  .transactions .row > div:nth-child(10) {
+  .transactions .row.row--scoped {
+    grid-template-columns:
+      32px                      /* Select */
+      minmax(140px, 2fr)        /* Date */
+      minmax(90px,  1.2fr)      /* Type */
+                                /* Description — hidden */
+      minmax(90px,  1.5fr)      /* Counterparty */
+      minmax(75px,  1.2fr)      /* Amount */
+                                /* Currency — hidden */
+                                /* Category — hidden */
+                                /* Cleared — hidden */
+      minmax(120px, 1.6fr);     /* Actions */
+  }
+
+  /* Unfiltered (11 col): hide Description (4), Currency (8), Category (9), Cleared (10) */
+  .transactions .row:not(.row--scoped) > div:nth-child(4),
+  .transactions .row:not(.row--scoped) > div:nth-child(8),
+  .transactions .row:not(.row--scoped) > div:nth-child(9),
+  .transactions .row:not(.row--scoped) > div:nth-child(10) {
+    display: none;
+  }
+
+  /* Scoped (10 col): hide Description (4), Currency (7), Category (8), Cleared (9) */
+  .transactions .row.row--scoped > div:nth-child(4),
+  .transactions .row.row--scoped > div:nth-child(7),
+  .transactions .row.row--scoped > div:nth-child(8),
+  .transactions .row.row--scoped > div:nth-child(9) {
     display: none;
   }
 }
@@ -91,13 +129,23 @@
   border-right: 0;
 }
 
-/* Cells that must not wrap */
-.transactions .row > div:nth-child(1),  /* Select */
-.transactions .row > div:nth-child(2),  /* Date */
-.transactions .row > div:nth-child(7),  /* Amount */
-.transactions .row > div:nth-child(8),  /* Currency */
-.transactions .row > div:nth-child(10), /* Cleared */
-.transactions .row > div:nth-child(11)  /* Actions */ {
+/* Cells that must not wrap (unfiltered: 11 cols) */
+.transactions .row:not(.row--scoped) > div:nth-child(1),  /* Select */
+.transactions .row:not(.row--scoped) > div:nth-child(2),  /* Date */
+.transactions .row:not(.row--scoped) > div:nth-child(7),  /* Amount */
+.transactions .row:not(.row--scoped) > div:nth-child(8),  /* Currency */
+.transactions .row:not(.row--scoped) > div:nth-child(10), /* Cleared */
+.transactions .row:not(.row--scoped) > div:nth-child(11)  /* Actions */ {
+  white-space: nowrap;
+}
+
+/* Cells that must not wrap (scoped: 10 cols, no Account column) */
+.transactions .row.row--scoped > div:nth-child(1),  /* Select */
+.transactions .row.row--scoped > div:nth-child(2),  /* Date */
+.transactions .row.row--scoped > div:nth-child(6),  /* Amount */
+.transactions .row.row--scoped > div:nth-child(7),  /* Currency */
+.transactions .row.row--scoped > div:nth-child(9),  /* Cleared */
+.transactions .row.row--scoped > div:nth-child(10)  /* Actions */ {
   white-space: nowrap;
 }
 
@@ -141,6 +189,10 @@
 .tx-type--withdrawal { color: var(--color-negative); }
 .tx-type--clawback   { color: var(--color-negative); }
 .tx-type--transfer   { color: var(--bark-light); }
+
+/* Signed amount color */
+.tx-amount--inflow  { color: var(--color-positive); }
+.tx-amount--outflow { color: var(--color-negative); }
 
 /* Forms */
 .transactions form {

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,7 @@
 class TransactionsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_transaction, only: %i[ show edit update destroy ]
+  before_action :set_scoped_account, only: %i[ index new create edit update show destroy exclude unexclude merge unmerge ]
   before_action :set_form_collections, only: %i[ index new create edit update show ]
 
   # GET /transactions or /transactions.json
@@ -11,9 +12,7 @@ class TransactionsController < ApplicationController
     scope = current_user.transactions.unmerged
     scope = scope.unexcluded unless @show_excluded
     @transactions = scope.includes(:category, :src_account, :dest_account, :currency, :fx_currency, merged_sources: [ :src_account, :dest_account ]).order(transacted_at: :desc, created_at: :desc)
-    account_id = params.fetch(:account_id, nil)
-    if account_id.present?
-      @account = current_user.accounts.find(account_id)
+    if @account
       @transactions = @transactions.where(src_account_id: @account.id).or(@transactions.where(dest_account_id: @account.id))
     end
   end
@@ -137,7 +136,7 @@ class TransactionsController < ApplicationController
         @transaction.reload
         format.turbo_stream {
           if show_excluded?
-            render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction })
+            render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction, account: @account })
           else
             render turbo_stream: turbo_stream.remove(@transaction)
           end
@@ -159,7 +158,7 @@ class TransactionsController < ApplicationController
     respond_to do |format|
       if unexcluder.call
         @transaction.reload
-        format.turbo_stream { render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction }) }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@transaction, partial: "transactions/transaction", locals: { transaction: @transaction, account: @account }) }
         format.html { redirect_back fallback_location: transactions_url(show_excluded: 1), notice: "Transaction was restored." }
       else
         @exclude_errors = unexcluder.errors
@@ -191,9 +190,14 @@ class TransactionsController < ApplicationController
       current_user.transactions.build(transacted_at: Time.current)
     end
 
+    def set_scoped_account
+      account_id = params[:account_id]
+      @account = current_user.accounts.find(account_id) if account_id.present?
+    end
+
     # Only allow a list of trusted parameters through.
     def transaction_params
-      params.expect(transaction: [
+      raw = params.expect(transaction: [
         :transacted_at,
         :category_id,
         :src_account_id,
@@ -204,8 +208,45 @@ class TransactionsController < ApplicationController
         :fx_amount_minor,
         :fx_currency_id,
         :notes,
-        :cleared
+        :cleared,
+        :anchor_account_id,
+        :counterparty_account_id
       ])
+      translate_form_params(raw)
+    end
+
+    # Translates the form's anchor + counterparty + signed amount into the
+    # model's underlying src/dest pair. Direction is inferred from the amount's
+    # sign: negative → outflow (anchor as src), zero/positive/blank → inflow
+    # (anchor as dest). The sign is stripped before the model sees the amount,
+    # since amount_minor is always stored positive. The JSON API may continue to
+    # post src_account_id/dest_account_id directly and bypass translation.
+    def translate_form_params(raw)
+      counterparty_id = raw[:counterparty_account_id].presence
+      anchor_id = raw[:anchor_account_id].presence
+
+      stripped = raw.except(:anchor_account_id, :counterparty_account_id)
+      return stripped if counterparty_id.nil? || anchor_id.nil?
+
+      amount_str = raw[:amount].to_s.strip
+      decimal = begin
+        BigDecimal(amount_str) if amount_str.present?
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      direction = if decimal.nil? || decimal.negative?
+        "out" # blank, unparseable, or explicit minus → outflow (the common case)
+      else
+        "in"
+      end
+
+      src_id, dest_id = direction == "in" ? [ counterparty_id, anchor_id ] : [ anchor_id, counterparty_id ]
+      # Preserve the user's typed formatting (e.g. "5.00") by stripping just the
+      # leading sign rather than round-tripping through BigDecimal#to_s.
+      abs_amount = amount_str.sub(/\A[+-]/, "")
+
+      stripped.merge(src_account_id: src_id, dest_account_id: dest_id, amount: abs_amount)
     end
 
     def find_preceding_transaction(transaction)

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -25,9 +25,73 @@ module TransactionsHelper
     amount_to_currency(transaction.amount_minor, transaction.currency)
   end
 
+  # Renders the amount with sign from the perspective of `perspective_account`:
+  # negative when the account is the src side, positive when dest. Wraps the value
+  # in a span carrying tx-amount--outflow / tx-amount--inflow for styling.
+  def transaction_signed_amount_with_currency(transaction, perspective:)
+    perspective ||= transaction.anchor_account
+    return transaction_amount_with_currency(transaction) if perspective.nil?
+
+    signed_minor = transaction.signed_amount_minor_for(perspective)
+    css = signed_minor.negative? ? "tx-amount tx-amount--outflow" : "tx-amount tx-amount--inflow"
+    tag.span(amount_to_currency(signed_minor, transaction.currency), class: css)
+  end
+
   def transaction_fx_amount_with_currency(transaction)
     return nil unless transaction.has_fx?
 
     amount_to_currency(transaction.fx_amount_minor, transaction.fx_currency)
+  end
+
+  # ---- Form helpers --------------------------------------------------------
+  # On account-scoped views the anchor is implicit (= scoped_account). On the
+  # unfiltered view the form needs an explicit anchor selector. The amount is
+  # entered as a signed value (negative → outflow, positive → inflow); direction
+  # is inferred server-side and the amount is stripped to its magnitude before
+  # the model sees it.
+
+  def transaction_form_anchor_id(transaction, scoped_account: nil)
+    return scoped_account.id if scoped_account
+    transaction.anchor_account&.id
+  end
+
+  def transaction_form_counterparty_id(transaction, scoped_account: nil)
+    if scoped_account
+      return transaction.dest_account_id if transaction.src_account_id == scoped_account.id
+      return transaction.src_account_id if transaction.dest_account_id == scoped_account.id
+      nil
+    else
+      transaction.counterparty_account&.id
+    end
+  end
+
+  # Returns the amount as a signed string for display in the form input. Sign
+  # is derived from whether the (in-memory) anchor is the src side. For
+  # persisted transactions the magnitude is formatted to the currency's decimal
+  # places via amount_minor_to_decimal.
+  def transaction_form_amount(transaction, scoped_account: nil)
+    raw_amount = transaction.amount
+    return nil if raw_amount.nil? || raw_amount.to_s.empty?
+
+    # Preserve the user's sign if they typed one (the controller may have
+    # stripped it before the model saw it, but the literal string survives in
+    # the @amount instance variable).
+    if transaction.amount_written?
+      raw = raw_amount.to_s
+      return raw if raw.start_with?("-") || raw.start_with?("+")
+    end
+
+    anchor_id = transaction_form_anchor_id(transaction, scoped_account: scoped_account)
+    is_outflow = anchor_id.present? && transaction.src_account_id == anchor_id
+
+    magnitude = if transaction.amount_written?
+      raw_amount.to_s
+    elsif transaction.currency
+      amount_minor_to_decimal(transaction.amount_minor, transaction.currency)
+    else
+      raw_amount.to_s
+    end
+
+    is_outflow ? "-#{magnitude}" : magnitude
   end
 end

--- a/app/javascript/controllers/transactions/form_controller.js
+++ b/app/javascript/controllers/transactions/form_controller.js
@@ -1,8 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "srcAccount", "destAccount", "type", "amount", "currency", "error" ]
-  static values = { accountName: String }
+  static targets = [ "anchorAccount", "counterpartyAccount", "type", "amount", "currency", "error" ]
   static TYPE_CONFIG = {
     withdrawal: { label: "↓ Withdrawal", class: "tx-type tx-type--withdrawal" },
     refund:     { label: "↑ Refund",     class: "tx-type tx-type--refund" },
@@ -23,54 +22,53 @@ export default class extends Controller {
     }
   }
 
+  // Filter the counterparty options based on the anchor's kind. The model
+  // requires that any income/expense side pair with a balance-sheet account, so
+  // when the anchor is itself income/expense the counterparty must be balance-sheet.
   updateEnabledAccounts(resetInvalidFields = true) {
-    if (!this.hasSrcAccountTarget || !this.hasDestAccountTarget) return
+    if (!this.hasCounterpartyAccountTarget) return
 
-    const { id: srcId, kind: srcKind } = this.selectedAccount(this.srcAccountTarget)
-    const { id: destId, kind: destKind } = this.selectedAccount(this.destAccountTarget)
-    const srcOptions = this.srcAccountTarget.options
-    const destOptions = this.destAccountTarget.options
+    const anchor = this.anchor()
+    const counterpartyOptions = this.counterpartyAccountTarget.options
 
-    /*
-      Disable options that would create invalid transactions:
-      - Source and destination accounts cannot be the same
-      - Cannot transact from a revenue account to an expense account
-      - Cannot transact from an expense account to a revenue account
-    */
     const isIncomeExpense = (kind) => kind === "expense" || kind === "revenue"
 
-    for (const option of srcOptions) {
-      const sameId = option.value !== "" && option.value === destId
-      const incompatibleKind = isIncomeExpense(destKind) && isIncomeExpense(option.dataset.kind)
+    for (const option of counterpartyOptions) {
+      if (option.value === "") continue
+      const sameId = option.value === anchor.id
+      const incompatibleKind = isIncomeExpense(anchor.kind) && isIncomeExpense(option.dataset.kind)
       option.disabled = sameId || incompatibleKind
       if (resetInvalidFields && option.disabled && option.selected) {
-        this.srcAccountTarget.selectedIndex = 0
-      }
-    }
-    for (const option of destOptions) {
-      const sameId = option.value !== "" && option.value === srcId
-      const incompatibleKind = isIncomeExpense(srcKind) && isIncomeExpense(option.dataset.kind)
-      option.disabled = sameId || incompatibleKind
-      if (resetInvalidFields && option.disabled && option.selected) {
-        this.destAccountTarget.selectedIndex = 0
+        this.counterpartyAccountTarget.selectedIndex = 0
       }
     }
   }
 
+  // Currency follows the anchor (the balance-sheet side that owns the balance).
   updateCurrency() {
-    if (!this.hasDestAccountTarget || !this.hasCurrencyTarget) return
+    if (!this.hasCurrencyTarget) return
 
-    const select = this.destAccountTarget
-    const option = select.options[select.selectedIndex]
-    const currency = option ? option.dataset.currency || "" : ""
-    this.currencyTarget.textContent = currency || "—"
+    const anchor = this.anchor()
+    this.currencyTarget.textContent = anchor.currency || "—"
   }
 
   updateTypeFromSelectedAccounts() {
-    if (!this.hasSrcAccountTarget || !this.hasDestAccountTarget) return
+    if (!this.hasCounterpartyAccountTarget) return
 
-    const { kind: srcKind } = this.selectedAccount(this.srcAccountTarget)
-    const { kind: destKind } = this.selectedAccount(this.destAccountTarget)
+    const anchor = this.anchor()
+    const counterparty = this.selectedAccount(this.counterpartyAccountTarget)
+    const direction = this.directionValue()
+
+    // Resolve src/dest from anchor + direction, then run the same kind-pair
+    // mapping the server-side helper uses.
+    let srcKind, destKind
+    if (direction === "in") {
+      srcKind = counterparty.kind
+      destKind = anchor.kind
+    } else {
+      srcKind = anchor.kind
+      destKind = counterparty.kind
+    }
 
     const isBalanceSheet = (kind) => !!kind && kind !== "expense" && kind !== "revenue"
 
@@ -88,6 +86,34 @@ export default class extends Controller {
     }
 
     this.updateTypeTarget(type)
+  }
+
+  // Anchor target is either a select (unfiltered view) or a hidden input
+  // (account-scoped view). For the hidden case we read kind/currency from
+  // data attributes on the input so the controller has the same metadata.
+  anchor() {
+    if (!this.hasAnchorAccountTarget) return { id: undefined, kind: undefined, currency: undefined }
+
+    const target = this.anchorAccountTarget
+    if (target.tagName === "SELECT") {
+      return this.selectedAccount(target)
+    }
+    return {
+      id: target.value,
+      kind: target.dataset.kind || undefined,
+      currency: target.dataset.currency || undefined
+    }
+  }
+
+  // Direction is inferred from the amount field's sign: a leading "-" means
+  // outflow; positive (with or without "+") means inflow; blank defaults to
+  // outflow to match the controller's fallback.
+  directionValue() {
+    if (!this.hasAmountTarget) return "out"
+    const value = this.amountTarget.value.trim()
+    if (value === "") return "out"
+    if (value.startsWith("-")) return "out"
+    return "in"
   }
 
   selectedAccount(select) {

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -20,6 +20,10 @@ class Transaction < ApplicationRecord
   belongs_to :merged_into, class_name: "Transaction", optional: true
   has_many :merged_sources, class_name: "Transaction", foreign_key: "merged_into_id", dependent: :destroy
 
+  # Virtual form attributes — see TransactionsController#translate_form_params,
+  # which converts them into src/dest before save.
+  attr_accessor :anchor_account_id, :counterparty_account_id
+
   before_validation :assign_currency_from_dest_account, unless: :opening_balance?
   before_validation :assign_cleared_at_from_cleared, unless: :opening_balance?
 
@@ -80,6 +84,28 @@ class Transaction < ApplicationRecord
   def opening_balance_target_account
     return nil unless opening_balance?
     [ src_account, dest_account ].find { |a| a&.real? }
+  end
+
+  # The "anchor" is the side a human reads from: the balance-sheet account
+  # (asset / liability / equity). Validation guarantees at least one side is
+  # balance-sheet. For asset↔asset transfers, src wins.
+  def anchor_account
+    return nil if src_account.nil? && dest_account.nil?
+    return src_account if src_account&.balance_sheet?
+    dest_account
+  end
+
+  def counterparty_account
+    anchor = anchor_account
+    return nil if anchor.nil?
+    anchor == src_account ? dest_account : src_account
+  end
+
+  # Signed amount from `account`'s perspective: negative when account is the
+  # source (money leaving), positive when account is the destination.
+  def signed_amount_minor_for(account)
+    return nil if account.nil?
+    account.id == src_account_id ? -amount_minor.to_i : amount_minor.to_i
   end
 
   private

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,9 +1,23 @@
+<%
+  scoped_account = local_assigns[:account]
+  initial_anchor_id = transaction_form_anchor_id(transaction, scoped_account: scoped_account)
+  initial_counterparty_id = transaction_form_counterparty_id(transaction, scoped_account: scoped_account)
+  initial_amount = transaction_form_amount(transaction, scoped_account: scoped_account)
+%>
 <%= form_with(model: transaction, data: {
   controller: "transactions--form",
   action: "transactions--form#clearError",
   transactions__row_target: "form"
 }, html: { autocomplete: "off" }) do |form| %>
-  <div class="row" data-action="keydown.esc->transactions--row#cancelEdit">
+  <% if scoped_account %>
+    <%= hidden_field_tag :account_id, scoped_account.id %>
+    <%= form.hidden_field :anchor_account_id, value: scoped_account.id, data: {
+      transactions__form_target: "anchorAccount",
+      kind: scoped_account.kind,
+      currency: scoped_account.currency&.code
+    } %>
+  <% end %>
+  <div class="row<%= " row--scoped" if scoped_account %>" data-action="keydown.esc->transactions--row#cancelEdit">
     <div class="select"></div>
     <div>
       <%= form.label :transacted_at, "Date" %>
@@ -19,31 +33,36 @@
       <%= form.text_field :description %>
     </div>
 
+    <% unless scoped_account %>
+      <div>
+        <%= form.label :anchor_account_id, "Account" %>
+        <%= form.select :anchor_account_id,
+          grouped_account_options_for_select(accounts, Account.kinds.keys, selected_key: initial_anchor_id),
+          { include_blank: "Account…" },
+          data: {
+            action: "transactions--form#updateEnabledAccounts transactions--form#updateCurrency transactions--form#updateTypeFromSelectedAccounts",
+            transactions__form_target: "anchorAccount"
+          } %>
+      </div>
+    <% end %>
+
     <div>
-      <%= form.label :src_account_id, "From" %>
-      <%= form.select :src_account_id,
-        grouped_account_options_for_select(accounts, Account.kinds.keys, selected_key: transaction.src_account_id),
-        { include_blank: "From…" },
+      <%= form.label :counterparty_account_id, "Counterparty" %>
+      <%= form.select :counterparty_account_id,
+        grouped_account_options_for_select(accounts, Account.kinds.keys, selected_key: initial_counterparty_id),
+        { include_blank: "Counterparty…" },
         data: {
           action: "transactions--form#updateEnabledAccounts transactions--form#updateTypeFromSelectedAccounts",
-          transactions__form_target: "srcAccount"
+          transactions__form_target: "counterpartyAccount"
         } %>
     </div>
 
-    <div>
-      <%= form.label :dest_account_id, "To" %>
-      <%= form.select :dest_account_id,
-        grouped_account_options_for_select(accounts, Account.kinds.keys, selected_key: transaction.dest_account_id),
-        { include_blank: "To…" },
-        data: {
-          action: "transactions--form#updateEnabledAccounts transactions--form#updateCurrency transactions--form#updateTypeFromSelectedAccounts",
-          transactions__form_target: "destAccount"
-        } %>
-    </div>
-
-    <div class="numeric">
+    <div class="numeric field-amount">
       <%= form.label :amount %>
-      <%= form.text_field :amount, data: { transactions__form_target: "amount" } %>
+      <%= form.text_field :amount, value: initial_amount, data: {
+        action: "input->transactions--form#updateTypeFromSelectedAccounts",
+        transactions__form_target: "amount"
+      } %>
     </div>
 
     <div class="field-currency">

--- a/app/views/transactions/_merge_bar.html.erb
+++ b/app/views/transactions/_merge_bar.html.erb
@@ -20,6 +20,9 @@
     <p class="merge-confirmation__preview"></p>
 
     <%= form_with url: merge_transactions_path, method: :post, data: { action: "turbo:submit-end->transactions--merge#cancel" } do |f| %>
+      <% if local_assigns[:account] %>
+        <input type="hidden" name="account_id" value="<%= account.id %>">
+      <% end %>
       <input type="hidden" name="transaction_ids[]" value="" data-slot="a">
       <input type="hidden" name="transaction_ids[]" value="" data-slot="b">
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -1,3 +1,16 @@
+<%
+  scoped_account = local_assigns[:account]
+  perspective = scoped_account || transaction.anchor_account
+  counterparty = if scoped_account
+    if transaction.src_account_id == scoped_account.id
+      transaction.dest_account
+    elsif transaction.dest_account_id == scoped_account.id
+      transaction.src_account
+    end
+  else
+    transaction.counterparty_account
+  end
+%>
 <!-- Show -->
 <%= turbo_frame_tag transaction do %>
   <div class="transaction" data-controller="transactions--row" data-transactions--row-id-value="<%= transaction.id %>"
@@ -13,7 +26,7 @@
        data-merge-currency-code="<%= transaction.currency.code %>"
        data-merge-currency-decimal-places="<%= transaction.currency.decimal_places %>">
 
-    <div class="row show">
+    <div class="row show<%= " row--scoped" if scoped_account %>">
       <div class="select">
         <% unless transaction.opening_balance? || transaction.excluded? %>
           <input type="checkbox"
@@ -33,9 +46,11 @@
         <% end %>
       </div>
       <div data-label="Description"><%= transaction.description %></div>
-      <div data-label="From"><%= transaction.src_account&.name %></div>
-      <div data-label="To"><%= transaction.dest_account&.name %></div>
-      <div data-label="Amount" class="numeric"><%= transaction_amount_with_currency(transaction) %></div>
+      <% unless scoped_account %>
+        <div data-label="Account"><%= transaction.anchor_account&.name %></div>
+      <% end %>
+      <div data-label="Counterparty"><%= counterparty&.name %></div>
+      <div data-label="Amount" class="numeric"><%= transaction_signed_amount_with_currency(transaction, perspective: perspective) %></div>
       <div data-label="Currency"><%= transaction.currency.code %></div>
       <div data-label="Category"><%= transaction.category&.name %></div>
       <div data-label="Cleared" class="boolean"><%= transaction.cleared_at ? "✓" : "" %></div>
@@ -45,14 +60,14 @@
         <% else %>
           <a href="#" data-action="transactions--row#edit">Edit</a>
         <% end %>
-        <%= link_to "Delete", transaction, data: { turbo_method: :delete, turbo_confirm: "Delete this transaction?", turbo_frame: dom_id(transaction) } %>
+        <%= link_to "Delete", transaction_path(transaction, account_id: scoped_account&.id), data: { turbo_method: :delete, turbo_confirm: "Delete this transaction?", turbo_frame: dom_id(transaction) } %>
         <% if transaction.excluded? %>
-          <%= link_to "Restore", unexclude_transaction_path(transaction), data: { turbo_method: :post } %>
+          <%= link_to "Restore", unexclude_transaction_path(transaction, account_id: scoped_account&.id), data: { turbo_method: :post } %>
         <% elsif transaction.sourceable_type.present? && !transaction.opening_balance? && !transaction.merged_sources.any? %>
-          <%= link_to "Exclude", exclude_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
+          <%= link_to "Exclude", exclude_transaction_path(transaction, account_id: scoped_account&.id), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
         <% end %>
         <% if transaction.merged_sources.any? %>
-          <%= link_to "Unmerge", unmerge_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Unmerge this transfer back into the original transactions?" } %>
+          <%= link_to "Unmerge", unmerge_transaction_path(transaction, account_id: scoped_account&.id), data: { turbo_method: :post, turbo_confirm: "Unmerge this transfer back into the original transactions?" } %>
         <% end %>
       </div>
 
@@ -71,8 +86,8 @@
     </div>
 
     <!-- Edit -->
-    <%= turbo_frame_tag dom_id(transaction, :edit), src: edit_transaction_path(transaction), loading: "lazy", class: "edit" do %>
-      <div class="row">
+    <%= turbo_frame_tag dom_id(transaction, :edit), src: edit_transaction_path(transaction, account_id: scoped_account&.id), loading: "lazy", class: "edit" do %>
+      <div class="row<%= " row--scoped" if scoped_account %>">
         <div class="loading">Loading...</div>
       </div>
     <% end %>

--- a/app/views/transactions/create.turbo_stream.erb
+++ b/app/views/transactions/create.turbo_stream.erb
@@ -3,15 +3,18 @@
     <%= render partial: 'form', locals: {
       transaction: @new_transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      account: @account
     } %>
   <% end %>
 <% end %>
 
 <% if @last_transaction %>
-  <%= turbo_stream.before dom_id(@last_transaction), @transaction %>
+  <%= turbo_stream.before dom_id(@last_transaction) do %>
+    <%= render partial: 'transaction', locals: { transaction: @transaction, account: @account } %>
+  <% end %>
 <% else %>
   <%= turbo_stream.prepend :transactions do %>
-    <%= render @transaction %>
+    <%= render partial: 'transaction', locals: { transaction: @transaction, account: @account } %>
   <% end %>
 <% end %>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -2,6 +2,7 @@
   <%= render partial: 'form', locals: {
     transaction: @transaction,
     accounts: @accounts,
-    categories: @categories
+    categories: @categories,
+    account: @account
   } %>
 <% end %>

--- a/app/views/transactions/edit.turbo_stream.erb
+++ b/app/views/transactions/edit.turbo_stream.erb
@@ -3,7 +3,8 @@
     <%= render partial: 'form', locals: {
       transaction: @transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      account: @account
     } %>
   <% end %>
 <% end %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -12,14 +12,16 @@
 </div>
 
 <div data-controller="transactions--merge" data-transactions--merge-merge-url-value="<%= merge_transactions_path %>">
-  <div class="transactions">
-    <div class="row header">
+  <div class="transactions<%= " transactions--scoped" if @account %>">
+    <div class="row header<%= " row--scoped" if @account %>">
       <div></div>
       <div>Date</div>
       <div>Type</div>
       <div>Description</div>
-      <div>From</div>
-      <div>To</div>
+      <% unless @account %>
+        <div>Account</div>
+      <% end %>
+      <div>Counterparty</div>
       <div>Amount</div>
       <div>Currency</div>
       <div>Category</div>
@@ -31,14 +33,15 @@
       <%= render partial: 'form', locals: {
         transaction: @new_transaction,
         accounts: @accounts,
-        categories: @categories
+        categories: @categories,
+        account: @account
       } %>
     <% end %>
 
     <%= turbo_frame_tag :transactions do %>
-      <%= render @transactions %>
+      <%= render partial: 'transaction', collection: @transactions, as: :transaction, locals: { account: @account } %>
     <% end %>
   </div>
 
-  <%= render "merge_bar", categories: @categories %>
+  <%= render "merge_bar", categories: @categories, account: @account %>
 </div>

--- a/app/views/transactions/merge.turbo_stream.erb
+++ b/app/views/transactions/merge.turbo_stream.erb
@@ -3,9 +3,11 @@
 <% end %>
 
 <% if @last_transaction %>
-  <%= turbo_stream.before dom_id(@last_transaction), @merged_transaction %>
+  <%= turbo_stream.before dom_id(@last_transaction) do %>
+    <%= render partial: 'transaction', locals: { transaction: @merged_transaction, account: @account } %>
+  <% end %>
 <% else %>
   <%= turbo_stream.prepend :transactions do %>
-    <%= render @merged_transaction %>
+    <%= render partial: 'transaction', locals: { transaction: @merged_transaction, account: @account } %>
   <% end %>
 <% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -2,6 +2,7 @@
   <%= render partial: 'form', locals: {
     transaction: @transaction,
     accounts: @accounts,
-    categories: @categories
+    categories: @categories,
+    account: @account
   } %>
 <% end %>

--- a/app/views/transactions/new.turbo_stream.erb
+++ b/app/views/transactions/new.turbo_stream.erb
@@ -3,7 +3,8 @@
     <%= render partial: 'form', locals: {
       transaction: @transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      account: @account
     } %>
   <% end %>
 <% end %>

--- a/app/views/transactions/show.turbo_stream.erb
+++ b/app/views/transactions/show.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace @transaction do %>
-  <%= render @transaction %>
+  <%= render partial: 'transaction', locals: { transaction: @transaction, account: @account } %>
 <% end %>

--- a/app/views/transactions/unmerge.turbo_stream.erb
+++ b/app/views/transactions/unmerge.turbo_stream.erb
@@ -2,12 +2,14 @@
 
 <% if @after_transaction %>
   <% @restored_transactions.reverse_each do |transaction| %>
-    <%= turbo_stream.after dom_id(@after_transaction), transaction %>
+    <%= turbo_stream.after dom_id(@after_transaction) do %>
+      <%= render partial: 'transaction', locals: { transaction: transaction, account: @account } %>
+    <% end %>
   <% end %>
 <% else %>
   <% @restored_transactions.reverse_each do |transaction| %>
     <%= turbo_stream.prepend :transactions do %>
-      <%= render transaction %>
+      <%= render partial: 'transaction', locals: { transaction: transaction, account: @account } %>
     <% end %>
   <% end %>
 <% end %>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -106,6 +106,78 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content
   end
 
+  test "create with negative amount translates to src=anchor, dest=counterparty (outflow)" do
+    asset = accounts(:asset_account)
+    expense = accounts(:expense_account)
+
+    post transactions_url, params: { transaction: {
+      transacted_at: Time.current,
+      anchor_account_id: asset.id,
+      counterparty_account_id: expense.id,
+      description: "Outflow translation",
+      amount: "-9.99"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    created = Transaction.find_by(description: "Outflow translation")
+    assert_equal asset.id, created.src_account_id
+    assert_equal expense.id, created.dest_account_id
+    # Sign is stripped before reaching the model; amount_minor is positive.
+    assert_equal 999, created.amount_minor
+  end
+
+  test "create with positive amount translates to src=counterparty, dest=anchor (inflow)" do
+    asset = accounts(:asset_account)
+    revenue = accounts(:revenue_account)
+
+    post transactions_url, params: { transaction: {
+      transacted_at: Time.current,
+      anchor_account_id: asset.id,
+      counterparty_account_id: revenue.id,
+      description: "Inflow translation",
+      amount: "42.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    created = Transaction.find_by(description: "Inflow translation")
+    assert_equal revenue.id, created.src_account_id
+    assert_equal asset.id, created.dest_account_id
+    assert_equal 4200, created.amount_minor
+  end
+
+  test "update translates anchor/counterparty params with signed amount" do
+    new_dest = accounts(:liability_account)
+    asset = accounts(:asset_account)
+
+    patch transaction_url(@transaction), params: { transaction: {
+      anchor_account_id: asset.id,
+      counterparty_account_id: new_dest.id,
+      amount: "-7.50"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    @transaction.reload
+    assert_equal asset.id, @transaction.src_account_id
+    assert_equal new_dest.id, @transaction.dest_account_id
+    assert_equal 750, @transaction.amount_minor
+  end
+
+  test "JSON API still accepts src_account_id/dest_account_id directly" do
+    assert_difference("Transaction.count") do
+      post transactions_url, params: { transaction: {
+        transacted_at: Time.current,
+        src_account_id: accounts(:asset_account).id,
+        dest_account_id: accounts(:expense_account).id,
+        description: "Direct API",
+        amount: "1.00"
+      } }, as: :json
+    end
+
+    assert_response :created
+    assert_equal accounts(:asset_account).id, Transaction.last.src_account_id
+    assert_equal accounts(:expense_account).id, Transaction.last.dest_account_id
+  end
+
   test "should create transaction with turbo_stream" do
     assert_difference("Transaction.count") do
       post transactions_url, params: { transaction: {

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -716,6 +716,68 @@ class TransactionTest < ActiveSupport::TestCase
     assert_equal expected, targets
   end
 
+  test "anchor_account is the balance-sheet src for a withdrawal" do
+    transaction = transactions(:one) # asset → expense
+    assert_equal accounts(:asset_account), transaction.anchor_account
+  end
+
+  test "anchor_account is the balance-sheet dest for a deposit" do
+    transaction = transactions(:two) # revenue → asset
+    assert_equal accounts(:asset_account), transaction.anchor_account
+  end
+
+  test "anchor_account is the balance-sheet dest for a refund" do
+    refund = Transaction.create!(
+      user: users(:one),
+      src_account: accounts(:expense_account),
+      dest_account: accounts(:asset_account),
+      amount_minor: 1000, currency: currencies(:usd), transacted_at: Time.current
+    )
+    assert_equal accounts(:asset_account), refund.anchor_account
+  end
+
+  test "anchor_account is the balance-sheet src for a clawback" do
+    clawback = Transaction.create!(
+      user: users(:one),
+      src_account: accounts(:asset_account),
+      dest_account: accounts(:revenue_account),
+      amount_minor: 1000, currency: currencies(:usd), transacted_at: Time.current
+    )
+    assert_equal accounts(:asset_account), clawback.anchor_account
+  end
+
+  test "anchor_account is the src for an asset-to-asset transfer" do
+    transfer = Transaction.create!(
+      user: users(:one),
+      src_account: accounts(:asset_account),
+      dest_account: accounts(:linked_asset),
+      amount_minor: 1000, currency: currencies(:usd), transacted_at: Time.current
+    )
+    assert_equal accounts(:asset_account), transfer.anchor_account
+  end
+
+  test "counterparty_account returns the side opposite to anchor" do
+    transaction = transactions(:one) # anchor = asset (src), counterparty = expense (dest)
+    assert_equal accounts(:expense_account), transaction.counterparty_account
+
+    deposit = transactions(:two) # anchor = asset (dest), counterparty = revenue (src)
+    assert_equal accounts(:revenue_account), deposit.counterparty_account
+  end
+
+  test "signed_amount_minor_for is negative when account is the src side" do
+    transaction = transactions(:one)
+    assert_equal(-transaction.amount_minor, transaction.signed_amount_minor_for(transaction.src_account))
+  end
+
+  test "signed_amount_minor_for is positive when account is the dest side" do
+    transaction = transactions(:one)
+    assert_equal transaction.amount_minor, transaction.signed_amount_minor_for(transaction.dest_account)
+  end
+
+  test "signed_amount_minor_for returns nil when account is nil" do
+    assert_nil transactions(:one).signed_amount_minor_for(nil)
+  end
+
   test "destroying with in-memory account reassignment still broadcasts persisted accounts" do
     transaction = transactions(:one)
     persisted_src = transaction.src_account

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -16,9 +16,9 @@ class TransactionsTest < ApplicationSystemTestCase
     visit transactions_path
 
     fill_in "transaction[description]", with: "Live update probe"
-    select src.name, from: "transaction[src_account_id]"
-    select dest.name, from: "transaction[dest_account_id]"
-    fill_in "transaction[amount]", with: "12.34"
+    select src.name, from: "transaction[anchor_account_id]"
+    select dest.name, from: "transaction[counterparty_account_id]"
+    fill_in "transaction[amount]", with: "-12.34"
     click_button "Create"
 
     within("##{ActionView::RecordIdentifier.dom_id(src, :sidebar_link)}") do
@@ -55,6 +55,124 @@ class TransactionsTest < ApplicationSystemTestCase
       assert_text "-$5.00"
     end
     assert_selector active_link_selector
+  end
+
+  test "unfiltered transactions index renders Account + Counterparty headers" do
+    visit transactions_path
+
+    within(".transactions .row.header") do
+      assert_text "Account"
+      assert_text "Counterparty"
+      assert_no_text "From"
+      assert_no_text "To"
+    end
+  end
+
+  test "account-scoped transactions index hides the Account header" do
+    visit account_transactions_path(accounts(:asset_account))
+
+    within(".transactions .row.header") do
+      assert_text "Counterparty"
+      assert_no_text "From"
+      assert_no_text "To"
+      assert_no_selector "div", exact_text: "Account"
+    end
+  end
+
+  test "row shows signed amount with outflow class when scoped to src account" do
+    asset = accounts(:asset_account)
+    Transaction.create!(
+      user: @user,
+      src_account: asset,
+      dest_account: accounts(:expense_account),
+      amount_minor: 4250,
+      currency: currencies(:usd),
+      description: "Coffee shop",
+      transacted_at: Time.current
+    )
+
+    visit account_transactions_path(asset)
+
+    assert_selector ".tx-amount--outflow", text: "-$42.50"
+  end
+
+  test "row shows signed amount with inflow class when scoped to dest account" do
+    asset = accounts(:asset_account)
+    Transaction.create!(
+      user: @user,
+      src_account: accounts(:revenue_account),
+      dest_account: asset,
+      amount_minor: 100000,
+      currency: currencies(:usd),
+      description: "Paycheck inflow probe",
+      transacted_at: Time.current
+    )
+
+    visit account_transactions_path(asset)
+
+    assert_selector ".tx-amount--inflow", text: "$1,000.00"
+  end
+
+  test "creating a transaction with a negative amount infers outflow" do
+    asset = accounts(:asset_account)
+    expense = accounts(:expense_account)
+    asset.update!(balance_minor: 0)
+
+    visit account_transactions_path(asset)
+
+    fill_in "transaction[description]", with: "Scoped outflow"
+    select expense.name, from: "transaction[counterparty_account_id]"
+    fill_in "transaction[amount]", with: "-5.00"
+    click_button "Create"
+
+    assert_text "Scoped outflow"
+
+    created = Transaction.find_by(description: "Scoped outflow")
+    assert_not_nil created
+    assert_equal asset.id, created.src_account_id
+    assert_equal expense.id, created.dest_account_id
+    assert_equal 500, created.amount_minor
+  end
+
+  test "creating a transaction with a positive amount infers inflow" do
+    asset = accounts(:asset_account)
+    revenue = accounts(:revenue_account)
+    asset.update!(balance_minor: 0)
+
+    visit account_transactions_path(asset)
+
+    fill_in "transaction[description]", with: "Scoped inflow"
+    select revenue.name, from: "transaction[counterparty_account_id]"
+    fill_in "transaction[amount]", with: "200.00"
+    click_button "Create"
+
+    assert_text "Scoped inflow"
+
+    created = Transaction.find_by(description: "Scoped inflow")
+    assert_not_nil created
+    assert_equal revenue.id, created.src_account_id
+    assert_equal asset.id, created.dest_account_id
+    assert_equal 20000, created.amount_minor
+  end
+
+  test "creating a transaction on the unfiltered view requires picking an anchor" do
+    asset = accounts(:asset_account)
+    expense = accounts(:expense_account)
+
+    visit transactions_path
+
+    fill_in "transaction[description]", with: "Unfiltered create"
+    select asset.name, from: "transaction[anchor_account_id]"
+    select expense.name, from: "transaction[counterparty_account_id]"
+    fill_in "transaction[amount]", with: "-7.50"
+    click_button "Create"
+
+    assert_text "Unfiltered create"
+
+    created = Transaction.find_by(description: "Unfiltered create")
+    assert_not_nil created
+    assert_equal asset.id, created.src_account_id
+    assert_equal expense.id, created.dest_account_id
   end
 
   private


### PR DESCRIPTION
## Summary

- Replaces the From/To selects on the transactions table and inline form with **Account** (anchor), **Counterparty**, and a single **signed Amount** field.
- On account-scoped views (`/accounts/:id/transactions`) the anchor is implicit; the form drops a field. On the unfiltered view, an explicit Account column appears alongside Counterparty.
- Direction is inferred from the amount's sign: `-5.00` = outflow (anchor as src), `5.00` = inflow (anchor as dest). The sign is stripped before reaching the model — `amount_minor` stays positive.

## Status

**Draft / shelved.** Open question: "Counterparty" is finance jargon and feels off for category-like accounts (Groceries, Salary). No replacement landed on yet — leaving as-is for now.

## Test plan

- [x] `bin/rails test` — model tests for `anchor_account` / `counterparty_account` / `signed_amount_minor_for` across all five transaction kinds plus an asset↔asset transfer; controller tests for negative/positive amount translation on POST and PATCH; JSON API still works with `src/dest` directly.
- [x] `bin/rails test:system` — header layout (scoped vs unfiltered), signed-amount class on both perspectives, inline create on both views with negative + positive amounts.
- [x] `bin/rubocop` clean.
- [x] `bin/brakeman` clean.
- [ ] Manual UI dogfooding (deferred — system tests cover the JS + CSS path via Capybara/Selenium; visual pass still worth doing before unshelving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)