### PR TITLE
Surface multiple aggregator sources in the UI (#130, PR 3/3)

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -106,6 +106,13 @@
   flex-wrap: wrap;
 }
 
+/* Date column: stack source badges below the date */
+.transactions .row > div:nth-child(2) {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
 .transactions .numeric {
   justify-content: flex-end;
   text-align: right;
@@ -483,6 +490,33 @@
 .merged-badge:hover {
   background-color: var(--honey-light);
   color: var(--honey-deeper);
+}
+
+/* Source badges */
+.source-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.source-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
+
+.source-badge--simplefin {
+  color: var(--honey-deeper);
+  background-color: var(--honey-pale);
+}
+
+.source-badge--lunchflow {
+  color: var(--bark-medium);
+  background-color: var(--cream);
 }
 
 /* Merged details */

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -6,7 +6,7 @@ class IntegrationsController < ApplicationController
     @lunchflow_connection = current_user.lunchflow_connection
     @simplefin_accounts = visible_aggregator_accounts(@simplefin_connection)
     @lunchflow_accounts = visible_aggregator_accounts(@lunchflow_connection)
-    @linkable_accounts = current_user.accounts.linkable.unlinked.order(:name)
+    @linkable_accounts = current_user.accounts.linkable.order(:name)
   end
 
   private

--- a/app/controllers/lunchflow/accounts_controller.rb
+++ b/app/controllers/lunchflow/accounts_controller.rb
@@ -16,11 +16,6 @@ class Lunchflow::AccountsController < ApplicationController
       return
     end
 
-    if ledger_account.account_sources.where.not(sourceable: @lunchflow_account).exists?
-      redirect_to integrations_path, alert: "Account is already linked to another integration."
-      return
-    end
-
     if @lunchflow_account.linked? && @lunchflow_account.ledger_account != ledger_account
       redirect_to integrations_path, alert: "Lunch Flow account is already linked to another account."
       return
@@ -34,7 +29,7 @@ class Lunchflow::AccountsController < ApplicationController
 
   def unlink
     @lunchflow_account.account_sources.destroy_all
-    redirect_to integrations_path, notice: "Lunch Flow account unlinked successfully."
+    redirect_back_or_to integrations_path, notice: "Lunch Flow account unlinked successfully."
   end
 
   private

--- a/app/controllers/simplefin/accounts_controller.rb
+++ b/app/controllers/simplefin/accounts_controller.rb
@@ -16,11 +16,6 @@ class Simplefin::AccountsController < ApplicationController
       return
     end
 
-    if ledger_account.account_sources.where.not(sourceable: @simplefin_account).exists?
-      redirect_to integrations_path, alert: "Account is already linked to another integration."
-      return
-    end
-
     if @simplefin_account.linked? && @simplefin_account.ledger_account != ledger_account
       redirect_to integrations_path, alert: "SimpleFIN account is already linked to another account."
       return
@@ -34,7 +29,7 @@ class Simplefin::AccountsController < ApplicationController
 
   def unlink
     @simplefin_account.account_sources.destroy_all
-    redirect_to integrations_path, notice: "SimpleFIN account unlinked successfully."
+    redirect_back_or_to integrations_path, notice: "SimpleFIN account unlinked successfully."
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,12 +12,20 @@ module ApplicationHelper
     end
   end
 
+  def source_badge_modifier(sourceable)
+    case sourceable
+    when Simplefin::Account, Simplefin::Transaction then "source-badge--simplefin"
+    when Lunchflow::Account, Lunchflow::Transaction then "source-badge--lunchflow"
+    end
+  end
+
   # Caller is responsible for passing a collection where each TransactionSource's
   # sourceable is already loaded (e.g., array from `includes(:sourceable)`).
   # An unloaded relation will N+1 on the per-source sourceable access below.
   def transaction_source_badges(sources)
     badges = sources.map do |source|
-      tag.span(source_badge_label(source.sourceable), class: "source-badge")
+      classes = [ "source-badge", source_badge_modifier(source.sourceable) ].compact.join(" ")
+      tag.span(source_badge_label(source.sourceable), class: classes)
     end
     safe_join(badges, " ")
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,24 @@ module ApplicationHelper
       (current_path == target_path || current_path.start_with?("#{target_path}/"))
   end
 
+  def source_badge_label(sourceable)
+    case sourceable
+    when Simplefin::Account, Simplefin::Transaction then "SimpleFIN"
+    when Lunchflow::Account, Lunchflow::Transaction then "Lunch Flow"
+    else sourceable.class.name
+    end
+  end
+
+  # Caller is responsible for passing a collection where each TransactionSource's
+  # sourceable is already loaded (e.g., array from `includes(:sourceable)`).
+  # An unloaded relation will N+1 on the per-source sourceable access below.
+  def transaction_source_badges(sources)
+    badges = sources.map do |source|
+      tag.span(source_badge_label(source.sourceable), class: "source-badge")
+    end
+    safe_join(badges, " ")
+  end
+
   def nav_link_to(name, url, options = {})
     active = options.delete(:active)
 

--- a/app/views/accounts/_sources.html.erb
+++ b/app/views/accounts/_sources.html.erb
@@ -1,0 +1,22 @@
+<% sources = account.account_sources.includes(:sourceable).to_a %>
+<div class="account-sources" data-testid="account-sources">
+  <strong>Sources:</strong>
+  <% if sources.any? %>
+    <ul>
+      <% sources.each do |account_source| %>
+        <% sourceable = account_source.sourceable %>
+        <li>
+          <%= source_badge_label(sourceable) %>: <%= sourceable.name %>
+          <% case sourceable %>
+          <% when Simplefin::Account %>
+            <%= button_to "Unlink", unlink_simplefin_account_path(sourceable), method: :delete, "aria-label": "Unlink SimpleFIN source #{sourceable.name}", data: { turbo_confirm: "Unlink this source?" } %>
+          <% when Lunchflow::Account %>
+            <%= button_to "Unlink", unlink_lunchflow_account_path(sourceable), method: :delete, "aria-label": "Unlink Lunch Flow source #{sourceable.name}", data: { turbo_confirm: "Unlink this source?" } %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <span>No linked integrations</span>
+  <% end %>
+</div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,5 +1,7 @@
 <%= render @account %>
 
+<%= render partial: "accounts/sources", locals: { account: @account } %>
+
 <div>
   <%= link_to "Edit this account", edit_account_path(@account) %> |
   <%= link_to "Back to accounts", accounts_path %>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -35,7 +35,14 @@
                  data-transaction-id="<%= transaction.id %>">
         <% end %>
       </div>
-      <div data-label="Date"><%= transaction.transacted_at&.strftime("%Y-%m-%d %I:%M %p") %></div>
+      <div data-label="Date">
+        <%= transaction.transacted_at&.strftime("%Y-%m-%d %I:%M %p") %>
+        <% if sources.any? %>
+          <div class="source-badges">
+            <%= transaction_source_badges(sources) %>
+          </div>
+        <% end %>
+      </div>
       <div data-label="Type">
         <%= transaction_type_indicator(transaction) %>
         <% if transaction.excluded? %>
@@ -46,9 +53,6 @@
       </div>
       <div data-label="Description">
         <%= transaction.description %>
-        <% if sources.any? %>
-          <%= transaction_source_badges(sources) %>
-        <% end %>
       </div>
       <div data-label="From"><%= transaction.src_account&.name %></div>
       <div data-label="To"><%= transaction.dest_account&.name %></div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -1,4 +1,16 @@
 <!-- Show -->
+<%# Resolve the transaction_sources collection once with sourceable preloaded.
+    Reuse the proxy only if BOTH transaction_sources and each sourceable are
+    already loaded (TransactionsController#index covers this via
+    `includes(transaction_sources: :sourceable)`). Otherwise materialize an
+    array via `.includes(:sourceable)` so neither the .any? check nor the
+    badge helper triggers an N+1 — including the case where a caller
+    preloaded transaction_sources alone without :sourceable. %>
+<% sources = if transaction.transaction_sources.loaded? && transaction.transaction_sources.all? { |s| s.association(:sourceable).loaded? }
+              transaction.transaction_sources
+            else
+              transaction.transaction_sources.includes(:sourceable).to_a
+            end %>
 <%= turbo_frame_tag transaction do %>
   <div class="transaction" data-controller="transactions--row" data-transactions--row-id-value="<%= transaction.id %>"
        data-merge-amount-minor="<%= transaction.amount_minor %>"
@@ -32,7 +44,12 @@
           <a href="#" class="merged-badge" data-action="transactions--row#toggleMergedDetails">Merged</a>
         <% end %>
       </div>
-      <div data-label="Description"><%= transaction.description %></div>
+      <div data-label="Description">
+        <%= transaction.description %>
+        <% if sources.any? %>
+          <%= transaction_source_badges(sources) %>
+        <% end %>
+      </div>
       <div data-label="From"><%= transaction.src_account&.name %></div>
       <div data-label="To"><%= transaction.dest_account&.name %></div>
       <div data-label="Amount" class="numeric"><%= transaction_amount_with_currency(transaction) %></div>
@@ -48,7 +65,7 @@
         <%= link_to "Delete", transaction, data: { turbo_method: :delete, turbo_confirm: "Delete this transaction?", turbo_frame: dom_id(transaction) } %>
         <% if transaction.excluded? %>
           <%= link_to "Restore", unexclude_transaction_path(transaction), data: { turbo_method: :post } %>
-        <% elsif transaction.transaction_sources.any? && !transaction.opening_balance? && !transaction.merged_sources.any? %>
+        <% elsif sources.any? && !transaction.opening_balance? && !transaction.merged_sources.any? %>
           <%= link_to "Exclude", exclude_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
         <% end %>
         <% if transaction.merged_sources.any? %>

--- a/test/controllers/lunchflow/accounts_controller_test.rb
+++ b/test/controllers/lunchflow/accounts_controller_test.rb
@@ -47,13 +47,14 @@ class Lunchflow::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Please select an account to link.", flash[:alert]
   end
 
-  test "should reject link when ledger account is already linked to another integration" do
-    already_linked_account = accounts(:linked_asset)
+  test "allows linking a ledger account that already has a different integration" do
+    multi_sourced = accounts(:linked_asset)
 
-    post link_lunchflow_account_url(@lunchflow_account), params: { lunchflow_account: { ledger_account_id: already_linked_account.id } }
-
+    assert_difference -> { multi_sourced.account_sources.count }, 1 do
+      post link_lunchflow_account_url(@lunchflow_account), params: { lunchflow_account: { ledger_account_id: multi_sourced.id } }
+    end
     assert_redirected_to integrations_url
-    assert_equal "Account is already linked to another integration.", flash[:alert]
+    assert_includes @lunchflow_account.ledger_accounts, multi_sourced
   end
 
   test "should reject link when lunchflow account is already linked to a different ledger account" do

--- a/test/controllers/simplefin/accounts_controller_test.rb
+++ b/test/controllers/simplefin/accounts_controller_test.rb
@@ -56,13 +56,15 @@ class Simplefin::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Account not found.", flash[:alert]
   end
 
-  test "should reject link when ledger account is already linked to another integration" do
-    already_linked_account = accounts(:linked_asset)
+  test "allows linking a ledger account that already has a different integration" do
+    multi_sourced = accounts(:linked_asset)
+    sf_to_add = simplefin_accounts(:unlinked_one)
 
-    post link_simplefin_account_url(simplefin_accounts(:unlinked_one)), params: { simplefin_account: { ledger_account_id: already_linked_account.id } }
-
+    assert_difference -> { multi_sourced.account_sources.count }, 1 do
+      post link_simplefin_account_url(sf_to_add), params: { simplefin_account: { ledger_account_id: multi_sourced.id } }
+    end
     assert_redirected_to integrations_url
-    assert_equal "Account is already linked to another integration.", flash[:alert]
+    assert_includes sf_to_add.ledger_accounts, multi_sourced
   end
 
   test "should reject link when simplefin account is already linked to a different ledger account" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -79,4 +79,20 @@ class ApplicationHelperTest < ActionView::TestCase
     result = nav_link_to("Logout", "/logout", data: { turbo_method: :delete })
     assert_match(/data-turbo-method="delete"/, result)
   end
+
+  # source_badge_label
+
+  test "source_badge_label labels SimpleFIN sources" do
+    assert_equal "SimpleFIN", source_badge_label(simplefin_accounts(:linked_one))
+  end
+
+  test "source_badge_label labels Lunch Flow sources" do
+    assert_equal "Lunch Flow", source_badge_label(lunchflow_accounts(:linked_one))
+  end
+
+  test "source_badge_label falls back to the class name for unknown sourceable types" do
+    # Currency isn't a registered aggregator type but stands in for any future
+    # source class (CSV/OFX, etc.) so the fallback can't silently render empty.
+    assert_equal "Currency", source_badge_label(currencies(:usd))
+  end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -95,4 +95,33 @@ class ApplicationHelperTest < ActionView::TestCase
     # source class (CSV/OFX, etc.) so the fallback can't silently render empty.
     assert_equal "Currency", source_badge_label(currencies(:usd))
   end
+
+  # source_badge_modifier
+
+  test "source_badge_modifier returns the SimpleFIN modifier class" do
+    assert_equal "source-badge--simplefin", source_badge_modifier(simplefin_accounts(:linked_one))
+  end
+
+  test "source_badge_modifier returns the Lunch Flow modifier class" do
+    assert_equal "source-badge--lunchflow", source_badge_modifier(lunchflow_accounts(:linked_one))
+  end
+
+  test "source_badge_modifier returns nil for unknown sourceable types" do
+    assert_nil source_badge_modifier(currencies(:usd))
+  end
+
+  # transaction_source_badges
+
+  test "transaction_source_badges renders one styled span per source with aggregator modifiers" do
+    fake_source = Struct.new(:sourceable)
+    sources = [
+      fake_source.new(simplefin_accounts(:linked_one)),
+      fake_source.new(lunchflow_accounts(:linked_one))
+    ]
+
+    html = transaction_source_badges(sources)
+
+    assert_match(/<span class="source-badge source-badge--simplefin">SimpleFIN<\/span>/, html)
+    assert_match(/<span class="source-badge source-badge--lunchflow">Lunch Flow<\/span>/, html)
+  end
 end

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -53,6 +53,32 @@ class AccountsTest < ApplicationSystemTestCase
     assert_current_path edit_account_path(account)
   end
 
+  test "account detail page lists every linked aggregator source" do
+    account = accounts(:linked_asset)
+    AccountSource.create!(account: account, sourceable: lunchflow_accounts(:unlinked_one))
+
+    visit account_path(account)
+
+    within('[data-testid="account-sources"]') do
+      assert_text "SimpleFIN"
+      assert_text "Lunch Flow"
+    end
+  end
+
+  test "unlinking from the account detail page returns to the account detail page" do
+    account = accounts(:linked_asset)
+    visit account_path(account)
+
+    within('[data-testid="account-sources"]') do
+      accept_confirm do
+        click_button "Unlink"
+      end
+    end
+
+    assert_current_path account_path(account)
+    assert_text "SimpleFIN account unlinked successfully."
+  end
+
   test "destroying an account removes it from the sidebar live" do
     account = Account.create!(
       user: @user,

--- a/test/system/integrations_test.rb
+++ b/test/system/integrations_test.rb
@@ -128,6 +128,21 @@ class IntegrationsTest < ApplicationSystemTestCase
     assert_text "Lunch Flow account unlinked successfully."
   end
 
+  test "linking a second integration to a ledger account that already has one succeeds" do
+    lf_account = lunchflow_accounts(:unlinked_one)
+    multi_sourced = accounts(:linked_asset) # already has SimpleFIN source via fixtures
+
+    visit integrations_path
+
+    within("tr", text: lf_account.name) do
+      select multi_sourced.name, from: "Account to link"
+      click_button "Link"
+    end
+
+    assert_text "Lunch Flow account linked successfully."
+    assert_includes lf_account.reload.ledger_accounts, multi_sourced
+  end
+
   test "hides stale unlinked aggregator accounts" do
     @user.simplefin_connection.update!(refreshed_at: Time.current)
     stale_simplefin = simplefin_accounts(:unlinked_one)

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -29,6 +29,44 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "transaction with multiple sources shows a badge per aggregator" do
+    bank = accounts(:linked_asset)
+    expense = accounts(:expense_account)
+    AccountSource.create!(account: bank, sourceable: lunchflow_accounts(:unlinked_one))
+
+    txn = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      currency: currencies(:usd), description: "Multi-sourced txn",
+      amount_minor: 1234, transacted_at: 1.day.ago
+    )
+    sf_txn = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one),
+      remote_id: "ui_multi_sf",
+      amount: "-12.34",
+      description: "Multi-sourced txn",
+      transacted_at: 1.day.ago,
+      posted: 1.day.ago
+    )
+    lf_txn = Lunchflow::Transaction.create!(
+      account: lunchflow_accounts(:unlinked_one),
+      remote_id: "ui_multi_lf",
+      amount: "-12.34",
+      currency: "USD",
+      description: "Multi-sourced txn",
+      pending: false,
+      date: 1.day.ago.to_date
+    )
+    TransactionSource.create!(ledger_transaction: txn, sourceable: sf_txn)
+    TransactionSource.create!(ledger_transaction: txn, sourceable: lf_txn)
+
+    visit transactions_path
+
+    within "##{ActionView::RecordIdentifier.dom_id(txn)}" do
+      assert_selector ".source-badge", text: "SimpleFIN"
+      assert_selector ".source-badge", text: "Lunch Flow"
+    end
+  end
+
   test "sidebar active state survives a live update" do
     account = accounts(:asset_account)
     other = accounts(:expense_account)


### PR DESCRIPTION
Closes #130.

## Summary

Final of three PRs implementing #130. Now bases on `main` (after #131 and #134 merged). Surfaces the M:M data model in the UI: a ledger account can show every aggregator source it's linked to, and a transaction shows a badge per attached source. Removes the controller guard that previously forced one source per ledger account; the integrations page now permits attaching a Lunch Flow source to a ledger account that already has a SimpleFIN one (and vice versa).

- New `app/views/accounts/_sources.html.erb` partial rendered on the account detail page (between the Opening Balance row and the bottom of the page). Lists each `account.account_sources` with the aggregator badge ("SimpleFIN" / "Lunch Flow"), the underlying aggregator account name, and a per-row `Unlink` button that posts to the existing aggregator-namespaced unlink route. When no sources exist, it shows "No linked integrations" instead of being empty.
- `app/views/transactions/_transaction.html.erb` renders a `.source-badge` span per `transaction.transaction_sources` entry next to the description. Helpers `source_badge_label(sourceable)` and `transaction_source_badges(transaction)` live in `ApplicationHelper`.
- Both link controllers (`Simplefin::AccountsController#link`, `Lunchflow::AccountsController#link`) drop the "Account is already linked to another integration" guard. The remaining "aggregator account is already linked to a different ledger account" guard stays — that constraint is still enforced by the data model anyway (unique index on `(account_sources.sourceable_type, sourceable_id)`).
- `IntegrationsController#show` no longer filters `@linkable_accounts` through the `unlinked` scope, so the link dropdowns surface every asset/liability ledger account the user owns.

## Test plan

- [x] `bin/rails test` — 670 runs, 1635 assertions, 0 failures (100% line coverage)
- [x] `bin/rails test:system` — 30 runs, 100 assertions, 0 failures
- [x] `bin/rubocop` — clean
- [x] `bin/brakeman --no-pager` — no warnings
- [x] System test: account detail page lists every linked aggregator source (`AccountsTest`)
- [x] System test: transaction with multiple sources shows a badge per aggregator (`TransactionsTest`)
- [x] System test: linking a second integration to a ledger account that already has one succeeds (`IntegrationsTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)