### PR TITLE
Add CSV import with column mapping for arbitrary bank exports

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -519,6 +519,11 @@
   background-color: var(--cream);
 }
 
+.source-badge--csv {
+  color: var(--bark-medium);
+  background-color: var(--cream);
+}
+
 /* Merged details */
 .transactions .row > .merged-details {
   grid-column: 1 / -1;

--- a/app/controllers/csv/imports_controller.rb
+++ b/app/controllers/csv/imports_controller.rb
@@ -1,0 +1,137 @@
+class Csv::ImportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_account, except: :index
+  before_action :set_csv_import, only: %i[ show update destroy confirm parse ]
+
+  def index
+    if params[:account_id].present?
+      @account = current_user.accounts.real.find(params[:account_id])
+      @csv_imports = @account.csv_imports.order(created_at: :desc)
+    else
+      @csv_imports = current_user.csv_imports.includes(:account).order(created_at: :desc)
+    end
+  end
+
+  def new
+    @csv_import = @account.csv_imports.new(user: current_user)
+  end
+
+  def create
+    @csv_import = @account.csv_imports.new(
+      user: current_user,
+      column_mappings: Csv::Import.last_mapping_for(account: @account),
+      state: "pending"
+    )
+    file_param = params.require(:csv_import)[:file]
+    @csv_import.file.attach(file_param) if file_param.present?
+
+    if @csv_import.save
+      redirect_to account_csv_import_path(@account, @csv_import), notice: "CSV uploaded. Map the columns to continue."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @preview = build_preview
+  end
+
+  def update
+    if @csv_import.update(state: "mapped", column_mappings: mapping_params, error: nil)
+      redirect_to confirm_account_csv_import_path(@account, @csv_import),
+                  notice: "Mapping saved. Review how the rows will import below, then click \"Parse and import\"."
+    else
+      @preview = build_preview
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  def confirm
+    if @csv_import.pending? || @csv_import.column_mappings.blank?
+      redirect_to account_csv_import_path(@account, @csv_import),
+                  alert: "Save a column mapping before confirming."
+      return
+    end
+
+    @preview = build_preview
+  end
+
+  def parse
+    if @csv_import.column_mappings.blank? || @csv_import.pending?
+      redirect_to account_csv_import_path(@account, @csv_import), alert: "Save a column mapping before parsing."
+      return
+    end
+
+    Csv::ParseJob.perform_later(@csv_import.id)
+    redirect_to account_csv_import_path(@account, @csv_import), notice: "Parse and import enqueued."
+  end
+
+  def destroy
+    @csv_import.destroy!
+    redirect_to account_csv_imports_path(@account), notice: "Import deleted.", status: :see_other
+  end
+
+  private
+
+    def set_account
+      @account = current_user.accounts.real.find(params[:account_id])
+    end
+
+    def set_csv_import
+      @csv_import = @account.csv_imports.find(params[:id])
+    end
+
+    def mapping_params
+      raw = params.require(:csv_import).fetch(:column_mappings, {}).to_unsafe_h
+      raw["description_columns"] = Array(raw["description_columns"]).reject(&:blank?)
+      raw["debit_values"] = split_csv_list(raw["debit_values"]) if raw.key?("debit_values")
+      raw["skip_rows"] = raw["skip_rows"].to_i if raw["skip_rows"].present?
+      raw
+    end
+
+    def split_csv_list(value)
+      return value if value.is_a?(Array)
+      value.to_s.split(",").map(&:strip).reject(&:empty?)
+    end
+
+    def build_preview
+      return nil unless @csv_import.file.attached?
+
+      mappings = @csv_import.column_mappings.presence || {}
+      currency = @account.currency
+
+      raw = @csv_import.file.open { |io| Csv::Parser.raw_preview(io, limit: 10) } rescue { headers: [], rows: [] }
+
+      parsed_rows = []
+      parse_error = nil
+      if mappings_complete?(mappings)
+        begin
+          parsed = @csv_import.file.open { |io| Csv::Parser.preview(io, mappings: mappings, currency: currency, limit: 10) }
+          parsed_rows = parsed[:rows]
+        rescue Csv::Parser::Error, Csv::Parser::RowError => e
+          parse_error = e.message
+        end
+      end
+
+      {
+        headers: raw[:headers],
+        raw_rows: raw[:rows],
+        parsed_rows: parsed_rows,
+        error: parse_error
+      }
+    end
+
+    def mappings_complete?(mappings)
+      return false if mappings.blank?
+      mappings = mappings.with_indifferent_access
+      return false if mappings[:date_column].blank? || mappings[:amount_mode].blank?
+      case mappings[:amount_mode]
+      when "signed", "sign_indicator"
+        mappings[:amount_column].present?
+      when "debit_credit"
+        mappings[:debit_column].present? && mappings[:credit_column].present?
+      else
+        false
+      end
+    end
+end

--- a/app/controllers/csv/imports_controller.rb
+++ b/app/controllers/csv/imports_controller.rb
@@ -82,7 +82,8 @@ class Csv::ImportsController < ApplicationController
     end
 
     def mapping_params
-      raw = params.require(:csv_import).fetch(:column_mappings, {}).to_unsafe_h
+      mapping = params.dig(:csv_import, :column_mappings)
+      raw = mapping.respond_to?(:to_unsafe_h) ? mapping.to_unsafe_h : (mapping.is_a?(Hash) ? mapping.dup : {})
       raw["description_columns"] = Array(raw["description_columns"]).reject(&:blank?)
       raw["debit_values"] = split_csv_list(raw["debit_values"]) if raw.key?("debit_values")
       raw["skip_rows"] = raw["skip_rows"].to_i if raw["skip_rows"].present?
@@ -100,7 +101,11 @@ class Csv::ImportsController < ApplicationController
       mappings = @csv_import.column_mappings.presence || {}
       currency = @account.currency
 
-      raw = @csv_import.file.open { |io| Csv::Parser.raw_preview(io, limit: 10) } rescue { headers: [], rows: [] }
+      raw = begin
+        @csv_import.file.open { |io| Csv::Parser.raw_preview(io, limit: 10) }
+      rescue Csv::Parser::Error, ::CSV::MalformedCSVError, ActiveStorage::Error
+        { headers: [], rows: [] }
+      end
 
       parsed_rows = []
       parse_error = nil

--- a/app/controllers/csv/imports_controller.rb
+++ b/app/controllers/csv/imports_controller.rb
@@ -87,6 +87,7 @@ class Csv::ImportsController < ApplicationController
       raw["description_columns"] = Array(raw["description_columns"]).reject(&:blank?)
       raw["debit_values"] = split_csv_list(raw["debit_values"]) if raw.key?("debit_values")
       raw["skip_rows"] = raw["skip_rows"].to_i if raw["skip_rows"].present?
+      raw["invert_amount"] = ActiveModel::Type::Boolean.new.cast(raw["invert_amount"]) if raw.key?("invert_amount")
       raw
     end
 

--- a/app/controllers/csv/imports_controller.rb
+++ b/app/controllers/csv/imports_controller.rb
@@ -47,9 +47,9 @@ class Csv::ImportsController < ApplicationController
   end
 
   def confirm
-    if @csv_import.pending? || @csv_import.column_mappings.blank?
+    unless @csv_import.mappings_complete?
       redirect_to account_csv_import_path(@account, @csv_import),
-                  alert: "Save a column mapping before confirming."
+                  alert: "Save a complete column mapping before confirming."
       return
     end
 
@@ -57,8 +57,9 @@ class Csv::ImportsController < ApplicationController
   end
 
   def parse
-    if @csv_import.column_mappings.blank? || @csv_import.pending?
-      redirect_to account_csv_import_path(@account, @csv_import), alert: "Save a column mapping before parsing."
+    unless @csv_import.mappings_complete?
+      redirect_to account_csv_import_path(@account, @csv_import),
+                  alert: "Save a complete column mapping before parsing."
       return
     end
 
@@ -99,9 +100,6 @@ class Csv::ImportsController < ApplicationController
     def build_preview
       return nil unless @csv_import.file.attached?
 
-      mappings = @csv_import.column_mappings.presence || {}
-      currency = @account.currency
-
       raw = begin
         @csv_import.file.open { |io| Csv::Parser.raw_preview(io, limit: 10) }
       rescue Csv::Parser::Error, ::CSV::MalformedCSVError, ActiveStorage::Error
@@ -110,9 +108,9 @@ class Csv::ImportsController < ApplicationController
 
       parsed_rows = []
       parse_error = nil
-      if mappings_complete?(mappings)
+      if @csv_import.mappings_complete?
         begin
-          parsed = @csv_import.file.open { |io| Csv::Parser.preview(io, mappings: mappings, currency: currency, limit: 10) }
+          parsed = @csv_import.file.open { |io| Csv::Parser.preview(io, mappings: @csv_import.column_mappings, currency: @account.currency, limit: 10) }
           parsed_rows = parsed[:rows]
         rescue Csv::Parser::Error, Csv::Parser::RowError => e
           parse_error = e.message
@@ -125,19 +123,5 @@ class Csv::ImportsController < ApplicationController
         parsed_rows: parsed_rows,
         error: parse_error
       }
-    end
-
-    def mappings_complete?(mappings)
-      return false if mappings.blank?
-      mappings = mappings.with_indifferent_access
-      return false if mappings[:date_column].blank? || mappings[:amount_mode].blank?
-      case mappings[:amount_mode]
-      when "signed", "sign_indicator"
-        mappings[:amount_column].present?
-      when "debit_credit"
-        mappings[:debit_column].present? && mappings[:credit_column].present?
-      else
-        false
-      end
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,7 @@ module ApplicationHelper
     case sourceable
     when Simplefin::Account, Simplefin::Transaction then "SimpleFIN"
     when Lunchflow::Account, Lunchflow::Transaction then "Lunch Flow"
+    when Csv::Transaction then "CSV"
     else sourceable.class.name
     end
   end
@@ -16,6 +17,7 @@ module ApplicationHelper
     case sourceable
     when Simplefin::Account, Simplefin::Transaction then "source-badge--simplefin"
     when Lunchflow::Account, Lunchflow::Transaction then "source-badge--lunchflow"
+    when Csv::Transaction then "source-badge--csv"
     end
   end
 

--- a/app/javascript/controllers/csv_mapping_controller.js
+++ b/app/javascript/controllers/csv_mapping_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["radio", "signed", "debitCredit", "signIndicator"]
+  static values = { mode: String }
+
+  connect() {
+    this.update()
+  }
+
+  change() {
+    const checked = this.radioTargets.find(radio => radio.checked)
+    if (checked) {
+      this.modeValue = checked.value
+    }
+    this.update()
+  }
+
+  update() {
+    const mode = this.modeValue || "signed"
+    if (this.hasSignedTarget) this.signedTarget.hidden = mode !== "signed"
+    if (this.hasDebitCreditTarget) this.debitCreditTarget.hidden = mode !== "debit_credit"
+    if (this.hasSignIndicatorTarget) this.signIndicatorTarget.hidden = mode !== "sign_indicator"
+  }
+}

--- a/app/jobs/csv/import_transactions_job.rb
+++ b/app/jobs/csv/import_transactions_job.rb
@@ -69,7 +69,14 @@ class Csv::ImportTransactionsJob < ApplicationJob
           transaction = Transaction.new
         end
 
-        rule = user.import_rules.for_description(csv_transaction.description).first
+        # Csv::Transaction#description is `""` when the user mapped no
+        # description column or the row's cells are blank. Account names
+        # can't be blank, and ImportRule matching against an empty string
+        # has no useful semantics, so fall back to a placeholder. Users can
+        # rename the resulting "(no description)" account afterwards.
+        description_for_import = csv_transaction.description.presence || "(no description)"
+
+        rule = user.import_rules.for_description(description_for_import).first
         rule_account = rule&.account
         bs_rule_account = rule_account if rule_account&.balance_sheet?
 
@@ -77,7 +84,7 @@ class Csv::ImportTransactionsJob < ApplicationJob
         counterpart = if rule_account && !bs_rule_account
           rule_account
         else
-          Account.find_or_create_for_import(user: user, description: csv_transaction.description, kind: kind, currency: ledger_account.currency, skip_rules: true)
+          Account.find_or_create_for_import(user: user, description: description_for_import, kind: kind, currency: ledger_account.currency, skip_rules: true)
         end
 
         if csv_transaction.amount_minor.negative?
@@ -91,7 +98,7 @@ class Csv::ImportTransactionsJob < ApplicationJob
         transaction.user = user
         transaction.src_account = transaction_src
         transaction.dest_account = transaction_dest
-        transaction.description = csv_transaction.description
+        transaction.description = description_for_import
         transaction.amount_minor = csv_transaction.amount_minor.abs
         transaction.currency = ledger_account.currency
         transaction.transacted_at = csv_transaction.transacted_at

--- a/app/jobs/csv/import_transactions_job.rb
+++ b/app/jobs/csv/import_transactions_job.rb
@@ -1,0 +1,105 @@
+class Csv::ImportTransactionsJob < ApplicationJob
+  queue_as :default
+
+  def perform(import_id)
+    import = Csv::Import.find_by(id: import_id)
+    return if import.nil?
+
+    csv_transactions = Csv::Transaction
+      .where(import_id: import.id)
+      .includes(import: [ :user, { account: :currency } ])
+      .left_joins(:ledger_transactions)
+      .where("transactions.id IS NULL OR (transactions.merged_into_id IS NULL AND transactions.excluded_at IS NULL AND csv_transactions.synced_at > COALESCE(transactions.synced_at, '1970-01-01'))")
+
+    Transaction.collecting_sidebar_broadcasts do
+      csv_transactions.find_each do |csv_transaction|
+        user = csv_transaction.import.user
+        ledger_account = csv_transaction.import.account
+
+        existing_source = TransactionSource.find_by(sourceable: csv_transaction)
+
+        if existing_source
+          ledger_transaction = existing_source.ledger_transaction
+          canonical_source = ledger_transaction.transaction_sources.order(:created_at, :id).first
+
+          unless canonical_source.id == existing_source.id
+            ledger_transaction.update!(synced_at: Time.current)
+            next
+          end
+
+          ledger_transaction.update!(
+            amount_minor: csv_transaction.amount_minor.abs,
+            transacted_at: csv_transaction.transacted_at,
+            cleared_at: csv_transaction.posted_at,
+            synced_at: Time.current
+          )
+          next
+        elsif (match = Transaction::Reconcile.call(
+          ledger_account: ledger_account,
+          amount_minor: csv_transaction.amount_minor.abs,
+          currency_id: ledger_account.currency_id,
+          transacted_at: csv_transaction.transacted_at,
+          description: csv_transaction.description,
+          incoming_source: csv_transaction
+        ))
+          begin
+            Transaction.transaction do
+              TransactionSource::Attach.call(transaction: match, sourceable: csv_transaction)
+              match.update!(synced_at: Time.current)
+            end
+          rescue TransactionSource::Attach::MismatchedTransaction
+            # Another import handled this source; skip this iteration.
+          end
+          next
+        else
+          transaction = Transaction.new
+        end
+
+        rule = user.import_rules.for_description(csv_transaction.description).first
+        rule_account = rule&.account
+        bs_rule_account = rule_account if rule_account&.balance_sheet?
+
+        kind = csv_transaction.amount_minor.negative? ? :expense : :revenue
+        counterpart = if rule_account && !bs_rule_account
+          rule_account
+        else
+          Account.find_or_create_for_import(user: user, description: csv_transaction.description, kind: kind, currency: ledger_account.currency, skip_rules: true)
+        end
+
+        if csv_transaction.amount_minor.negative?
+          transaction_src = ledger_account
+          transaction_dest = counterpart
+        else
+          transaction_src = counterpart
+          transaction_dest = ledger_account
+        end
+
+        transaction.user = user
+        transaction.src_account = transaction_src
+        transaction.dest_account = transaction_dest
+        transaction.description = csv_transaction.description
+        transaction.amount_minor = csv_transaction.amount_minor.abs
+        transaction.currency = ledger_account.currency
+        transaction.transacted_at = csv_transaction.transacted_at
+        transaction.cleared_at = csv_transaction.posted_at
+        transaction.synced_at = Time.current
+        begin
+          Transaction.transaction do
+            transaction.save!
+            TransactionSource::Attach.call(transaction: transaction, sourceable: csv_transaction)
+          end
+        rescue TransactionSource::Attach::MismatchedTransaction
+          next
+        end
+
+        if rule&.exclude?
+          Transaction::Exclude.new(transaction, user: user).call
+        else
+          Transaction::AutoMerge.call(transaction, rule_account: bs_rule_account)
+        end
+      end
+    end
+
+    import.update!(state: "imported", imported_at: Time.current, error: nil)
+  end
+end

--- a/app/jobs/csv/import_transactions_job.rb
+++ b/app/jobs/csv/import_transactions_job.rb
@@ -27,6 +27,20 @@ class Csv::ImportTransactionsJob < ApplicationJob
             next
           end
 
+          # If the user re-parsed with a different sign (e.g. they toggled
+          # invert_amount), the absolute amount is the same but src/dest need
+          # to flip so the ledger account balances move in the correct
+          # direction. Swap the existing src/dest in place — the counterpart
+          # account stays the same; its kind may now read awkwardly relative
+          # to the direction, but the balance-sheet side is correct and the
+          # user can re-categorize from the transactions UI.
+          ledger_account_was_src = ledger_transaction.src_account_id == ledger_account.id
+          should_be_src = csv_transaction.amount_minor.negative?
+          if ledger_account_was_src != should_be_src
+            ledger_transaction.src_account, ledger_transaction.dest_account =
+              ledger_transaction.dest_account, ledger_transaction.src_account
+          end
+
           ledger_transaction.update!(
             amount_minor: csv_transaction.amount_minor.abs,
             transacted_at: csv_transaction.transacted_at,

--- a/app/jobs/csv/parse_job.rb
+++ b/app/jobs/csv/parse_job.rb
@@ -6,7 +6,7 @@ class Csv::ParseJob < ApplicationJob
     return if import.nil?
     return unless import.file.attached?
 
-    parsed_count = 0
+    produced_indices = []
     import.file.open do |io|
       parser = Csv::Parser.new(io: io, mappings: import.column_mappings, currency: import.account.currency)
       parser.each_row do |parsed|
@@ -22,12 +22,22 @@ class Csv::ParseJob < ApplicationJob
           synced_at: Time.current
         )
         record.save!
-        parsed_count += 1
+        produced_indices << parsed.row_index
       end
     end
 
+    # Drop csv_transactions whose row_index is no longer produced by the
+    # current mapping (e.g. user changed `skip_rows` after a previous parse).
+    # `dependent: :destroy` on transaction_sources cleans up the join row; any
+    # ledger transactions previously sourced from these rows simply lose their
+    # CSV source and remain as ordinary ledger transactions.
+    import.transactions.where.not(row_index: produced_indices).destroy_all
+
     import.update!(state: "parsed", parsed_at: Time.current, error: nil)
-    Csv::ImportTransactionsJob.perform_later(import.id) if parsed_count.positive?
+    # Always enqueue the import job — it no-ops when there are no rows but
+    # still transitions the import to "imported", so a 0-row parse doesn't
+    # leave the import permanently stuck in "parsed".
+    Csv::ImportTransactionsJob.perform_later(import.id)
   rescue Csv::Parser::Error => e
     import&.update!(state: "failed", error: e.message)
   rescue StandardError => e

--- a/app/jobs/csv/parse_job.rb
+++ b/app/jobs/csv/parse_job.rb
@@ -6,7 +6,11 @@ class Csv::ParseJob < ApplicationJob
     return if import.nil?
     return unless import.file.attached?
 
-    produced_indices = []
+    # Stamp every row produced by this run with the same parse_started_at, then
+    # drop rows that weren't touched (synced_at < parse_started_at or NULL).
+    # Avoids accumulating row_indices in memory for large files and uses the
+    # synced_at index instead of an unbounded NOT IN (...).
+    parse_started_at = Time.current
     import.file.open do |io|
       parser = Csv::Parser.new(io: io, mappings: import.column_mappings, currency: import.account.currency)
       parser.each_row do |parsed|
@@ -19,10 +23,9 @@ class Csv::ParseJob < ApplicationJob
           description: parsed.description,
           amount_minor: parsed.amount_minor,
           raw: parsed.raw,
-          synced_at: Time.current
+          synced_at: parse_started_at
         )
         record.save!
-        produced_indices << parsed.row_index
       end
     end
 
@@ -31,7 +34,7 @@ class Csv::ParseJob < ApplicationJob
     # `dependent: :destroy` on transaction_sources cleans up the join row; any
     # ledger transactions previously sourced from these rows simply lose their
     # CSV source and remain as ordinary ledger transactions.
-    import.transactions.where.not(row_index: produced_indices).destroy_all
+    import.transactions.where("synced_at IS NULL OR synced_at < ?", parse_started_at).destroy_all
 
     import.update!(state: "parsed", parsed_at: Time.current, error: nil)
     # Always enqueue the import job — it no-ops when there are no rows but

--- a/app/jobs/csv/parse_job.rb
+++ b/app/jobs/csv/parse_job.rb
@@ -1,0 +1,37 @@
+class Csv::ParseJob < ApplicationJob
+  queue_as :default
+
+  def perform(import_id)
+    import = Csv::Import.find_by(id: import_id)
+    return if import.nil?
+    return unless import.file.attached?
+
+    parsed_count = 0
+    import.file.open do |io|
+      parser = Csv::Parser.new(io: io, mappings: import.column_mappings, currency: import.account.currency)
+      parser.each_row do |parsed|
+        record = Csv::Transaction
+          .where(import_id: import.id, row_index: parsed.row_index)
+          .first_or_initialize
+        record.assign_attributes(
+          transacted_at: parsed.transacted_at,
+          posted_at: parsed.posted_at,
+          description: parsed.description,
+          amount_minor: parsed.amount_minor,
+          raw: parsed.raw,
+          synced_at: Time.current
+        )
+        record.save!
+        parsed_count += 1
+      end
+    end
+
+    import.update!(state: "parsed", parsed_at: Time.current, error: nil)
+    Csv::ImportTransactionsJob.perform_later(import.id) if parsed_count.positive?
+  rescue Csv::Parser::Error => e
+    import&.update!(state: "failed", error: e.message)
+  rescue StandardError => e
+    import&.update!(state: "failed", error: "#{e.class}: #{e.message}")
+    raise
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -18,6 +18,7 @@ class Account < ApplicationRecord
 
   has_many :import_rules, dependent: :destroy
   has_many :account_sources, dependent: :destroy
+  has_many :csv_imports, class_name: "Csv::Import", dependent: :destroy
 
   after_create_commit  :broadcast_sidebar_insert, if: :real?
   after_update_commit  :broadcast_sidebar_change, if: :real?

--- a/app/models/csv.rb
+++ b/app/models/csv.rb
@@ -1,0 +1,5 @@
+module Csv
+  def self.table_name_prefix
+    "csv_"
+  end
+end

--- a/app/models/csv/import.rb
+++ b/app/models/csv/import.rb
@@ -33,6 +33,24 @@ class Csv::Import < ApplicationRecord
     file.attached? ? file.filename.to_s : nil
   end
 
+  # Whether the saved column_mappings have every field the parser needs to
+  # process a row. Used to gate the confirm/parse step in the controller and
+  # the "Parse and import" button in the confirm view, so the user can't
+  # enqueue a parse that will fail at parse-time validation.
+  def mappings_complete?
+    return false if column_mappings.blank?
+    mapping = column_mappings.with_indifferent_access
+    return false if mapping[:date_column].blank? || mapping[:amount_mode].blank?
+    case mapping[:amount_mode]
+    when "signed", "sign_indicator"
+      mapping[:amount_column].present?
+    when "debit_credit"
+      mapping[:debit_column].present? && mapping[:credit_column].present?
+    else
+      false
+    end
+  end
+
   private
 
     def account_belongs_to_user

--- a/app/models/csv/import.rb
+++ b/app/models/csv/import.rb
@@ -1,5 +1,6 @@
 class Csv::Import < ApplicationRecord
   STATES = %w[ pending mapped parsed imported failed ].freeze
+  MAX_FILE_BYTES = 25.megabytes
 
   belongs_to :user
   belongs_to :account
@@ -9,6 +10,8 @@ class Csv::Import < ApplicationRecord
   validates :state, inclusion: { in: STATES }
   validate :account_belongs_to_user
   validate :account_is_real
+  validate :file_attached
+  validate :file_within_size_limit, if: -> { file.attached? }
 
   STATES.each do |state_name|
     define_method("#{state_name}?") { state == state_name }
@@ -40,5 +43,15 @@ class Csv::Import < ApplicationRecord
     def account_is_real
       return if account.blank?
       errors.add(:account, "must be a real (non-virtual) account") if account.virtual?
+    end
+
+    def file_attached
+      errors.add(:file, "must be attached") unless file.attached?
+    end
+
+    def file_within_size_limit
+      if file.byte_size > MAX_FILE_BYTES
+        errors.add(:file, "must be smaller than #{ActiveSupport::NumberHelper.number_to_human_size(MAX_FILE_BYTES)}")
+      end
     end
 end

--- a/app/models/csv/import.rb
+++ b/app/models/csv/import.rb
@@ -8,9 +8,9 @@ class Csv::Import < ApplicationRecord
   has_one_attached :file
 
   validates :state, inclusion: { in: STATES }
+  validates :file, presence: true
   validate :account_belongs_to_user
   validate :account_is_real
-  validate :file_attached
   validate :file_within_size_limit, if: -> { file.attached? }
 
   STATES.each do |state_name|
@@ -43,10 +43,6 @@ class Csv::Import < ApplicationRecord
     def account_is_real
       return if account.blank?
       errors.add(:account, "must be a real (non-virtual) account") if account.virtual?
-    end
-
-    def file_attached
-      errors.add(:file, "must be attached") unless file.attached?
     end
 
     def file_within_size_limit

--- a/app/models/csv/import.rb
+++ b/app/models/csv/import.rb
@@ -1,0 +1,44 @@
+class Csv::Import < ApplicationRecord
+  STATES = %w[ pending mapped parsed imported failed ].freeze
+
+  belongs_to :user
+  belongs_to :account
+  has_many :transactions, class_name: "Csv::Transaction", foreign_key: :import_id, dependent: :destroy
+  has_one_attached :file
+
+  validates :state, inclusion: { in: STATES }
+  validate :account_belongs_to_user
+  validate :account_is_real
+
+  STATES.each do |state_name|
+    define_method("#{state_name}?") { state == state_name }
+  end
+
+  # Returns the column_mappings hash from the most recent prior import for the same
+  # ledger account, or an empty hash. Used to pre-fill the mapping form on a new
+  # import so the user does not have to re-map columns for the same institution's
+  # export format.
+  def self.last_mapping_for(account:)
+    where(account_id: account.id)
+      .where.not(column_mappings: {})
+      .order(created_at: :desc)
+      .limit(1)
+      .pick(:column_mappings) || {}
+  end
+
+  def filename
+    file.attached? ? file.filename.to_s : nil
+  end
+
+  private
+
+    def account_belongs_to_user
+      return if account.blank? || user.blank?
+      errors.add(:account, "must belong to you") unless account.accessible_by?(user)
+    end
+
+    def account_is_real
+      return if account.blank?
+      errors.add(:account, "must be a real (non-virtual) account") if account.virtual?
+    end
+end

--- a/app/models/csv/transaction.rb
+++ b/app/models/csv/transaction.rb
@@ -1,0 +1,7 @@
+class Csv::Transaction < ApplicationRecord
+  belongs_to :import, class_name: "Csv::Import"
+  has_many :transaction_sources, as: :sourceable, dependent: :destroy
+  has_many :ledger_transactions, through: :transaction_sources
+
+  delegate :user, :account, to: :import
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,6 @@ class User < ApplicationRecord
 
   has_one :lunchflow_connection, class_name: "Lunchflow::Connection", dependent: :destroy
   has_many :lunchflow_accounts, class_name: "Lunchflow::Account", through: :lunchflow_connection, source: :accounts
+
+  has_many :csv_imports, class_name: "Csv::Import", dependent: :destroy
 end

--- a/app/services/csv/parser.rb
+++ b/app/services/csv/parser.rb
@@ -1,0 +1,262 @@
+require "csv"
+
+class Csv::Parser
+  class Error < StandardError; end
+  class RowError < Error
+    attr_reader :row_index
+    def initialize(message, row_index:)
+      super("row #{row_index}: #{message}")
+      @row_index = row_index
+    end
+  end
+
+  AMOUNT_MODES = %w[ signed debit_credit sign_indicator ].freeze
+
+  Row = Struct.new(:row_index, :transacted_at, :posted_at, :description, :amount_minor, :raw, keyword_init: true)
+
+  def self.headers(io)
+    new(io: io, mappings: {}, currency: nil).headers
+  end
+
+  def self.raw_preview(io, limit: 10)
+    parser = new(io: io, mappings: {}, currency: nil)
+    headers = parser.headers
+    raw_rows = []
+    ::CSV.parse(parser.send(:read_string), headers: true, liberal_parsing: true, skip_blanks: true).each do |csv_row|
+      raw_rows << csv_row.to_h
+      break if raw_rows.size >= limit
+    end
+    { headers: headers, rows: raw_rows }
+  end
+
+  def self.preview(io, mappings:, currency:, limit: 10)
+    parser = new(io: io, mappings: mappings, currency: currency)
+    parser.headers # ensure headers are loaded
+    rows = []
+    parser.each_row do |row|
+      rows << row
+      break if rows.size >= limit
+    end
+    { headers: parser.headers, rows: rows }
+  end
+
+  def initialize(io:, mappings:, currency:)
+    @io = io
+    @mappings = (mappings || {}).with_indifferent_access
+    @currency = currency
+  end
+
+  def headers
+    @headers ||= begin
+      content = read_string
+      first_line = content.each_line.first
+      ::CSV.parse_line(first_line || "", liberal_parsing: true) || []
+    end
+  end
+
+  # Yields a Row for each data row in the CSV. Caller is responsible for
+  # rescuing RowError.
+  def each_row
+    return to_enum(:each_row) unless block_given?
+
+    require_currency!
+    require_mappings!
+
+    skip_rows = (@mappings[:skip_rows] || 0).to_i
+    options = { headers: true, liberal_parsing: true, skip_blanks: true }
+
+    ::CSV.parse(read_string, **options).each_with_index do |csv_row, index|
+      next if index < skip_rows
+
+      raw_hash = csv_row.to_h
+      amount_decimal = parse_amount(csv_row, index)
+      transacted_at = parse_date(
+        compose_datetime(csv_row, @mappings[:date_column], @mappings[:time_column], @mappings[:timezone_column]),
+        format: effective_date_format,
+        field: "date",
+        row_index: index
+      )
+      posted_at_value = posted_at_column.present? ? compose_datetime(csv_row, posted_at_column, @mappings[:time_column], @mappings[:timezone_column]) : nil
+      posted_at = posted_at_value.present? ? parse_date(posted_at_value, format: effective_date_format, field: "posted_at", row_index: index) : nil
+      description = build_description(csv_row)
+
+      yield Row.new(
+        row_index: index,
+        transacted_at: transacted_at,
+        posted_at: posted_at,
+        description: description,
+        amount_minor: minor_from(amount_decimal),
+        raw: raw_hash
+      )
+    end
+  end
+
+  private
+
+    def require_currency!
+      raise Error, "currency is required to parse amounts" if @currency.nil?
+    end
+
+    def require_mappings!
+      %i[ date_column amount_mode ].each do |key|
+        raise Error, "#{key} is required" if @mappings[key].blank?
+      end
+
+      unless AMOUNT_MODES.include?(@mappings[:amount_mode].to_s)
+        raise Error, "amount_mode must be one of #{AMOUNT_MODES.join(', ')}"
+      end
+
+      case @mappings[:amount_mode]
+      when "signed"
+        raise Error, "amount_column is required for signed mode" if @mappings[:amount_column].blank?
+      when "debit_credit"
+        raise Error, "debit_column and credit_column are required for debit_credit mode" if @mappings[:debit_column].blank? || @mappings[:credit_column].blank?
+      when "sign_indicator"
+        raise Error, "amount_column, sign_column, and debit_values are required for sign_indicator mode" if @mappings[:amount_column].blank? || @mappings[:sign_column].blank? || Array(@mappings[:debit_values]).empty?
+      end
+    end
+
+    def read_string
+      @read_string ||= begin
+        @io.rewind if @io.respond_to?(:rewind)
+        content = @io.read
+        content = content.dup.force_encoding("UTF-8") if content.respond_to?(:force_encoding)
+        content = content.sub(/\A﻿/, "")
+        content
+      end
+    end
+
+    def posted_at_column
+      @mappings[:posted_at_column]
+    end
+
+    # Combines the value at `date_column` with the values at `time_column` and
+    # `timezone_column` (if any) using single space separators, so a strftime
+    # can match the value even when the file splits date, time, and timezone
+    # across separate columns (PayPal exports do this).
+    def compose_datetime(csv_row, date_column, time_column, timezone_column = nil)
+      parts = [ csv_row[date_column].to_s.strip ]
+      return parts.first if parts.first.empty?
+
+      if time_column.present?
+        time_value = csv_row[time_column].to_s.strip
+        parts << time_value unless time_value.empty?
+      end
+
+      if timezone_column.present?
+        tz_value = csv_row[timezone_column].to_s.strip
+        parts << tz_value unless tz_value.empty?
+      end
+
+      parts.join(" ")
+    end
+
+    # If a timezone column is mapped but the user's format doesn't already
+    # contain a %Z/%z token, auto-append " %Z" so strptime handles the
+    # appended abbreviation. The user can still override by writing %z (numeric
+    # offset) themselves.
+    def effective_date_format
+      format = @mappings[:date_format]
+      return nil if format.blank?
+      return format if @mappings[:timezone_column].blank?
+      return format if format.include?("%Z") || format.include?("%z")
+      "#{format} %Z"
+    end
+
+    def build_description(csv_row)
+      columns = Array(@mappings[:description_columns]).reject(&:blank?)
+      columns = [ @mappings[:description_column] ] if columns.empty? && @mappings[:description_column].present?
+      values = columns.map { |column| csv_row[column].to_s.strip }.reject(&:empty?)
+      values.join(" ").squeeze(" ").strip
+    end
+
+    def parse_amount(csv_row, row_index)
+      case @mappings[:amount_mode]
+      when "signed"
+        parse_decimal(csv_row[@mappings[:amount_column]], field: @mappings[:amount_column], row_index: row_index)
+      when "debit_credit"
+        debit_raw = csv_row[@mappings[:debit_column]]
+        credit_raw = csv_row[@mappings[:credit_column]]
+        debit = parse_optional_decimal(debit_raw, field: @mappings[:debit_column], row_index: row_index)
+        credit = parse_optional_decimal(credit_raw, field: @mappings[:credit_column], row_index: row_index)
+        if debit && credit
+          raise RowError.new("both debit and credit columns are populated", row_index: row_index)
+        elsif debit
+          -debit.abs
+        elsif credit
+          credit.abs
+        else
+          raise RowError.new("neither debit nor credit column is populated", row_index: row_index)
+        end
+      when "sign_indicator"
+        amount = parse_decimal(csv_row[@mappings[:amount_column]], field: @mappings[:amount_column], row_index: row_index)
+        sign_value = csv_row[@mappings[:sign_column]].to_s.strip
+        debit_values = Array(@mappings[:debit_values]).map { |value| value.to_s.strip.downcase }
+        if debit_values.include?(sign_value.downcase)
+          -amount.abs
+        else
+          amount.abs
+        end
+      end
+    end
+
+    def parse_decimal(value, field:, row_index:)
+      decimal = parse_optional_decimal(value, field: field, row_index: row_index)
+      raise RowError.new("missing #{field}", row_index: row_index) if decimal.nil?
+      decimal
+    end
+
+    def parse_optional_decimal(value, field:, row_index:)
+      return nil if value.nil?
+      cleaned = value.to_s.strip
+      return nil if cleaned.empty?
+
+      negative = false
+      if cleaned.start_with?("(") && cleaned.end_with?(")")
+        negative = true
+        cleaned = cleaned[1..-2]
+      end
+      cleaned = cleaned.gsub(/[\$,\s]/, "")
+      return nil if cleaned.empty?
+
+      begin
+        result = BigDecimal(cleaned)
+      rescue ArgumentError, TypeError
+        raise RowError.new("could not parse #{field.inspect} as a number: #{value.inspect}", row_index: row_index)
+      end
+      negative ? -result : result
+    end
+
+    def parse_date(value, format:, field:, row_index:)
+      raise RowError.new("missing #{field}", row_index: row_index) if value.nil? || value.to_s.strip.empty?
+
+      cleaned = value.to_s.strip
+
+      if format.present?
+        formats_to_try = [ format ]
+        # If the user supplied a date+time format separated by whitespace but
+        # this column only carries the date (e.g. PayPal exports split Date and
+        # Time across columns), also try the leading date-only segment so the
+        # mapping still works without forcing the user to drop the time tokens.
+        formats_to_try << format.split(/\s+/).first if format.match?(/\s/)
+        formats_to_try.uniq.compact.each do |fmt|
+          begin
+            return ::DateTime.strptime(cleaned, fmt).to_time
+          rescue ::Date::Error
+            next
+          end
+        end
+        raise RowError.new("could not parse #{field} #{value.inspect} with format #{format.inspect}", row_index: row_index)
+      end
+
+      begin
+        ::DateTime.parse(cleaned).to_time
+      rescue ::Date::Error, ArgumentError
+        raise RowError.new("could not parse #{field} #{value.inspect}", row_index: row_index)
+      end
+    end
+
+    def minor_from(decimal)
+      (decimal * (10 ** @currency.decimal_places)).round.to_i
+    end
+end

--- a/app/services/csv/parser.rb
+++ b/app/services/csv/parser.rb
@@ -252,7 +252,11 @@ class Csv::Parser
       begin
         ::DateTime.parse(cleaned).to_time
       rescue ::Date::Error, ArgumentError
-        raise RowError.new("could not parse #{field} #{value.inspect}", row_index: row_index)
+        raise RowError.new(
+          "could not parse #{field} #{value.inspect}; set a date format above " \
+          "(e.g. %m/%d/%y for M/D/YY, %m/%d/%Y for M/D/YYYY, or %Y-%m-%d for ISO)",
+          row_index: row_index
+        )
       end
     end
 

--- a/app/services/csv/parser.rb
+++ b/app/services/csv/parser.rb
@@ -4,8 +4,11 @@ class Csv::Parser
   class Error < StandardError; end
   class RowError < Error
     attr_reader :row_index
+    # row_index is the zero-based index used internally; the displayed
+    # number is +1 so users can locate the offending row in their CSV
+    # (the header is line 1, so data row 1 is line 2).
     def initialize(message, row_index:)
-      super("row #{row_index}: #{message}")
+      super("data row #{row_index + 1}: #{message}")
       @row_index = row_index
     end
   end

--- a/app/services/csv/parser.rb
+++ b/app/services/csv/parser.rb
@@ -242,13 +242,14 @@ class Csv::Parser
       cleaned = value.to_s.strip
 
       if format.present?
-        formats_to_try = [ format ]
-        # If the user supplied a date+time format separated by whitespace but
-        # this column only carries the date (e.g. PayPal exports split Date and
-        # Time across columns), also try the leading date-only segment so the
-        # mapping still works without forcing the user to drop the time tokens.
-        formats_to_try << format.split(/\s+/).first if format.match?(/\s/)
-        formats_to_try.uniq.compact.each do |fmt|
+        # Try the user-supplied format, then progressively shorter prefixes by
+        # dropping trailing whitespace-separated segments. This covers two real
+        # cases for files that split date/time/timezone across columns: a row
+        # whose timezone cell is blank (try without trailing %Z), and a row
+        # whose time and timezone cells are both blank (try date-only).
+        segments = format.split(/\s+/).reject(&:empty?)
+        formats_to_try = segments.size.downto(1).map { |n| segments.first(n).join(" ") }
+        formats_to_try.each do |fmt|
           begin
             return ::DateTime.strptime(cleaned, fmt).to_time
           rescue ::Date::Error

--- a/app/services/csv/parser.rb
+++ b/app/services/csv/parser.rb
@@ -70,6 +70,7 @@ class Csv::Parser
 
       raw_hash = csv_row.to_h
       amount_decimal = parse_amount(csv_row, index)
+      amount_decimal = -amount_decimal if invert_amount?
       transacted_at = parse_date(
         compose_datetime(csv_row, @mappings[:date_column], @mappings[:time_column], @mappings[:timezone_column]),
         format: effective_date_format,
@@ -128,6 +129,14 @@ class Csv::Parser
 
     def posted_at_column
       @mappings[:posted_at_column]
+    end
+
+    # Whether to flip the sign of the parsed amount before computing
+    # amount_minor. Used for credit card / liability CSVs whose statement
+    # convention reports purchases as positive and payments as negative,
+    # opposite of the asset-style convention the import logic assumes.
+    def invert_amount?
+      ActiveModel::Type::Boolean.new.cast(@mappings[:invert_amount])
     end
 
     # Combines the value at `date_column` with the values at `time_column` and

--- a/app/services/transaction/reconcile.rb
+++ b/app/services/transaction/reconcile.rb
@@ -9,6 +9,7 @@ class Transaction::Reconcile
     @currency_id = currency_id
     @transacted_at = transacted_at
     @description = description
+    @incoming_source = incoming_source
     @incoming_source_class = incoming_source&.class
   end
 
@@ -75,6 +76,20 @@ class Transaction::Reconcile
         ts_table[:sourceable_type].eq(account_class.transaction_class.name)
           .and(ts_table[:sourceable_id].in(live_transactions_for(account_class).arel))
       end
+
+      # Csv::Transaction isn't in AggregatorLinkable.registry (it has no
+      # connection-style aggregator account). Two distinct rows in the same
+      # Csv::Import are by definition different real-world events even when
+      # amount/date/description coincide, so candidates already sourced by a
+      # row from the same import must disqualify a CSV-incoming candidate from
+      # being adopted. Cross-import CSV-on-CSV adoption is still allowed (e.g.
+      # overlapping monthly statements).
+      if @incoming_source.is_a?(Csv::Transaction) && @incoming_source.import_id.present?
+        same_import_csv_ids = Csv::Transaction.where(import_id: @incoming_source.import_id).select(:id)
+        live_pairs_clauses << ts_table[:sourceable_type].eq("Csv::Transaction")
+          .and(ts_table[:sourceable_id].in(same_import_csv_ids.arel))
+      end
+
       return Arel.sql("FALSE") if live_pairs_clauses.empty?
 
       Arel::Nodes::Exists.new(

--- a/app/views/csv/imports/confirm.html.erb
+++ b/app/views/csv/imports/confirm.html.erb
@@ -1,0 +1,52 @@
+<% parsed_rows = (@preview && @preview[:parsed_rows]) || [] %>
+<% preview_error = @preview && @preview[:error] %>
+
+<h1>CSV Import — <%= @account.name %></h1>
+
+<p>
+  <%= link_to "← Back to Step 2 (mapping)", account_csv_import_path(@account, @csv_import) %>
+  ·
+  <%= link_to "Account transactions", account_transactions_path(@account) %>
+</p>
+
+<dl>
+  <dt>Status</dt><dd><%= @csv_import.state %></dd>
+  <dt>Account</dt><dd><%= @csv_import.account.name %></dd>
+  <dt>File</dt><dd><%= @csv_import.filename || "(missing)" %></dd>
+</dl>
+
+<% if @csv_import.error.present? %>
+  <p style="color: red"><strong>Error:</strong> <%= @csv_import.error %></p>
+<% end %>
+
+<% if preview_error %>
+  <p style="color: orange"><strong>Preview error:</strong> <%= preview_error %></p>
+<% end %>
+
+<h2>Step 3: Confirm and import</h2>
+
+<% if parsed_rows.any? %>
+  <p>Below is how the first <%= parsed_rows.size %> row<%= "s" if parsed_rows.size != 1 %> of your file will be imported with the saved mapping. If anything looks off, go back to Step 2 and adjust.</p>
+  <table>
+    <tr>
+      <th>Row #</th>
+      <th>Transacted at</th>
+      <th>Description</th>
+      <th>Amount</th>
+    </tr>
+    <% parsed_rows.each do |row| %>
+      <tr>
+        <td><%= row.row_index %></td>
+        <td><%= row.transacted_at.strftime("%Y-%m-%d") %></td>
+        <td><%= row.description %></td>
+        <td><%= number_with_precision(row.amount_minor.to_d / (10 ** @account.currency.decimal_places), precision: @account.currency.decimal_places) %></td>
+      </tr>
+    <% end %>
+  </table>
+<% else %>
+  <p>The mapping does not produce any rows yet. <%= link_to "Adjust the mapping", account_csv_import_path(@account, @csv_import) %>.</p>
+<% end %>
+
+<p style="margin-top: 1em">
+  <%= button_to "Parse and import these rows", parse_account_csv_import_path(@account, @csv_import), method: :post %>
+</p>

--- a/app/views/csv/imports/confirm.html.erb
+++ b/app/views/csv/imports/confirm.html.erb
@@ -4,8 +4,7 @@
 <h1>CSV Import — <%= @account.name %></h1>
 
 <p>
-  <%= link_to "← Back to Step 2 (mapping)", account_csv_import_path(@account, @csv_import) %>
-  ·
+  <%= link_to "← Back to Step 2 (mapping)", account_csv_import_path(@account, @csv_import) %> |
   <%= link_to "Account transactions", account_transactions_path(@account) %>
 </p>
 

--- a/app/views/csv/imports/confirm.html.erb
+++ b/app/views/csv/imports/confirm.html.erb
@@ -28,14 +28,14 @@
   <p>Below is how the first <%= parsed_rows.size %> row<%= "s" if parsed_rows.size != 1 %> of your file will be imported with the saved mapping. If anything looks off, go back to Step 2 and adjust.</p>
   <table>
     <tr>
-      <th>Row #</th>
+      <th>Data row</th>
       <th>Transacted at</th>
       <th>Description</th>
       <th>Amount</th>
     </tr>
     <% parsed_rows.each do |row| %>
       <tr>
-        <td><%= row.row_index %></td>
+        <td><%= row.row_index + 1 %></td>
         <td><%= row.transacted_at.strftime("%Y-%m-%d") %></td>
         <td><%= row.description %></td>
         <td><%= number_with_precision(row.amount_minor.to_d / (10 ** @account.currency.decimal_places), precision: @account.currency.decimal_places) %></td>
@@ -46,6 +46,8 @@
   <p>The mapping does not produce any rows yet. <%= link_to "Adjust the mapping", account_csv_import_path(@account, @csv_import) %>.</p>
 <% end %>
 
-<p style="margin-top: 1em">
-  <%= button_to "Parse and import these rows", parse_account_csv_import_path(@account, @csv_import), method: :post %>
-</p>
+<% if parsed_rows.any? %>
+  <p style="margin-top: 1em">
+    <%= button_to "Parse and import these rows", parse_account_csv_import_path(@account, @csv_import), method: :post %>
+  </p>
+<% end %>

--- a/app/views/csv/imports/index.html.erb
+++ b/app/views/csv/imports/index.html.erb
@@ -4,8 +4,7 @@
 
 <p>
   <% if scoped %>
-    <%= link_to "Upload a CSV", new_account_csv_import_path(@account) %>
-    ·
+    <%= link_to "Upload a CSV", new_account_csv_import_path(@account) %> |
     <%= link_to "Back to transactions", account_transactions_path(@account) %>
   <% else %>
     <%= link_to "Back to integrations", integrations_path %>
@@ -33,7 +32,6 @@
         <td><%= csv_import.state %><% if csv_import.error.present? %> — <span style="color: red"><%= csv_import.error %></span><% end %></td>
         <td style="display: flex; gap: 0.25em; align-items: center; white-space: nowrap">
           <%= link_to "Open", account_csv_import_path(csv_import.account, csv_import) %>
-          ·
           <%= button_to "Delete", account_csv_import_path(csv_import.account, csv_import), method: :delete, data: { turbo_confirm: "Delete this CSV import? Imported transactions remain on the ledger." } %>
         </td>
       </tr>

--- a/app/views/csv/imports/index.html.erb
+++ b/app/views/csv/imports/index.html.erb
@@ -31,7 +31,7 @@
         <% end %>
         <td><%= csv_import.filename || "(missing)" %></td>
         <td><%= csv_import.state %><% if csv_import.error.present? %> — <span style="color: red"><%= csv_import.error %></span><% end %></td>
-        <td>
+        <td style="display: flex; gap: 0.25em; align-items: center; white-space: nowrap">
           <%= link_to "Open", account_csv_import_path(csv_import.account, csv_import) %>
           ·
           <%= button_to "Delete", account_csv_import_path(csv_import.account, csv_import), method: :delete, data: { turbo_confirm: "Delete this CSV import? Imported transactions remain on the ledger." } %>

--- a/app/views/csv/imports/index.html.erb
+++ b/app/views/csv/imports/index.html.erb
@@ -30,9 +30,9 @@
         <% end %>
         <td><%= csv_import.filename || "(missing)" %></td>
         <td><%= csv_import.state %><% if csv_import.error.present? %> — <span style="color: red"><%= csv_import.error %></span><% end %></td>
-        <td style="display: flex; gap: 0.25em; align-items: center; white-space: nowrap">
-          <%= link_to "Open", account_csv_import_path(csv_import.account, csv_import) %>
-          <%= button_to "Delete", account_csv_import_path(csv_import.account, csv_import), method: :delete, data: { turbo_confirm: "Delete this CSV import? Imported transactions remain on the ledger." } %>
+        <td style="white-space: nowrap">
+          <%= link_to "Open", account_csv_import_path(csv_import.account, csv_import) %> |
+          <%= link_to "Delete", account_csv_import_path(csv_import.account, csv_import), data: { turbo_method: :delete, turbo_confirm: "Delete this CSV import? Imported transactions remain on the ledger." } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/csv/imports/index.html.erb
+++ b/app/views/csv/imports/index.html.erb
@@ -1,0 +1,44 @@
+<% scoped = @account.present? %>
+
+<h1>CSV Imports<%= " — #{@account.name}" if scoped %></h1>
+
+<p>
+  <% if scoped %>
+    <%= link_to "Upload a CSV", new_account_csv_import_path(@account) %>
+    ·
+    <%= link_to "Back to transactions", account_transactions_path(@account) %>
+  <% else %>
+    <%= link_to "Back to integrations", integrations_path %>
+  <% end %>
+</p>
+
+<% if @csv_imports.any? %>
+  <table>
+    <tr>
+      <th>Uploaded</th>
+      <% unless scoped %>
+        <th>Account</th>
+      <% end %>
+      <th>File</th>
+      <th>Status</th>
+      <th>Actions</th>
+    </tr>
+    <% @csv_imports.each do |csv_import| %>
+      <tr>
+        <td><%= csv_import.created_at.strftime("%B %d, %Y %I:%M %p") %></td>
+        <% unless scoped %>
+          <td><%= link_to csv_import.account.name, account_transactions_path(csv_import.account) %></td>
+        <% end %>
+        <td><%= csv_import.filename || "(missing)" %></td>
+        <td><%= csv_import.state %><% if csv_import.error.present? %> — <span style="color: red"><%= csv_import.error %></span><% end %></td>
+        <td>
+          <%= link_to "Open", account_csv_import_path(csv_import.account, csv_import) %>
+          ·
+          <%= button_to "Delete", account_csv_import_path(csv_import.account, csv_import), method: :delete, data: { turbo_confirm: "Delete this CSV import? Imported transactions remain on the ledger." } %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% else %>
+  <p>No CSV imports<%= " for this account" if scoped %>.</p>
+<% end %>

--- a/app/views/csv/imports/new.html.erb
+++ b/app/views/csv/imports/new.html.erb
@@ -1,0 +1,20 @@
+<h1>Upload CSV — <%= @account.name %></h1>
+
+<p><%= link_to "Back to imports", account_csv_imports_path(@account) %> · <%= link_to "Account transactions", account_transactions_path(@account) %></p>
+
+<%= form_with model: @csv_import, url: account_csv_imports_path(@account), html: { multipart: true } do |form| %>
+  <% if @csv_import.errors.any? %>
+    <ul style="color: red">
+      <% @csv_import.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <p>
+    <%= form.label :file, "CSV file" %><br>
+    <%= form.file_field :file, accept: ".csv,text/csv" %>
+  </p>
+
+  <p><%= form.submit "Upload" %></p>
+<% end %>

--- a/app/views/csv/imports/new.html.erb
+++ b/app/views/csv/imports/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Upload CSV — <%= @account.name %></h1>
 
-<p><%= link_to "Back to imports", account_csv_imports_path(@account) %> · <%= link_to "Account transactions", account_transactions_path(@account) %></p>
+<p><%= link_to "Back to imports", account_csv_imports_path(@account) %> | <%= link_to "Account transactions", account_transactions_path(@account) %></p>
 
 <%= form_with model: @csv_import, url: account_csv_imports_path(@account), html: { multipart: true } do |form| %>
   <% if @csv_import.errors.any? %>

--- a/app/views/csv/imports/show.html.erb
+++ b/app/views/csv/imports/show.html.erb
@@ -1,0 +1,169 @@
+<% require "ostruct" %>
+<% mappings = @csv_import.column_mappings.with_indifferent_access %>
+<% headers = (@preview && @preview[:headers]) || [] %>
+<% raw_rows = (@preview && @preview[:raw_rows]) || [] %>
+<% can_confirm = !@csv_import.pending? && @csv_import.column_mappings.present? %>
+
+<h1>CSV Import — <%= @account.name %></h1>
+
+<p>
+  <%= link_to "Back to imports", account_csv_imports_path(@account) %>
+  ·
+  <%= link_to "Account transactions", account_transactions_path(@account) %>
+</p>
+
+<dl>
+  <dt>Status</dt><dd><%= @csv_import.state %></dd>
+  <dt>Account</dt><dd><%= @csv_import.account.name %></dd>
+  <dt>File</dt><dd><%= @csv_import.filename || "(missing)" %></dd>
+  <dt>Uploaded</dt><dd><%= @csv_import.created_at.strftime("%B %d, %Y %I:%M %p") %></dd>
+  <% if @csv_import.parsed_at %>
+    <dt>Parsed</dt><dd><%= @csv_import.parsed_at.strftime("%B %d, %Y %I:%M %p") %></dd>
+  <% end %>
+  <% if @csv_import.imported_at %>
+    <dt>Imported</dt><dd><%= @csv_import.imported_at.strftime("%B %d, %Y %I:%M %p") %></dd>
+  <% end %>
+</dl>
+
+<% if @csv_import.error.present? %>
+  <p style="color: red"><strong>Error:</strong> <%= @csv_import.error %></p>
+<% end %>
+
+<% if @preview&.dig(:error) %>
+  <p style="color: orange"><strong>Preview error:</strong> <%= @preview[:error] %></p>
+<% end %>
+
+<% if raw_rows.any? %>
+  <h2>Step 1: Inspect the file (first <%= raw_rows.size %> row<%= "s" if raw_rows.size != 1 %>)</h2>
+  <div style="overflow-x: auto">
+    <table>
+      <thead>
+        <tr>
+          <% headers.each do |header| %>
+            <th><%= header %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% raw_rows.each do |row| %>
+          <tr>
+            <% headers.each do |header| %>
+              <td><%= row[header] %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+
+<h2>Step 2: Map columns</h2>
+
+<%= form_with model: @csv_import, url: account_csv_import_path(@account, @csv_import), method: :patch do |form| %>
+  <%= form.fields_for :column_mappings, OpenStruct.new(mappings) do |mapping_form| %>
+    <% header_options = headers.compact.reject(&:empty?) %>
+
+    <p>
+      <%= mapping_form.label :date_column, "Date column" %><br>
+      <%= mapping_form.select :date_column, header_options, { include_blank: "—" }, selected: mappings[:date_column] %>
+    </p>
+
+    <p>
+      <%= mapping_form.label :time_column, "Time column (optional)" %><br>
+      <%= mapping_form.select :time_column, header_options, { include_blank: "—" }, selected: mappings[:time_column] %>
+      <small>Pick this if the file stores the time-of-day in its own column.</small>
+    </p>
+
+    <p>
+      <%= mapping_form.label :timezone_column, "Timezone column (optional)" %><br>
+      <%= mapping_form.select :timezone_column, header_options, { include_blank: "—" }, selected: mappings[:timezone_column] %>
+      <small>Pick this if the file stores a timezone abbreviation (e.g. <code>PDT</code>) in its own column.</small>
+    </p>
+
+    <p>
+      <%= mapping_form.label :date_format, "Date format (strftime)" %><br>
+      <%= mapping_form.text_field :date_format, value: mappings[:date_format], placeholder: "%m/%d/%Y" %>
+      <small>
+        The parser joins your Date, Time, and Timezone column values with single spaces and parses the result with this format. Match every part you mapped above:
+        <ul style="margin: 0.25em 0 0.25em 1.25em">
+          <li>Date column only → <code>%m/%d/%Y</code> or <code>%Y-%m-%d</code></li>
+          <li>Date + Time → <code>%m/%d/%Y %H:%M:%S</code></li>
+          <li>Date + Time + Timezone → <code>%m/%d/%Y %H:%M:%S</code> (we auto-append <code>%Z</code> when a timezone column is set)</li>
+        </ul>
+        Leave blank to try flexible parsing (only safe when no Time or Timezone column is mapped).
+      </small>
+    </p>
+
+    <fieldset>
+      <legend>Description column(s)</legend>
+      <% selected_description_columns = Array(mappings[:description_columns]) %>
+      <%= hidden_field_tag "csv_import[column_mappings][description_columns][]", "" %>
+      <% header_options.each do |header| %>
+        <% input_id = "csv_import_column_mappings_description_columns_#{header.parameterize}" %>
+        <label for="<%= input_id %>" style="display: block">
+          <%= check_box_tag "csv_import[column_mappings][description_columns][]",
+                            header,
+                            selected_description_columns.include?(header),
+                            id: input_id %>
+          <%= header %>
+        </label>
+      <% end %>
+      <small>Selected columns are concatenated with spaces.</small>
+    </fieldset>
+
+    <p>
+      <%= mapping_form.label :posted_at_column, "Posted-at column (optional)" %><br>
+      <%= mapping_form.select :posted_at_column, header_options, { include_blank: "—" }, selected: mappings[:posted_at_column] %>
+    </p>
+
+    <fieldset data-controller="csv-mapping" data-csv-mapping-mode-value="<%= mappings[:amount_mode] || "signed" %>">
+      <legend>Amount</legend>
+      <% Csv::Parser::AMOUNT_MODES.each do |mode| %>
+        <label>
+          <%= mapping_form.radio_button :amount_mode, mode, checked: mappings[:amount_mode] == mode || (mappings[:amount_mode].blank? && mode == "signed"), data: { action: "csv-mapping#change", csv_mapping_target: "radio" } %>
+          <%= mode.humanize %>
+        </label>
+      <% end %>
+
+      <div data-csv-mapping-target="signed">
+        <p>
+          <%= mapping_form.label :amount_column, "Amount column (signed: negative = expense)" %><br>
+          <%= mapping_form.select :amount_column, header_options, { include_blank: "—" }, selected: mappings[:amount_column] %>
+        </p>
+      </div>
+
+      <div data-csv-mapping-target="debitCredit">
+        <p>
+          <%= mapping_form.label :debit_column, "Debit column (money out)" %><br>
+          <%= mapping_form.select :debit_column, header_options, { include_blank: "—" }, selected: mappings[:debit_column] %>
+        </p>
+        <p>
+          <%= mapping_form.label :credit_column, "Credit column (money in)" %><br>
+          <%= mapping_form.select :credit_column, header_options, { include_blank: "—" }, selected: mappings[:credit_column] %>
+        </p>
+      </div>
+
+      <div data-csv-mapping-target="signIndicator">
+        <p>
+          <%= mapping_form.label :sign_column, "Sign indicator column" %><br>
+          <%= mapping_form.select :sign_column, header_options, { include_blank: "—" }, selected: mappings[:sign_column] %>
+        </p>
+        <p>
+          <%= mapping_form.label :debit_values, "Values that mean money out (comma-separated)" %><br>
+          <%= mapping_form.text_field :debit_values, value: Array(mappings[:debit_values]).join(", "), placeholder: "DEBIT, ACH_DEBIT" %>
+        </p>
+      </div>
+    </fieldset>
+
+    <p>
+      <%= mapping_form.label :skip_rows, "Skip the first N data rows" %><br>
+      <%= mapping_form.number_field :skip_rows, value: mappings[:skip_rows] || 0, min: 0 %>
+    </p>
+  <% end %>
+
+  <p><%= form.submit "Save mapping" %></p>
+<% end %>
+
+<% if can_confirm %>
+  <p>Mapping saved. <%= link_to "Continue to Step 3 →", confirm_account_csv_import_path(@account, @csv_import) %></p>
+<% end %>

--- a/app/views/csv/imports/show.html.erb
+++ b/app/views/csv/imports/show.html.erb
@@ -1,4 +1,3 @@
-<% require "ostruct" %>
 <% mappings = @csv_import.column_mappings.with_indifferent_access %>
 <% headers = (@preview && @preview[:headers]) || [] %>
 <% raw_rows = (@preview && @preview[:raw_rows]) || [] %>

--- a/app/views/csv/imports/show.html.erb
+++ b/app/views/csv/imports/show.html.erb
@@ -151,6 +151,14 @@
           <%= mapping_form.text_field :debit_values, value: Array(mappings[:debit_values]).join(", "), placeholder: "DEBIT, ACH_DEBIT" %>
         </p>
       </div>
+
+      <p>
+        <label>
+          <%= mapping_form.check_box :invert_amount, { checked: ActiveModel::Type::Boolean.new.cast(mappings[:invert_amount]) }, "1", "0" %>
+          Invert sign
+        </label><br>
+        <small>Check this if the file uses the bank-statement convention where a credit card purchase is positive and a payment is negative. Flipping it back makes the importer treat purchases as expenses and payments as incoming transfers.</small>
+      </p>
     </fieldset>
 
     <p>

--- a/app/views/csv/imports/show.html.erb
+++ b/app/views/csv/imports/show.html.erb
@@ -6,8 +6,7 @@
 <h1>CSV Import — <%= @account.name %></h1>
 
 <p>
-  <%= link_to "Back to imports", account_csv_imports_path(@account) %>
-  ·
+  <%= link_to "Back to imports", account_csv_imports_path(@account) %> |
   <%= link_to "Account transactions", account_transactions_path(@account) %>
 </p>
 

--- a/app/views/csv/imports/show.html.erb
+++ b/app/views/csv/imports/show.html.erb
@@ -1,7 +1,7 @@
 <% mappings = @csv_import.column_mappings.with_indifferent_access %>
 <% headers = (@preview && @preview[:headers]) || [] %>
 <% raw_rows = (@preview && @preview[:raw_rows]) || [] %>
-<% can_confirm = !@csv_import.pending? && @csv_import.column_mappings.present? %>
+<% can_confirm = @csv_import.mappings_complete? && !@csv_import.pending? %>
 
 <h1>CSV Import — <%= @account.name %></h1>
 

--- a/app/views/integrations/show.html.erb
+++ b/app/views/integrations/show.html.erb
@@ -1,5 +1,7 @@
 <h1>Integrations</h1>
 
+<p><%= link_to "CSV Imports →", csv_imports_path %> — past CSV uploads across all your accounts. Start a new one from any account's transactions page.</p>
+
 <h2>Connections</h2>
 <table>
   <tr>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -9,6 +9,9 @@
   <% else %>
     <%= link_to "Show excluded transactions", "#{base_path}?show_excluded=1" %>
   <% end %>
+  <% if @account&.real? %>
+    · <%= link_to "Import CSV", account_csv_imports_path(@account) %>
+  <% end %>
 </div>
 
 <div data-controller="transactions--merge" data-transactions--merge-merge-url-value="<%= merge_transactions_path %>">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -10,7 +10,7 @@
     <%= link_to "Show excluded transactions", "#{base_path}?show_excluded=1" %>
   <% end %>
   <% if @account&.real? %>
-    · <%= link_to "Import CSV", account_csv_imports_path(@account) %>
+    | <%= link_to "Import CSV", account_csv_imports_path(@account) %>
   <% end %>
 </div>
 

--- a/config/initializers/ostruct.rb
+++ b/config/initializers/ostruct.rb
@@ -1,0 +1,5 @@
+# OpenStruct is no longer autoloaded as of Ruby 3.5 / Rails 8.1, but it's used
+# from at least one view (app/views/csv/imports/show.html.erb) to wrap the
+# stored column_mappings hash for fields_for. Require it at boot so views and
+# controllers don't need to reach for a bare `require "ostruct"` themselves.
+require "ostruct"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@ Rails.application.routes.draw do
 
   resources :accounts do
     resources :transactions, only: %i[ index ]
+    resources :csv_imports, controller: "csv/imports", except: %i[ edit ] do
+      member do
+        get :confirm
+        post :parse
+      end
+    end
   end
   resources :import_rules, except: %i[ show ] do
     collection do
@@ -57,6 +63,11 @@ Rails.application.routes.draw do
         post :refresh
       end
     end
+  end
+
+  # User-wide index of CSV imports (per-account routes nested under accounts above)
+  namespace :csv do
+    resources :imports, only: %i[ index ]
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20260505160531_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260505160531_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/migrate/20260505160544_create_csv_imports.rb
+++ b/db/migrate/20260505160544_create_csv_imports.rb
@@ -1,0 +1,17 @@
+class CreateCsvImports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :csv_imports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :account, null: false, foreign_key: true
+      t.string :state, null: false, default: "pending"
+      t.jsonb :column_mappings, null: false, default: {}
+      t.datetime :parsed_at
+      t.datetime :imported_at
+      t.text :error
+
+      t.timestamps
+    end
+
+    add_index :csv_imports, [ :account_id, :created_at ]
+  end
+end

--- a/db/migrate/20260505160556_create_csv_transactions.rb
+++ b/db/migrate/20260505160556_create_csv_transactions.rb
@@ -1,0 +1,19 @@
+class CreateCsvTransactions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :csv_transactions do |t|
+      t.references :import, null: false, foreign_key: { to_table: :csv_imports }
+      t.integer :row_index, null: false
+      t.datetime :transacted_at, null: false
+      t.datetime :posted_at
+      t.string :description, null: false, default: ""
+      t.integer :amount_minor, null: false
+      t.datetime :synced_at
+      t.jsonb :raw, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :csv_transactions, [ :import_id, :row_index ], unique: true
+    add_index :csv_transactions, :synced_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_164216) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_160556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_164216) do
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "categories", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "icon"
@@ -47,6 +75,37 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_164216) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_categories_on_user_id"
+  end
+
+  create_table "csv_imports", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.jsonb "column_mappings", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.text "error"
+    t.datetime "imported_at"
+    t.datetime "parsed_at"
+    t.string "state", default: "pending", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["account_id", "created_at"], name: "index_csv_imports_on_account_id_and_created_at"
+    t.index ["account_id"], name: "index_csv_imports_on_account_id"
+    t.index ["user_id"], name: "index_csv_imports_on_user_id"
+  end
+
+  create_table "csv_transactions", force: :cascade do |t|
+    t.integer "amount_minor", null: false
+    t.datetime "created_at", null: false
+    t.string "description", default: "", null: false
+    t.bigint "import_id", null: false
+    t.datetime "posted_at"
+    t.jsonb "raw", default: {}, null: false
+    t.integer "row_index", null: false
+    t.datetime "synced_at"
+    t.datetime "transacted_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["import_id", "row_index"], name: "index_csv_transactions_on_import_id_and_row_index", unique: true
+    t.index ["import_id"], name: "index_csv_transactions_on_import_id"
+    t.index ["synced_at"], name: "index_csv_transactions_on_synced_at"
   end
 
   create_table "currencies", force: :cascade do |t|
@@ -231,7 +290,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_164216) do
   add_foreign_key "account_sources", "accounts"
   add_foreign_key "accounts", "currencies"
   add_foreign_key "accounts", "users"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "users"
+  add_foreign_key "csv_imports", "accounts"
+  add_foreign_key "csv_imports", "users"
+  add_foreign_key "csv_transactions", "csv_imports", column: "import_id"
   add_foreign_key "import_rules", "accounts"
   add_foreign_key "import_rules", "users"
   add_foreign_key "lunchflow_accounts", "lunchflow_connections", column: "connection_id"

--- a/test/controllers/csv/imports_controller_test.rb
+++ b/test/controllers/csv/imports_controller_test.rb
@@ -90,6 +90,23 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "DEBIT", "ACH_DEBIT" ], csv_import.column_mappings["debit_values"]
   end
 
+  test "PATCH update casts invert_amount to a boolean" do
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
+    patch account_csv_import_url(@account, csv_import), params: {
+      csv_import: { column_mappings: { date_column: "Date", amount_mode: "signed", amount_column: "Amount", invert_amount: "1" } }
+    }
+    csv_import.reload
+    assert_equal true, csv_import.column_mappings["invert_amount"]
+
+    patch account_csv_import_url(@account, csv_import), params: {
+      csv_import: { column_mappings: { date_column: "Date", amount_mode: "signed", amount_column: "Amount", invert_amount: "0" } }
+    }
+    csv_import.reload
+    assert_equal false, csv_import.column_mappings["invert_amount"]
+  end
+
   test "PATCH update tolerates a request body with no column_mappings" do
     csv_import = build_csv_import(state: "pending")
     csv_import.save!

--- a/test/controllers/csv/imports_controller_test.rb
+++ b/test/controllers/csv/imports_controller_test.rb
@@ -1,0 +1,168 @@
+require "test_helper"
+
+class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @other_user = users(:two)
+    @account = accounts(:asset_account)
+    sign_in @user
+  end
+
+  test "redirects unauthenticated requests" do
+    sign_out @user
+    get account_csv_imports_url(@account)
+    assert_redirected_to new_user_session_url
+  end
+
+  test "GET account index shows the account's imports" do
+    get account_csv_imports_url(@account)
+    assert_response :success
+  end
+
+  test "GET top-level index lists imports across all the user's accounts" do
+    get csv_imports_url
+    assert_response :success
+  end
+
+  test "cannot view imports on another user's account" do
+    other_account = accounts(:two)
+    get account_csv_imports_url(other_account)
+    assert_response :not_found
+  end
+
+  test "POST create attaches the file and redirects to show" do
+    file = fixture_file_upload_csv("Date,Description,Amount\n2026-01-15,Coffee,-4.75\n")
+
+    assert_difference "Csv::Import.count", 1 do
+      post account_csv_imports_url(@account), params: { csv_import: { file: file } }
+    end
+    csv_import = Csv::Import.last
+    assert_equal @user, csv_import.user
+    assert_equal @account, csv_import.account
+    assert csv_import.file.attached?
+    assert_redirected_to account_csv_import_url(@account, csv_import)
+  end
+
+  test "POST create defaults column_mappings to the most recent prior import for the account" do
+    prior_mappings = {
+      "date_column" => "Date",
+      "amount_mode" => "signed",
+      "amount_column" => "Amount",
+      "description_columns" => [ "Description" ]
+    }
+    Csv::Import.create!(user: @user, account: @account, state: "imported", column_mappings: prior_mappings)
+
+    file = fixture_file_upload_csv("Date,Description,Amount\n2026-01-15,Coffee,-4.75\n")
+    post account_csv_imports_url(@account), params: { csv_import: { file: file } }
+
+    csv_import = Csv::Import.last
+    assert_equal prior_mappings, csv_import.column_mappings
+  end
+
+  test "PATCH update saves the mapping and marks state as mapped" do
+    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+
+    patch account_csv_import_url(@account, csv_import), params: {
+      csv_import: {
+        column_mappings: {
+          date_column: "Date",
+          amount_mode: "signed",
+          amount_column: "Amount",
+          description_columns: [ "Description" ],
+          debit_values: "DEBIT, ACH_DEBIT"
+        }
+      }
+    }
+    assert_redirected_to confirm_account_csv_import_url(@account, csv_import)
+    csv_import.reload
+    assert_equal "mapped", csv_import.state
+    assert_equal "Date", csv_import.column_mappings["date_column"]
+    assert_equal [ "DEBIT", "ACH_DEBIT" ], csv_import.column_mappings["debit_values"]
+  end
+
+  test "GET confirm renders the parsed preview" do
+    csv_import = Csv::Import.create!(
+      user: @user,
+      account: @account,
+      state: "mapped",
+      column_mappings: {
+        "date_column" => "Date",
+        "amount_mode" => "signed",
+        "amount_column" => "Amount",
+        "description_columns" => [ "Description" ]
+      }
+    )
+    csv_import.file.attach(fixture_file_upload_csv("Date,Description,Amount\n2026-01-15,Coffee,-4.75\n"))
+
+    get confirm_account_csv_import_url(@account, csv_import)
+    assert_response :success
+    assert_match "Step 3: Confirm and import", response.body
+    assert_match "Coffee", response.body
+  end
+
+  test "GET confirm redirects to mapping when state is pending" do
+    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    get confirm_account_csv_import_url(@account, csv_import)
+    assert_redirected_to account_csv_import_url(@account, csv_import)
+  end
+
+  test "POST parse enqueues ParseJob once a mapping is saved" do
+    csv_import = Csv::Import.create!(
+      user: @user,
+      account: @account,
+      state: "mapped",
+      column_mappings: { "date_column" => "Date", "amount_mode" => "signed", "amount_column" => "Amount" }
+    )
+
+    assert_enqueued_with(job: Csv::ParseJob, args: [ csv_import.id ]) do
+      post parse_account_csv_import_url(@account, csv_import)
+    end
+    assert_redirected_to account_csv_import_url(@account, csv_import)
+  end
+
+  test "POST parse refuses to enqueue when the import is still pending" do
+    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    assert_no_enqueued_jobs only: Csv::ParseJob do
+      post parse_account_csv_import_url(@account, csv_import)
+    end
+  end
+
+  test "DELETE destroys the import" do
+    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    assert_difference "Csv::Import.count", -1 do
+      delete account_csv_import_url(@account, csv_import)
+    end
+  end
+
+  test "GET show pre-checks saved description_columns checkboxes" do
+    csv_import = Csv::Import.create!(
+      user: @user,
+      account: @account,
+      state: "mapped",
+      column_mappings: {
+        "date_column" => "Date",
+        "amount_mode" => "signed",
+        "amount_column" => "Amount",
+        "description_columns" => [ "Description", "Memo" ]
+      }
+    )
+    csv_import.file.attach(fixture_file_upload_csv(<<~CSV))
+      Date,Description,Memo,Amount
+      2026-01-15,Coffee,Latte,-4.75
+    CSV
+
+    get account_csv_import_url(@account, csv_import)
+    assert_response :success
+    assert_match %r{<input[^>]*value="Description"[^>]*checked="checked"|<input[^>]*checked="checked"[^>]*value="Description"}, response.body
+    assert_match %r{<input[^>]*value="Memo"[^>]*checked="checked"|<input[^>]*checked="checked"[^>]*value="Memo"}, response.body
+    assert_no_match %r{<input[^>]*value="Date"[^>]*name="csv_import\[column_mappings\]\[description_columns\]\[\]"[^>]*checked="checked"}, response.body
+  end
+
+  private
+
+    def fixture_file_upload_csv(content)
+      Rack::Test::UploadedFile.new(StringIO.new(content), "text/csv", original_filename: "test.csv")
+    end
+end

--- a/test/controllers/csv/imports_controller_test.rb
+++ b/test/controllers/csv/imports_controller_test.rb
@@ -159,6 +159,80 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET new renders the upload form" do
+    get new_account_csv_import_url(@account)
+    assert_response :success
+  end
+
+  test "PATCH update re-renders show with errors when validation fails" do
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+    csv_import.file.purge
+
+    patch account_csv_import_url(@account, csv_import), params: {
+      csv_import: { column_mappings: { date_column: "Date", amount_mode: "signed", amount_column: "Amount" } }
+    }
+    assert_response :unprocessable_entity
+  end
+
+  test "GET show with debit_credit mappings renders the mapped preview" do
+    csv_import = build_csv_import(
+      state: "mapped",
+      column_mappings: {
+        "date_column" => "Date",
+        "amount_mode" => "debit_credit",
+        "debit_column" => "Debit",
+        "credit_column" => "Credit",
+        "description_columns" => [ "Description" ]
+      },
+      content: "Date,Description,Debit,Credit\n2026-01-15,Coffee,4.75,\n"
+    )
+    csv_import.save!
+
+    get account_csv_import_url(@account, csv_import)
+    assert_response :success
+  end
+
+  test "GET show with an unknown amount_mode renders without a parsed preview" do
+    csv_import = build_csv_import(
+      state: "mapped",
+      column_mappings: { "date_column" => "Date", "amount_mode" => "garbage" }
+    )
+    csv_import.save!
+
+    get account_csv_import_url(@account, csv_import)
+    assert_response :success
+    assert_no_match "Mapped preview", response.body
+  end
+
+  test "GET show falls back to an empty raw preview when raw parsing raises a malformed CSV error" do
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
+    Csv::Parser.stub(:raw_preview, ->(*) { raise ::CSV::MalformedCSVError.new("Unquoted fields", 1) }) do
+      get account_csv_import_url(@account, csv_import)
+    end
+    assert_response :success
+  end
+
+  test "GET show surfaces parser RowError as a preview error message" do
+    csv_import = build_csv_import(
+      state: "mapped",
+      column_mappings: {
+        "date_column" => "Date",
+        "amount_mode" => "signed",
+        "amount_column" => "Amount",
+        "description_columns" => [ "Description" ]
+      },
+      content: "Date,Description,Amount\nnot a date,Coffee,-1.00\n"
+    )
+    csv_import.save!
+
+    get account_csv_import_url(@account, csv_import)
+    assert_response :success
+    assert_match "Preview error", response.body
+  end
+
   test "GET show pre-checks saved description_columns checkboxes" do
     csv_import = build_csv_import(
       state: "mapped",

--- a/test/controllers/csv/imports_controller_test.rb
+++ b/test/controllers/csv/imports_controller_test.rb
@@ -167,6 +167,32 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "POST parse refuses to enqueue when the saved mapping is incomplete" do
+    csv_import = build_csv_import(
+      state: "mapped",
+      column_mappings: { "date_column" => "Date" } # missing amount_mode/columns
+    )
+    csv_import.save!
+
+    assert_no_enqueued_jobs only: Csv::ParseJob do
+      post parse_account_csv_import_url(@account, csv_import)
+    end
+    assert_redirected_to account_csv_import_url(@account, csv_import)
+    follow_redirect!
+    assert_match "Save a complete column mapping", response.body
+  end
+
+  test "GET confirm redirects to mapping when column_mappings are incomplete" do
+    csv_import = build_csv_import(
+      state: "mapped",
+      column_mappings: { "date_column" => "Date" } # missing amount_mode/columns
+    )
+    csv_import.save!
+
+    get confirm_account_csv_import_url(@account, csv_import)
+    assert_redirected_to account_csv_import_url(@account, csv_import)
+  end
+
   test "DELETE destroys the import" do
     csv_import = build_csv_import(state: "pending")
     csv_import.save!

--- a/test/controllers/csv/imports_controller_test.rb
+++ b/test/controllers/csv/imports_controller_test.rb
@@ -45,6 +45,13 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to account_csv_import_url(@account, csv_import)
   end
 
+  test "POST create rejects an upload with no file" do
+    assert_no_difference "Csv::Import.count" do
+      post account_csv_imports_url(@account), params: { csv_import: { file: nil } }
+    end
+    assert_response :unprocessable_entity
+  end
+
   test "POST create defaults column_mappings to the most recent prior import for the account" do
     prior_mappings = {
       "date_column" => "Date",
@@ -52,7 +59,7 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
       "amount_column" => "Amount",
       "description_columns" => [ "Description" ]
     }
-    Csv::Import.create!(user: @user, account: @account, state: "imported", column_mappings: prior_mappings)
+    build_csv_import(state: "imported", column_mappings: prior_mappings).save!
 
     file = fixture_file_upload_csv("Date,Description,Amount\n2026-01-15,Coffee,-4.75\n")
     post account_csv_imports_url(@account), params: { csv_import: { file: file } }
@@ -62,7 +69,8 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "PATCH update saves the mapping and marks state as mapped" do
-    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
 
     patch account_csv_import_url(@account, csv_import), params: {
       csv_import: {
@@ -82,10 +90,20 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "DEBIT", "ACH_DEBIT" ], csv_import.column_mappings["debit_values"]
   end
 
+  test "PATCH update tolerates a request body with no column_mappings" do
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
+    patch account_csv_import_url(@account, csv_import), params: { csv_import: {} }
+    csv_import.reload
+    assert_equal "mapped", csv_import.state
+    # Default no-op mapping; the existing reject(&:blank?) normalizes the
+    # description_columns array to empty rather than dropping the key.
+    assert_equal({ "description_columns" => [] }, csv_import.column_mappings)
+  end
+
   test "GET confirm renders the parsed preview" do
-    csv_import = Csv::Import.create!(
-      user: @user,
-      account: @account,
+    csv_import = build_csv_import(
       state: "mapped",
       column_mappings: {
         "date_column" => "Date",
@@ -94,7 +112,7 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
         "description_columns" => [ "Description" ]
       }
     )
-    csv_import.file.attach(fixture_file_upload_csv("Date,Description,Amount\n2026-01-15,Coffee,-4.75\n"))
+    csv_import.save!
 
     get confirm_account_csv_import_url(@account, csv_import)
     assert_response :success
@@ -103,18 +121,19 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "GET confirm redirects to mapping when state is pending" do
-    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
     get confirm_account_csv_import_url(@account, csv_import)
     assert_redirected_to account_csv_import_url(@account, csv_import)
   end
 
   test "POST parse enqueues ParseJob once a mapping is saved" do
-    csv_import = Csv::Import.create!(
-      user: @user,
-      account: @account,
+    csv_import = build_csv_import(
       state: "mapped",
       column_mappings: { "date_column" => "Date", "amount_mode" => "signed", "amount_column" => "Amount" }
     )
+    csv_import.save!
 
     assert_enqueued_with(job: Csv::ParseJob, args: [ csv_import.id ]) do
       post parse_account_csv_import_url(@account, csv_import)
@@ -123,35 +142,35 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "POST parse refuses to enqueue when the import is still pending" do
-    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
     assert_no_enqueued_jobs only: Csv::ParseJob do
       post parse_account_csv_import_url(@account, csv_import)
     end
   end
 
   test "DELETE destroys the import" do
-    csv_import = Csv::Import.create!(user: @user, account: @account, state: "pending")
+    csv_import = build_csv_import(state: "pending")
+    csv_import.save!
+
     assert_difference "Csv::Import.count", -1 do
       delete account_csv_import_url(@account, csv_import)
     end
   end
 
   test "GET show pre-checks saved description_columns checkboxes" do
-    csv_import = Csv::Import.create!(
-      user: @user,
-      account: @account,
+    csv_import = build_csv_import(
       state: "mapped",
       column_mappings: {
         "date_column" => "Date",
         "amount_mode" => "signed",
         "amount_column" => "Amount",
         "description_columns" => [ "Description", "Memo" ]
-      }
+      },
+      content: "Date,Description,Memo,Amount\n2026-01-15,Coffee,Latte,-4.75\n"
     )
-    csv_import.file.attach(fixture_file_upload_csv(<<~CSV))
-      Date,Description,Memo,Amount
-      2026-01-15,Coffee,Latte,-4.75
-    CSV
+    csv_import.save!
 
     get account_csv_import_url(@account, csv_import)
     assert_response :success
@@ -164,5 +183,20 @@ class Csv::ImportsControllerTest < ActionDispatch::IntegrationTest
 
     def fixture_file_upload_csv(content)
       Rack::Test::UploadedFile.new(StringIO.new(content), "text/csv", original_filename: "test.csv")
+    end
+
+    def build_csv_import(state:, column_mappings: {}, content: "Date,Description,Amount\n2026-01-15,Coffee,-4.75\n")
+      csv_import = Csv::Import.new(
+        user: @user,
+        account: @account,
+        state: state,
+        column_mappings: column_mappings
+      )
+      csv_import.file.attach(
+        io: StringIO.new(content),
+        filename: "test.csv",
+        content_type: "text/csv"
+      )
+      csv_import
     end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -90,9 +90,14 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "Lunch Flow", source_badge_label(lunchflow_accounts(:linked_one))
   end
 
+  test "source_badge_label labels CSV sources as CSV (not Csv::Transaction)" do
+    csv_transaction = Csv::Transaction.new
+    assert_equal "CSV", source_badge_label(csv_transaction)
+  end
+
   test "source_badge_label falls back to the class name for unknown sourceable types" do
     # Currency isn't a registered aggregator type but stands in for any future
-    # source class (CSV/OFX, etc.) so the fallback can't silently render empty.
+    # source class (OFX, etc.) so the fallback can't silently render empty.
     assert_equal "Currency", source_badge_label(currencies(:usd))
   end
 
@@ -104,6 +109,10 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "source_badge_modifier returns the Lunch Flow modifier class" do
     assert_equal "source-badge--lunchflow", source_badge_modifier(lunchflow_accounts(:linked_one))
+  end
+
+  test "source_badge_modifier returns the CSV modifier class" do
+    assert_equal "source-badge--csv", source_badge_modifier(Csv::Transaction.new)
   end
 
   test "source_badge_modifier returns nil for unknown sourceable types" do

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -206,6 +206,25 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
     end
   end
 
+  test "imports a row whose description is blank without crashing" do
+    csv_import = create_csv_import
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "",
+      amount_minor: -475,
+      synced_at: Time.current
+    )
+
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+    transaction = Transaction.last
+    assert_equal "(no description)", transaction.description
+    assert_equal "(no description)", transaction.dest_account.name
+    assert_equal "imported", csv_import.reload.state
+  end
+
   test "imports two distinct rows from the same CSV that share amount/day/description" do
     csv_import = create_csv_import
     same_at = 1.day.ago.beginning_of_day + 12.hours

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -156,6 +156,13 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
   private
 
     def create_csv_import
-      Csv::Import.create!(user: @user, account: @bank_account, state: "parsed")
+      csv_import = Csv::Import.new(user: @user, account: @bank_account, state: "parsed")
+      csv_import.file.attach(
+        io: StringIO.new("Date,Description,Amount\n"),
+        filename: "stub.csv",
+        content_type: "text/csv"
+      )
+      csv_import.save!
+      csv_import
     end
 end

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -72,6 +72,59 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
     end
   end
 
+  test "re-syncs scalars on the canonical ledger transaction when csv_transaction synced_at advances" do
+    csv_import = create_csv_import
+    csv_transaction = csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: 2.days.ago
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    ledger_transaction = csv_transaction.ledger_transactions.first
+    assert_equal 475, ledger_transaction.amount_minor
+
+    # The user re-uploads / re-parses with a corrected amount; the synced_at on
+    # the csv_transaction advances past the ledger transaction's synced_at.
+    csv_transaction.update!(amount_minor: -500, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+
+    ledger_transaction.reload
+    assert_equal 500, ledger_transaction.amount_minor
+  end
+
+  test "secondary csv source skips canonical re-sync but still bumps ledger synced_at" do
+    csv_import = create_csv_import
+    csv_transaction = csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: 2.days.ago
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    ledger_transaction = csv_transaction.ledger_transactions.first
+
+    # Attach a *second* csv source representing the same transaction. The
+    # canonical (older) source remains, so the second source must not overwrite
+    # canonical scalars when its synced_at advances.
+    secondary = csv_import.transactions.create!(
+      row_index: 1,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -999,
+      synced_at: Time.current
+    )
+    TransactionSource.create!(ledger_transaction: ledger_transaction, sourceable: secondary)
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    ledger_transaction.reload
+    assert_equal 475, ledger_transaction.amount_minor
+  end
+
   test "applies an import rule that routes to a non-balance-sheet account" do
     csv_import = create_csv_import
     rule_account = Account.create!(user: @user, currency: @currency, name: "Groceries", kind: :expense)
@@ -150,6 +203,24 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
   test "no-ops when the import does not exist" do
     assert_nothing_raised do
       Csv::ImportTransactionsJob.perform_now(0)
+    end
+  end
+
+  test "skips a row cleanly when TransactionSource::Attach raises MismatchedTransaction during create" do
+    csv_import = create_csv_import
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: Time.current
+    )
+
+    raise_mismatch = ->(*) { raise TransactionSource::Attach::MismatchedTransaction, "concurrent attach" }
+    TransactionSource::Attach.stub(:call, raise_mismatch) do
+      assert_no_difference "Transaction.count" do
+        Csv::ImportTransactionsJob.perform_now(csv_import.id)
+      end
     end
   end
 

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -1,0 +1,161 @@
+require "test_helper"
+
+class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @bank_account = accounts(:asset_account)
+  end
+
+  test "imports an expense (negative amount_minor)" do
+    csv_import = create_csv_import
+    csv_transaction = csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 2.days.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: Time.current,
+      raw: { "Date" => "2026-01-15", "Description" => "Coffee Shop", "Amount" => "-4.75" }
+    )
+
+    assert_difference "Transaction.count", 1 do
+      assert_difference "Account.count", 1 do # auto-created expense counterpart
+        Csv::ImportTransactionsJob.perform_now(csv_import.id)
+      end
+    end
+
+    transaction = csv_transaction.ledger_transactions.first
+    assert_equal @bank_account, transaction.src_account
+    assert_equal "Coffee Shop", transaction.dest_account.name
+    assert_equal "expense", transaction.dest_account.kind
+    assert_equal 475, transaction.amount_minor
+    assert_equal @currency, transaction.currency
+
+    assert_equal "imported", csv_import.reload.state
+    assert_not_nil csv_import.imported_at
+  end
+
+  test "imports a revenue (positive amount_minor)" do
+    csv_import = create_csv_import
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Salary Payment",
+      amount_minor: 250000,
+      synced_at: Time.current
+    )
+
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+
+    transaction = Transaction.last
+    assert_equal @bank_account, transaction.dest_account
+    assert_equal "Salary Payment", transaction.src_account.name
+    assert_equal "revenue", transaction.src_account.kind
+    assert_equal 250000, transaction.amount_minor
+  end
+
+  test "does not re-create a ledger transaction when re-running with no synced_at change" do
+    csv_import = create_csv_import
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: Time.current
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+  end
+
+  test "applies an import rule that routes to a non-balance-sheet account" do
+    csv_import = create_csv_import
+    rule_account = Account.create!(user: @user, currency: @currency, name: "Groceries", kind: :expense)
+    @user.import_rules.create!(match_pattern: "MARKET", match_type: :contains, priority: 0, account: rule_account)
+
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "FARMERS MARKET",
+      amount_minor: -1500,
+      synced_at: Time.current
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    transaction = Transaction.last
+    assert_equal rule_account, transaction.dest_account
+    assert_equal @bank_account, transaction.src_account
+  end
+
+  test "excludes a transaction when an exclude rule matches" do
+    csv_import = create_csv_import
+    @user.import_rules.create!(match_pattern: "INTERNAL", match_type: :contains, priority: 0, exclude: true)
+
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "INTERNAL TRANSFER",
+      amount_minor: -2000,
+      synced_at: Time.current
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    transaction = Transaction.last
+    assert transaction.excluded?
+  end
+
+  test "reconciles to an existing manual ledger transaction with matching description" do
+    csv_import = create_csv_import
+    counterpart = Account.create!(user: @user, currency: @currency, name: "Coffee Shop", kind: :expense)
+
+    manual_transaction = Transaction.create!(
+      user: @user,
+      currency: @currency,
+      src_account: @bank_account,
+      dest_account: counterpart,
+      description: "Coffee Shop",
+      amount_minor: 475,
+      transacted_at: 1.day.ago.beginning_of_day + 12.hours
+    )
+
+    csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago.beginning_of_day + 12.hours,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: Time.current
+    )
+
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+
+    manual_transaction.reload
+    assert_includes manual_transaction.transaction_sources.map(&:sourceable_type), "Csv::Transaction"
+    assert_not_nil manual_transaction.synced_at
+  end
+
+  test "no-ops when the import has no rows" do
+    csv_import = create_csv_import
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+    assert_equal "imported", csv_import.reload.state
+  end
+
+  test "no-ops when the import does not exist" do
+    assert_nothing_raised do
+      Csv::ImportTransactionsJob.perform_now(0)
+    end
+  end
+
+  private
+
+    def create_csv_import
+      Csv::Import.create!(user: @user, account: @bank_account, state: "parsed")
+    end
+end

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -206,6 +206,40 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
     end
   end
 
+  test "imports two distinct rows from the same CSV that share amount/day/description" do
+    csv_import = create_csv_import
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    csv_import.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee", amount_minor: -475, synced_at: Time.current)
+    csv_import.transactions.create!(row_index: 1, transacted_at: same_at, description: "Coffee", amount_minor: -475, synced_at: Time.current)
+
+    assert_difference "Transaction.count", 2 do
+      Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    end
+  end
+
+  test "swaps src/dest on re-import when the sign flips (e.g. user toggled invert_amount)" do
+    csv_import = create_csv_import
+    csv_transaction = csv_import.transactions.create!(
+      row_index: 0,
+      transacted_at: 1.day.ago,
+      description: "Coffee Shop",
+      amount_minor: -475,
+      synced_at: 2.days.ago
+    )
+
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+    ledger_transaction = csv_transaction.ledger_transactions.first
+    assert_equal @bank_account, ledger_transaction.src_account, "ledger_account starts as src for negative amount"
+
+    # User toggles invert_amount; sign flips, synced_at advances.
+    csv_transaction.update!(amount_minor: 475, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(csv_import.id)
+
+    ledger_transaction.reload
+    assert_equal @bank_account, ledger_transaction.dest_account, "ledger_account moves to dest after sign flip"
+    assert_equal 475, ledger_transaction.amount_minor
+  end
+
   test "skips a row cleanly when TransactionSource::Attach raises MismatchedTransaction during create" do
     csv_import = create_csv_import
     csv_import.transactions.create!(

--- a/test/jobs/csv/parse_job_test.rb
+++ b/test/jobs/csv/parse_job_test.rb
@@ -83,6 +83,20 @@ class Csv::ParseJobTest < ActiveJob::TestCase
     end
   end
 
+  test "marks the import as failed and re-raises on an unexpected error" do
+    csv_import = build_csv_import_with_file("Date,Description,Amount\n2026-01-15,Coffee,-1.00\n")
+
+    Csv::Parser.stub_any_instance(:each_row, ->(*) { raise StandardError, "boom" }) do
+      assert_raises(StandardError) do
+        Csv::ParseJob.perform_now(csv_import.id)
+      end
+    end
+
+    csv_import.reload
+    assert_equal "failed", csv_import.state
+    assert_match(/boom/, csv_import.error)
+  end
+
   private
 
     def signed_mappings

--- a/test/jobs/csv/parse_job_test.rb
+++ b/test/jobs/csv/parse_job_test.rb
@@ -51,15 +51,36 @@ class Csv::ParseJobTest < ActiveJob::TestCase
   end
 
   test "no-ops when the import has no attached file" do
-    csv_import = Csv::Import.create!(
-      user: @user,
-      account: @bank_account,
-      state: "mapped",
-      column_mappings: signed_mappings
-    )
+    csv_import = build_csv_import_with_file("")
+    csv_import.file.purge
+    csv_import.reload
     Csv::ParseJob.perform_now(csv_import.id)
     csv_import.reload
     assert_equal "mapped", csv_import.state
+  end
+
+  test "drops csv_transactions whose row_index is no longer produced after a re-parse with skip_rows" do
+    csv_import = build_csv_import_with_file(<<~CSV)
+      Date,Description,Amount
+      2026-01-15,Coffee,-4.75
+      2026-01-16,Refund,12.00
+      2026-01-17,Other,-3.00
+    CSV
+
+    Csv::ParseJob.perform_now(csv_import.id)
+    assert_equal [ 0, 1, 2 ], csv_import.transactions.order(:row_index).pluck(:row_index)
+
+    csv_import.update!(column_mappings: csv_import.column_mappings.merge("skip_rows" => 2))
+    Csv::ParseJob.perform_now(csv_import.id)
+    assert_equal [ 2 ], csv_import.transactions.order(:row_index).pluck(:row_index)
+  end
+
+  test "still enqueues ImportTransactionsJob when no rows are produced" do
+    csv_import = build_csv_import_with_file("Date,Description,Amount\n")
+
+    assert_enqueued_with(job: Csv::ImportTransactionsJob, args: [ csv_import.id ]) do
+      Csv::ParseJob.perform_now(csv_import.id)
+    end
   end
 
   private
@@ -74,7 +95,7 @@ class Csv::ParseJobTest < ActiveJob::TestCase
     end
 
     def build_csv_import_with_file(content, mappings: signed_mappings)
-      csv_import = Csv::Import.create!(
+      csv_import = Csv::Import.new(
         user: @user,
         account: @bank_account,
         state: "mapped",
@@ -85,6 +106,7 @@ class Csv::ParseJobTest < ActiveJob::TestCase
         filename: "test.csv",
         content_type: "text/csv"
       )
+      csv_import.save!
       csv_import
     end
 end

--- a/test/jobs/csv/parse_job_test.rb
+++ b/test/jobs/csv/parse_job_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Csv::ParseJobTest < ActiveJob::TestCase
+  setup do
+    @user = users(:one)
+    @bank_account = accounts(:asset_account)
+  end
+
+  test "parses rows from the attached file and enqueues the import job" do
+    csv_import = build_csv_import_with_file(<<~CSV)
+      Date,Description,Amount
+      2026-01-15,Coffee,-4.75
+      2026-01-16,Refund,12.00
+    CSV
+
+    assert_enqueued_with(job: Csv::ImportTransactionsJob) do
+      assert_difference "Csv::Transaction.count", 2 do
+        Csv::ParseJob.perform_now(csv_import.id)
+      end
+    end
+
+    csv_import.reload
+    assert_equal "parsed", csv_import.state
+    assert_not_nil csv_import.parsed_at
+    assert_nil csv_import.error
+  end
+
+  test "is idempotent on re-parse via (import_id, row_index) uniqueness" do
+    csv_import = build_csv_import_with_file(<<~CSV)
+      Date,Description,Amount
+      2026-01-15,Coffee,-4.75
+    CSV
+
+    Csv::ParseJob.perform_now(csv_import.id)
+    assert_no_difference "Csv::Transaction.count" do
+      Csv::ParseJob.perform_now(csv_import.id)
+    end
+  end
+
+  test "marks the import as failed when the CSV cannot be parsed" do
+    content = <<~CSV
+      Date,Description,Amount
+      not a date,Coffee,-4.75
+    CSV
+    csv_import = build_csv_import_with_file(content)
+
+    Csv::ParseJob.perform_now(csv_import.id)
+    csv_import.reload
+    assert_equal "failed", csv_import.state
+    assert_match(/could not parse date/, csv_import.error)
+  end
+
+  test "no-ops when the import has no attached file" do
+    csv_import = Csv::Import.create!(
+      user: @user,
+      account: @bank_account,
+      state: "mapped",
+      column_mappings: signed_mappings
+    )
+    Csv::ParseJob.perform_now(csv_import.id)
+    csv_import.reload
+    assert_equal "mapped", csv_import.state
+  end
+
+  private
+
+    def signed_mappings
+      {
+        "date_column" => "Date",
+        "amount_mode" => "signed",
+        "amount_column" => "Amount",
+        "description_columns" => [ "Description" ]
+      }
+    end
+
+    def build_csv_import_with_file(content, mappings: signed_mappings)
+      csv_import = Csv::Import.create!(
+        user: @user,
+        account: @bank_account,
+        state: "mapped",
+        column_mappings: mappings
+      )
+      csv_import.file.attach(
+        io: StringIO.new(content),
+        filename: "test.csv",
+        content_type: "text/csv"
+      )
+      csv_import
+    end
+end

--- a/test/models/csv/import_test.rb
+++ b/test/models/csv/import_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Csv::ImportTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @account = accounts(:asset_account)
+  end
+
+  test "is invalid when no file is attached" do
+    csv_import = Csv::Import.new(user: @user, account: @account, state: "pending")
+    assert_not csv_import.valid?
+    assert_includes csv_import.errors[:file], "must be attached"
+  end
+
+  test "is invalid when the attached file exceeds MAX_FILE_BYTES" do
+    csv_import = Csv::Import.new(user: @user, account: @account, state: "pending")
+    csv_import.file.attach(
+      io: StringIO.new("a"),
+      filename: "tiny.csv",
+      content_type: "text/csv"
+    )
+    csv_import.file.blob.update!(byte_size: Csv::Import::MAX_FILE_BYTES + 1)
+
+    assert_not csv_import.valid?
+    assert_match(/must be smaller than/, csv_import.errors[:file].first)
+  end
+
+  test "rejects an account belonging to another user" do
+    other_account = accounts(:two)
+    csv_import = Csv::Import.new(user: @user, account: other_account, state: "pending")
+    csv_import.file.attach(io: StringIO.new("Date,Description,Amount\n"), filename: "f.csv", content_type: "text/csv")
+    assert_not csv_import.valid?
+    assert_includes csv_import.errors[:account], "must belong to you"
+  end
+
+  test "rejects a virtual account" do
+    virtual = Account.create!(user: @user, name: "Opening Balance", kind: :revenue, virtual: true)
+    csv_import = Csv::Import.new(user: @user, account: virtual, state: "pending")
+    csv_import.file.attach(io: StringIO.new("Date,Description,Amount\n"), filename: "f.csv", content_type: "text/csv")
+    assert_not csv_import.valid?
+    assert_includes csv_import.errors[:account], "must be a real (non-virtual) account"
+  end
+end

--- a/test/models/csv/import_test.rb
+++ b/test/models/csv/import_test.rb
@@ -9,7 +9,7 @@ class Csv::ImportTest < ActiveSupport::TestCase
   test "is invalid when no file is attached" do
     csv_import = Csv::Import.new(user: @user, account: @account, state: "pending")
     assert_not csv_import.valid?
-    assert_includes csv_import.errors[:file], "must be attached"
+    assert_includes csv_import.errors[:file], "can't be blank"
   end
 
   test "is invalid when the attached file exceeds MAX_FILE_BYTES" do

--- a/test/services/csv/parser_test.rb
+++ b/test/services/csv/parser_test.rb
@@ -129,6 +129,25 @@ class Csv::ParserTest < ActiveSupport::TestCase
     assert_equal Time.utc(2026, 4, 13, 18, 0, 0), rows.first.transacted_at.utc
   end
 
+  test "tolerates a blank timezone cell mid-import by dropping the %Z token" do
+    content = <<~CSV
+      Date,Time,TimeZone,Description,Amount
+      04/13/2026,11:00:00,PDT,Coffee,-4.75
+      04/14/2026,12:00:00,,Refund,5.00
+    CSV
+    mappings = signed_mappings.merge(
+      date_format: "%m/%d/%Y %H:%M:%S",
+      time_column: "Time",
+      timezone_column: "TimeZone"
+    )
+    rows = parse(content, mappings: mappings, currency: @usd)
+    # First row has TZ → 11:00 PDT == 18:00 UTC.
+    assert_equal Time.utc(2026, 4, 13, 18, 0, 0), rows[0].transacted_at.utc
+    # Second row has no TZ; we want to keep the time and parse without %Z.
+    # Stored time-of-day is 12:00:00 in whatever zone DateTime defaults to.
+    assert_equal 12, rows[1].transacted_at.hour
+  end
+
   test "respects a user-supplied %Z token without auto-appending one" do
     content = "Date,TimeZone,Description,Amount\n04/13/2026,PST,Coffee,-4.75\n"
     mappings = signed_mappings.merge(

--- a/test/services/csv/parser_test.rb
+++ b/test/services/csv/parser_test.rb
@@ -197,6 +197,22 @@ class Csv::ParserTest < ActiveSupport::TestCase
     assert_raises(Csv::Parser::Error) { parser.each_row.to_a }
   end
 
+  test "raises when amount_mode is unknown" do
+    parser = Csv::Parser.new(
+      io: StringIO.new("Date,Description,Amount\n"),
+      mappings: { date_column: "Date", amount_mode: "bogus", amount_column: "Amount" },
+      currency: @usd
+    )
+    error = assert_raises(Csv::Parser::Error) { parser.each_row.to_a }
+    assert_match(/amount_mode must be one of/, error.message)
+  end
+
+  test "raises a RowError when an amount column value is not a number" do
+    content = "Date,Description,Amount\n2026-01-15,Coffee,abc\n"
+    error = assert_raises(Csv::Parser::RowError) { parse(content, mappings: signed_mappings, currency: @usd) }
+    assert_match(/could not parse/, error.message)
+  end
+
   private
 
     def parse(content, mappings:, currency:)

--- a/test/services/csv/parser_test.rb
+++ b/test/services/csv/parser_test.rb
@@ -1,0 +1,217 @@
+require "test_helper"
+
+class Csv::ParserTest < ActiveSupport::TestCase
+  setup do
+    @usd = currencies(:usd)
+    @jpy = currencies(:jpy)
+  end
+
+  test "signed mode parses negative as expense and positive as revenue" do
+    content = <<~CSV
+      Date,Description,Amount
+      2026-01-15,Coffee,-4.75
+      2026-01-16,Refund,12.00
+    CSV
+
+    rows = parse(content, mappings: signed_mappings, currency: @usd)
+    assert_equal 2, rows.size
+    assert_equal(-475, rows[0].amount_minor)
+    assert_equal "Coffee", rows[0].description
+    assert_equal Time.zone.local(2026, 1, 15), rows[0].transacted_at
+    assert_equal 1200, rows[1].amount_minor
+  end
+
+  test "signed mode strips dollar sign and commas" do
+    content = "Date,Description,Amount\n2026-01-15,Big buy,\"$1,234.56\"\n"
+    rows = parse(content, mappings: signed_mappings, currency: @usd)
+    assert_equal 123456, rows.first.amount_minor
+  end
+
+  test "signed mode treats parenthesized amounts as negative" do
+    content = "Date,Description,Amount\n2026-01-15,Charge,(75.00)\n"
+    rows = parse(content, mappings: signed_mappings, currency: @usd)
+    assert_equal(-7500, rows.first.amount_minor)
+  end
+
+  test "debit_credit mode picks debit as negative and credit as positive" do
+    content = <<~CSV
+      Date,Description,Debit,Credit
+      2026-01-15,Coffee,4.75,
+      2026-01-16,Deposit,,100.00
+    CSV
+    mappings = base_mappings.merge(amount_mode: "debit_credit", debit_column: "Debit", credit_column: "Credit")
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal(-475, rows[0].amount_minor)
+    assert_equal 10000, rows[1].amount_minor
+  end
+
+  test "debit_credit mode raises when both debit and credit are populated" do
+    content = "Date,Description,Debit,Credit\n2026-01-15,Bad,1.00,2.00\n"
+    mappings = base_mappings.merge(amount_mode: "debit_credit", debit_column: "Debit", credit_column: "Credit")
+    error = assert_raises(Csv::Parser::RowError) { parse(content, mappings: mappings, currency: @usd) }
+    assert_match(/both debit and credit/, error.message)
+  end
+
+  test "debit_credit mode raises when neither debit nor credit is populated" do
+    content = "Date,Description,Debit,Credit\n2026-01-15,Empty,,\n"
+    mappings = base_mappings.merge(amount_mode: "debit_credit", debit_column: "Debit", credit_column: "Credit")
+    assert_raises(Csv::Parser::RowError) { parse(content, mappings: mappings, currency: @usd) }
+  end
+
+  test "sign_indicator mode flips sign based on debit_values" do
+    content = <<~CSV
+      Date,Description,Type,Amount
+      2026-01-15,Coffee,DEBIT,4.75
+      2026-01-16,Deposit,CREDIT,100.00
+      2026-01-17,Withdrawal,ach_debit,20.00
+    CSV
+    mappings = base_mappings.merge(
+      amount_mode: "sign_indicator",
+      amount_column: "Amount",
+      sign_column: "Type",
+      debit_values: [ "DEBIT", "ACH_DEBIT" ]
+    )
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal(-475, rows[0].amount_minor)
+    assert_equal 10000, rows[1].amount_minor
+    assert_equal(-2000, rows[2].amount_minor) # case-insensitive match
+  end
+
+  test "uses date_format strftime when provided" do
+    content = "Date,Description,Amount\n02/15/2026,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(date_format: "%m/%d/%Y")
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal Time.zone.local(2026, 2, 15), rows.first.transacted_at
+  end
+
+  test "uses flexible date parsing when no date_format is provided" do
+    content = "Date,Description,Amount\n2026-02-15,Coffee,-4.75\n"
+    rows = parse(content, mappings: signed_mappings, currency: @usd)
+    assert_equal Time.zone.local(2026, 2, 15), rows.first.transacted_at
+  end
+
+  test "raises RowError on unparseable dates" do
+    content = "Date,Description,Amount\nnot a date,Coffee,-4.75\n"
+    error = assert_raises(Csv::Parser::RowError) { parse(content, mappings: signed_mappings, currency: @usd) }
+    assert_equal 0, error.row_index
+  end
+
+  test "falls back to date-only format when user-supplied format includes time tokens but column lacks them" do
+    content = "Date,Description,Amount\n04/13/2026,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(date_format: "%m/%d/%Y %H:%M:%S")
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal Time.zone.local(2026, 4, 13), rows.first.transacted_at
+  end
+
+  test "combines date_column and time_column when time_column is mapped" do
+    content = "Date,Time,Description,Amount\n04/13/2026,14:30:00,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(date_format: "%m/%d/%Y %H:%M:%S", time_column: "Time")
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal Time.zone.local(2026, 4, 13, 14, 30, 0), rows.first.transacted_at
+  end
+
+  test "tolerates blank time values when time_column is mapped" do
+    content = "Date,Time,Description,Amount\n04/13/2026,,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(date_format: "%m/%d/%Y %H:%M:%S", time_column: "Time")
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal Time.zone.local(2026, 4, 13), rows.first.transacted_at
+  end
+
+  test "applies the timezone abbreviation from timezone_column when mapped" do
+    content = "Date,Time,TimeZone,Description,Amount\n04/13/2026,11:00:00,PDT,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(
+      date_format: "%m/%d/%Y %H:%M:%S",
+      time_column: "Time",
+      timezone_column: "TimeZone"
+    )
+    rows = parse(content, mappings: mappings, currency: @usd)
+    # 11:00 PDT == 18:00 UTC (PDT is UTC-7)
+    assert_equal Time.utc(2026, 4, 13, 18, 0, 0), rows.first.transacted_at.utc
+  end
+
+  test "respects a user-supplied %Z token without auto-appending one" do
+    content = "Date,TimeZone,Description,Amount\n04/13/2026,PST,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(
+      date_format: "%m/%d/%Y %Z",
+      timezone_column: "TimeZone"
+    )
+    rows = parse(content, mappings: mappings, currency: @usd)
+    # Midnight PST == 08:00 UTC (PST is UTC-8)
+    assert_equal Time.utc(2026, 4, 13, 8, 0, 0), rows.first.transacted_at.utc
+  end
+
+  test "raises informative RowError when neither full nor truncated user format matches" do
+    content = "Date,Description,Amount\n2026-04-13,Coffee,-4.75\n"
+    mappings = signed_mappings.merge(date_format: "%m/%d/%Y")
+    error = assert_raises(Csv::Parser::RowError) { parse(content, mappings: mappings, currency: @usd) }
+    assert_match(/with format/, error.message)
+  end
+
+  test "concatenates multiple description columns with spaces" do
+    content = "Date,Merchant,Memo,Amount\n2026-01-15,ACME,Coffee shop,-4.75\n"
+    mappings = signed_mappings.merge(description_columns: [ "Merchant", "Memo" ])
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal "ACME Coffee shop", rows.first.description
+  end
+
+  test "respects skip_rows" do
+    content = <<~CSV
+      Date,Description,Amount
+      2026-01-15,Skip me,1.00
+      2026-01-16,Keep me,2.00
+    CSV
+    mappings = signed_mappings.merge(skip_rows: 1)
+    rows = parse(content, mappings: mappings, currency: @usd)
+    assert_equal 1, rows.size
+    assert_equal "Keep me", rows.first.description
+  end
+
+  test "uses currency decimal_places when computing amount_minor" do
+    content = "Date,Description,Amount\n2026-01-15,Yen,-1500\n"
+    rows = parse(content, mappings: signed_mappings, currency: @jpy)
+    assert_equal(-1500, rows.first.amount_minor)
+  end
+
+  test "handles UTF-8 BOM at the start of the file" do
+    content = "﻿Date,Description,Amount\n2026-01-15,Coffee,-4.75\n"
+    rows = parse(content, mappings: signed_mappings, currency: @usd)
+    assert_equal 1, rows.size
+    assert_equal(-475, rows.first.amount_minor)
+  end
+
+  test "headers returns the header row" do
+    content = "Date,Description,Amount\n2026-01-15,Coffee,-4.75\n"
+    headers = Csv::Parser.headers(StringIO.new(content))
+    assert_equal [ "Date", "Description", "Amount" ], headers
+  end
+
+  test "preview returns headers and up to limit rows" do
+    content = "Date,Description,Amount\n2026-01-15,A,-1\n2026-01-16,B,-2\n2026-01-17,C,-3\n"
+    result = Csv::Parser.preview(StringIO.new(content), mappings: signed_mappings, currency: @usd, limit: 2)
+    assert_equal [ "Date", "Description", "Amount" ], result[:headers]
+    assert_equal 2, result[:rows].size
+  end
+
+  test "raises when amount_mode is missing" do
+    parser = Csv::Parser.new(io: StringIO.new("Date,Description,Amount\n"), mappings: { date_column: "Date" }, currency: @usd)
+    assert_raises(Csv::Parser::Error) { parser.each_row.to_a }
+  end
+
+  private
+
+    def parse(content, mappings:, currency:)
+      Csv::Parser.new(io: StringIO.new(content), mappings: mappings, currency: currency).each_row.to_a
+    end
+
+    def base_mappings
+      {
+        date_column: "Date",
+        description_columns: [ "Description" ],
+        skip_rows: 0
+      }
+    end
+
+    def signed_mappings
+      base_mappings.merge(amount_mode: "signed", amount_column: "Amount")
+    end
+end

--- a/test/services/csv/parser_test.rb
+++ b/test/services/csv/parser_test.rb
@@ -213,6 +213,32 @@ class Csv::ParserTest < ActiveSupport::TestCase
     assert_match(/could not parse/, error.message)
   end
 
+  test "invert_amount flips the parsed sign" do
+    content = <<~CSV
+      Date,Description,Amount
+      2026-01-15,PURCHASE,4.75
+      2026-01-16,PAYMENT,-100.00
+    CSV
+    rows = parse(content, mappings: signed_mappings.merge(invert_amount: true), currency: @usd)
+    # +4.75 -> expense (-475), -100.00 -> revenue/payment (+10000)
+    assert_equal(-475, rows[0].amount_minor)
+    assert_equal 10000, rows[1].amount_minor
+  end
+
+  test "invert_amount accepts truthy strings" do
+    content = "Date,Description,Amount\n2026-01-15,PURCHASE,4.75\n"
+    [ "1", "true", "on", true ].each do |truthy|
+      rows = parse(content, mappings: signed_mappings.merge(invert_amount: truthy), currency: @usd)
+      assert_equal(-475, rows.first.amount_minor, "expected #{truthy.inspect} to count as truthy")
+    end
+  end
+
+  test "invert_amount=false leaves the sign alone" do
+    content = "Date,Description,Amount\n2026-01-15,PURCHASE,4.75\n"
+    rows = parse(content, mappings: signed_mappings.merge(invert_amount: false), currency: @usd)
+    assert_equal 475, rows.first.amount_minor
+  end
+
   private
 
     def parse(content, mappings:, currency:)

--- a/test/services/csv/parser_test.rb
+++ b/test/services/csv/parser_test.rb
@@ -94,6 +94,10 @@ class Csv::ParserTest < ActiveSupport::TestCase
     content = "Date,Description,Amount\nnot a date,Coffee,-4.75\n"
     error = assert_raises(Csv::Parser::RowError) { parse(content, mappings: signed_mappings, currency: @usd) }
     assert_equal 0, error.row_index
+    # Surface the row in 1-based "data row" terms even though the internal
+    # index is 0-based, so users can locate the row in their CSV (header is
+    # line 1, so data row 1 is line 2).
+    assert_match(/data row 1:/, error.message)
   end
 
   test "falls back to date-only format when user-supplied format includes time tokens but column lacks them" do

--- a/test/system/csv_imports_test.rb
+++ b/test/system/csv_imports_test.rb
@@ -1,0 +1,62 @@
+require "application_system_test_case"
+
+class CsvImportsTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+    @user.update!(password: "password123")
+    @account = accounts(:asset_account)
+    @previous_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :inline
+    sign_in_as(@user)
+  end
+
+  teardown do
+    ActiveJob::Base.queue_adapter = @previous_adapter
+  end
+
+  test "upload, map columns, parse and import a CSV end-to-end" do
+    fixture_path = Rails.root.join("tmp/test_import.csv")
+    File.write(fixture_path, <<~CSV)
+      Date,Description,Amount
+      2026-01-15,Coffee Shop,-4.75
+      2026-01-16,Refund Issued,12.00
+    CSV
+
+    visit account_transactions_path(@account)
+    click_link "Import CSV"
+
+    assert_text "CSV Imports"
+    click_link "Upload a CSV"
+
+    attach_file "csv_import_file", fixture_path.to_s
+    click_button "Upload"
+
+    assert_text "Map columns"
+
+    select "Date", from: "csv_import_column_mappings_date_column"
+    check "Description"
+    select "Amount", from: "csv_import_column_mappings_amount_column"
+    click_button "Save mapping"
+
+    assert_text "Step 3: Confirm and import"
+    assert_text "Coffee Shop"
+    click_button "Parse and import these rows"
+    assert_text "Parse and import enqueued"
+
+    visit account_transactions_path(@account)
+    assert_text "Coffee Shop"
+    assert_text "Refund Issued"
+  ensure
+    File.delete(fixture_path) if defined?(fixture_path) && File.exist?(fixture_path)
+  end
+
+  private
+
+    def sign_in_as(user)
+      visit new_user_session_path
+      fill_in "Email", with: user.email
+      fill_in "Password", with: "password123"
+      click_button "Log in"
+      assert_link "Logout"
+    end
+end


### PR DESCRIPTION
## Summary

- Adds a per-account CSV upload flow at `/accounts/:id/csv_imports` so accounts on banks that aren't reachable through SimpleFIN or Lunch Flow can still be populated from the bank's CSV export.
- The mapping form covers three real-world amount shapes (signed, debit/credit, amount + sign-indicator), separate Date / Time / Timezone columns, multi-column descriptions, and skip-rows. Mapping defaults to the most recent prior import for the same account so re-runs don't re-map by hand.
- `Csv::Transaction` is a polymorphic sourceable on `TransactionSource` and runs through the existing `Transaction::Reconcile`, `ImportRule`, `Transaction::AutoMerge`, and `Transaction::Exclude` paths — no changes to those services required. Source badges in the transaction list render "CSV".

## Flow

1. From any account's transactions page, click **Import CSV** → upload form.
2. Mapping page (Steps 1 + 2): renders a 10-row raw preview of the file plus the mapping form. Save mapping.
3. Confirm page (Step 3): renders a parsed preview showing how the saved mapping will turn rows into ledger transactions, with a **Parse and import these rows** button.
4. `Csv::ParseJob` materializes `Csv::Transaction` rows; on success it enqueues `Csv::ImportTransactionsJob`, which mirrors `Simplefin::ImportTransactionsJob` line-for-line with substitutions for source class and ledger-account lookup.

## Date / time / timezone handling

The parser joins the Date, Time (optional), and Timezone (optional) columns with single spaces and parses the result with the user's strftime. When a Timezone column is mapped, `%Z` is auto-appended to the format if the user didn't already include it, and Ruby's `strptime` correctly applies abbreviations like `PDT`/`PST` to produce a UTC-correct `transacted_at`. Verified against a real-world PayPal export.

If the user supplies a date+time format but the column only has the date, the parser retries with the leading date-only segment (catches the case where the user mapped time later but kept the original format).

## Active Storage

This is the first Active Storage usage in the app. The install migration is included; default Disk service is fine for the current single-machine Kamal deploy.

## Notes / follow-ups

- #144: third near-copy of `ImportTransactionsJob` — extract a shared base.
- #146: heuristic auto-detect of column mappings from header names so the first import for an account doesn't require manual mapping.
- #147: respect a per-row `Currency` column for multi-currency exports (PayPal).
- #151: overlapping/duplicate CSV re-imports into the same account show duplicate "CSV" badges and accumulate `Csv::Transaction` sources — cosmetic/housekeeping, balances unaffected.
- #152: transaction descriptions rewritten between interim and later CSV exports (pending → enriched; not credit-card-specific) fail `Reconcile`'s prefix match, creating duplicate transactions and bypassing prior exclusions — DB-verified, non-blocking.
- #159: `Reconcile` is direction-blind — equal same-day charge/refund pairs (same amount/description, opposite direction) duplicate on CSV re-import because the ambiguous candidate count defeats the `size == 1` match — DB-verified, non-blocking.
- #160: no upload-time check that the file is a CSV (presence + 25 MB size only) — non-CSV uploads fail safe at parse time rather than at the form; extension allowlist / content sniff hardening, non-blocking.

## Test plan

- [x] `bin/rails test` — 731 runs, 0 failures, 99% line coverage.
- [x] `bin/rails test:system` — 32 runs, 0 failures (golden-path upload → map → confirm → import covered in `test/system/csv_imports_test.rb`).
- [x] `bin/rubocop` — no offenses.
- [x] `bin/brakeman --no-pager` — no warnings.
- [x] Manual: imported a real PayPal export with `Date` + `Time` + `TimeZone` columns mapped; 56 rows parsed, time-of-day stored in correct UTC offset per row.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)




