### PR TITLE
Stop creating orphan counterparts on aggregator description drift

### DIFF
--- a/app/jobs/lunchflow/import_transactions_job.rb
+++ b/app/jobs/lunchflow/import_transactions_job.rb
@@ -34,7 +34,17 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
             next
           end
 
-          transaction = ledger_transaction
+          # Refresh source-driven scalars only. Counterpart account, description,
+          # and merge/exclude state were settled at first import (possibly adjusted
+          # by AutoMerge or by the user) and must not be re-derived on every resync —
+          # re-running counterpart creation here is what produced #137.
+          ledger_transaction.update!(
+            amount_minor: lft.amount_minor.abs,
+            transacted_at: lft.date || Time.current,
+            cleared_at: lft.pending ? nil : lft.date,
+            synced_at: Time.current
+          )
+          next
         elsif (match = Transaction::Reconcile.call(
           ledger_account: ledger_account,
           amount_minor: lft.amount_minor.abs,

--- a/app/jobs/simplefin/import_transactions_job.rb
+++ b/app/jobs/simplefin/import_transactions_job.rb
@@ -32,7 +32,17 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
             next
           end
 
-          transaction = ledger_transaction
+          # Refresh source-driven scalars only. Counterpart account, description,
+          # and merge/exclude state were settled at first import (possibly adjusted
+          # by AutoMerge or by the user) and must not be re-derived on every resync —
+          # re-running counterpart creation here is what produced #137.
+          ledger_transaction.update!(
+            amount_minor: sft.amount_minor.abs,
+            transacted_at: sft.transacted_at || sft.posted || Time.current,
+            cleared_at: sft.posted,
+            synced_at: Time.current
+          )
+          next
         elsif (match = Transaction::Reconcile.call(
           ledger_account: ledger_account,
           amount_minor: sft.amount_minor.abs,

--- a/test/jobs/lunchflow/import_transactions_job_test.rb
+++ b/test/jobs/lunchflow/import_transactions_job_test.rb
@@ -121,6 +121,86 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
     assert transaction.synced_at > original_synced_at
   end
 
+  test "canonical resync with drifted merchant does not create a new counterpart account" do
+    lf_account, lf_bank_account = create_linked_lunchflow_account
+
+    lf_transaction = Lunchflow::Transaction.create!(
+      account: lf_account,
+      remote_id: "lf_drift",
+      amount: "-50.00",
+      currency: "USD",
+      description: "POS PURCHASE",
+      merchant: "Coffee Shop",
+      pending: false,
+      date: 2.days.ago.to_date
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+
+    transaction = lf_transaction.ledger_transactions.first
+    original_dest_account_id = transaction.dest_account_id
+    original_description = transaction.description
+    original_synced_at = transaction.synced_at
+
+    travel 2.seconds
+
+    lf_transaction.update!(
+      merchant: "Coffee Shop - 100 Main St SOMECITY US - Card Ending In 0000",
+      synced_at: Time.current
+    )
+
+    assert_no_difference "Transaction.count" do
+      assert_no_difference "Account.count" do
+        Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+      end
+    end
+
+    transaction.reload
+    assert_equal lf_bank_account, transaction.src_account
+    assert_equal original_dest_account_id, transaction.dest_account_id
+    assert_equal original_description, transaction.description
+    assert transaction.synced_at > original_synced_at
+  end
+
+  test "canonical resync with drifted merchant preserves balance-sheet rule target" do
+    lf_account, lf_bank_account = create_linked_lunchflow_account
+
+    savings_account = Account.create!(user: @user, currency: @currency, name: "Savings", kind: :asset)
+    ImportRule.create!(user: @user, account: savings_account, match_pattern: "TRANSFER TO SAVINGS", match_type: :contains)
+
+    lf_transaction = Lunchflow::Transaction.create!(
+      account: lf_account,
+      remote_id: "lf_drift_rule",
+      amount: "-500.00",
+      currency: "USD",
+      description: "POS PURCHASE",
+      merchant: "TRANSFER TO SAVINGS",
+      pending: false,
+      date: 1.day.ago.to_date
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+
+    transaction = lf_transaction.ledger_transactions.first
+    assert_equal lf_bank_account, transaction.src_account
+    assert_equal savings_account, transaction.dest_account
+
+    travel 2.seconds
+
+    lf_transaction.update!(
+      merchant: "TRANSFER TO SAVINGS - REF 9999 - Card Ending In 0000",
+      synced_at: Time.current
+    )
+
+    assert_no_difference "Account.count" do
+      Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+    end
+
+    transaction.reload
+    assert_equal savings_account, transaction.dest_account
+    assert_equal "TRANSFER TO SAVINGS", transaction.description
+  end
+
   test "pending transaction has nil cleared_at" do
     lf_account, _ = create_linked_lunchflow_account
 

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -178,6 +178,84 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
     assert transaction.synced_at > original_synced_at
   end
 
+  test "canonical resync with drifted description does not create a new counterpart account" do
+    sf_account, bank_account = create_linked_simplefin_account
+
+    sf_transaction = Simplefin::Transaction.create!(
+      account: sf_account,
+      remote_id: "txn_drift",
+      amount: "-50.00",
+      description: "Coffee Shop",
+      posted: 2.days.ago,
+      transacted_at: 2.days.ago,
+      pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = sf_transaction.ledger_transactions.first
+    original_dest_account_id = transaction.dest_account_id
+    original_description = transaction.description
+    original_synced_at = transaction.synced_at
+
+    travel 2.seconds
+
+    sf_transaction.update!(
+      description: "Coffee Shop - 100 Main St SOMECITY US - Card Ending In 0000",
+      synced_at: Time.current
+    )
+
+    assert_no_difference "Transaction.count" do
+      assert_no_difference "Account.count" do
+        Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+      end
+    end
+
+    transaction.reload
+    assert_equal bank_account, transaction.src_account
+    assert_equal original_dest_account_id, transaction.dest_account_id
+    assert_equal original_description, transaction.description
+    assert transaction.synced_at > original_synced_at
+  end
+
+  test "canonical resync with drifted description preserves balance-sheet rule target" do
+    sf_account, bank_account = create_linked_simplefin_account
+
+    savings_account = Account.create!(user: @user, currency: @currency, name: "Savings", kind: :asset)
+    ImportRule.create!(user: @user, account: savings_account, match_pattern: "TRANSFER TO SAVINGS", match_type: :contains)
+
+    sf_transaction = Simplefin::Transaction.create!(
+      account: sf_account,
+      remote_id: "txn_drift_rule",
+      amount: "-500.00",
+      description: "TRANSFER TO SAVINGS",
+      posted: 1.day.ago,
+      transacted_at: 1.day.ago,
+      pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = sf_transaction.ledger_transactions.first
+    assert_equal bank_account, transaction.src_account
+    assert_equal savings_account, transaction.dest_account
+
+    travel 2.seconds
+
+    sf_transaction.update!(
+      description: "TRANSFER TO SAVINGS - REF 9999 - Card Ending In 0000",
+      synced_at: Time.current
+    )
+
+    assert_no_difference "Account.count" do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+    end
+
+    transaction.reload
+    assert_equal savings_account, transaction.dest_account
+    assert_equal "TRANSFER TO SAVINGS", transaction.description
+  end
+
   test "skips transactions without linked account" do
     unlinked_sf_account = Simplefin::Account.create!(
       connection: simplefin_connections(:one),


### PR DESCRIPTION
## Summary

- The canonical-resync branch in `Simplefin::ImportTransactionsJob` and `Lunchflow::ImportTransactionsJob` was falling through to the shared counterpart-creation block on every resync. When an aggregator revised a transaction's description, `Account.find_or_create_for_import`'s exact-name lookup missed the original placeholder and created a fresh one, which `AutoMerge#apply_rule_account` then orphaned by redirecting `dest_account` back to the rule target.
- Refresh source-driven scalars only on canonical-resync (`amount_minor`, `transacted_at`, `cleared_at`, `synced_at`) and `next`. The counterpart, description, and merge/exclude state were settled at first import and must not be re-derived — they may have been adjusted by `AutoMerge` or by the user since.
- First-write description wins: aggregators no longer overwrite description on resync. Users can still edit manually in the UI.

Closes #137.

## Test plan

- [x] `bin/rails test test/jobs/simplefin/import_transactions_job_test.rb test/jobs/lunchflow/import_transactions_job_test.rb` — 51 runs, 0 failures
- [x] `bin/rails test` — full suite: 681 runs, 0 failures
- [x] `bin/rubocop` — clean
- [x] New regression test (SimpleFIN): canonical resync with drifted description does not create a new counterpart `Account` and leaves `dest_account_id` / `description` unchanged
- [x] New regression test (SimpleFIN): canonical resync with drifted description preserves the balance-sheet rule target on `dest_account`
- [x] New regression test (Lunchflow, symmetric): drifted `merchant` does not create a new counterpart
- [x] New regression test (Lunchflow, symmetric): drifted `merchant` preserves the balance-sheet rule target

Cleanup of the three pre-existing orphan accounts already created by the surfaced refresh is intentionally out of scope; they have zero balance and no transactions and can be removed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)