### PR TITLE
Collapse duplicate source badges by type

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,11 +24,20 @@ module ApplicationHelper
   # Caller is responsible for passing a collection where each TransactionSource's
   # sourceable is already loaded (e.g., array from `includes(:sourceable)`).
   # An unloaded relation will N+1 on the per-source sourceable access below.
+  #
+  # Deduped by label so a ledger transaction carrying several sources of the same
+  # type renders a single chip. A CSV that overlaps a prior import for the same
+  # account attaches a second Csv::Transaction source (no stable external id, so
+  # every import creates fresh rows) — without this, that shows as repeated "CSV"
+  # chips (#151). uniq keeps first-occurrence order, preserving badge ordering.
   def transaction_source_badges(sources)
-    badges = sources.map do |source|
-      classes = [ "source-badge", source_badge_modifier(source.sourceable) ].compact.join(" ")
-      tag.span(source_badge_label(source.sourceable), class: classes)
-    end
+    badges = sources
+      .map(&:sourceable)
+      .uniq { |sourceable| source_badge_label(sourceable) }
+      .map do |sourceable|
+        classes = [ "source-badge", source_badge_modifier(sourceable) ].compact.join(" ")
+        tag.span(source_badge_label(sourceable), class: classes)
+      end
     safe_join(badges, " ")
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -133,4 +133,30 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/<span class="source-badge source-badge--simplefin">SimpleFIN<\/span>/, html)
     assert_match(/<span class="source-badge source-badge--lunchflow">Lunch Flow<\/span>/, html)
   end
+
+  test "transaction_source_badges collapses sources sharing a label into one chip" do
+    fake_source = Struct.new(:sourceable)
+    sources = [
+      fake_source.new(Csv::Transaction.new),
+      fake_source.new(Csv::Transaction.new)
+    ]
+
+    html = transaction_source_badges(sources)
+
+    assert_equal 1, html.scan(/<span class="source-badge source-badge--csv">CSV<\/span>/).size
+  end
+
+  test "transaction_source_badges keeps distinct labels while collapsing repeats" do
+    fake_source = Struct.new(:sourceable)
+    sources = [
+      fake_source.new(Csv::Transaction.new),
+      fake_source.new(simplefin_accounts(:linked_one)),
+      fake_source.new(Csv::Transaction.new)
+    ]
+
+    html = transaction_source_badges(sources)
+
+    assert_equal 1, html.scan(/source-badge--csv">CSV<\/span>/).size
+    assert_equal 1, html.scan(/source-badge--simplefin">SimpleFIN<\/span>/).size
+  end
 end

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -67,6 +67,39 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "transaction with several CSV sources shows a single CSV badge" do
+    bank = accounts(:asset_account)
+    expense = accounts(:expense_account)
+
+    txn = Transaction.create!(
+      user: @user, src_account: bank, dest_account: expense,
+      currency: currencies(:usd), description: "Overlapping import",
+      amount_minor: 8772, transacted_at: 1.day.ago
+    )
+
+    2.times do
+      csv_import = Csv::Import.new(user: @user, account: bank, state: "imported")
+      csv_import.file.attach(
+        io: StringIO.new("Date,Description,Amount\n"),
+        filename: "statement.csv",
+        content_type: "text/csv"
+      )
+      csv_import.save!
+      csv_transaction = Csv::Transaction.create!(
+        import: csv_import, row_index: 0,
+        transacted_at: 1.day.ago, amount_minor: -8772,
+        description: "Overlapping import"
+      )
+      TransactionSource.create!(ledger_transaction: txn, sourceable: csv_transaction)
+    end
+
+    visit transactions_path
+
+    within "##{ActionView::RecordIdentifier.dom_id(txn)}" do
+      assert_selector ".source-badge", text: "CSV", count: 1
+    end
+  end
+
   test "sidebar active state survives a live update" do
     account = accounts(:asset_account)
     other = accounts(:expense_account)


### PR DESCRIPTION
## Summary

Re-importing a CSV that overlaps a prior import for the **same ledger account** caused a single ledger transaction to render **two (or more) identical "CSV" badges**.

This is not a data-integrity bug — dedup works as designed, no duplicate ledger transaction is created, and balances stay correct. The cause is an asymmetry: `Simplefin::Transaction` / `Lunchflow::Transaction` carry a stable external id and update the same source in place on re-refresh, but `Csv::Transaction` has **no stable external id** — every `Csv::Import` creates fresh rows. On an overlapping re-import, `Transaction::Reconcile` correctly matches the existing ledger transaction and `TransactionSource::Attach` adds a second `Csv::Transaction` source. `transaction_source_badges` then rendered one chip per source.

This is a pure display fix: `transaction_source_badges` now dedupes sources by their rendered label, so a transaction carrying several sources of the same type renders a single chip, while genuinely distinct sources (e.g. SimpleFIN + Lunch Flow) still each render. Attaching multiple `Csv::Transaction` sources stays intended behavior.

### Why not a content-hash identity for `Csv::Transaction`?

That approach conflicts with #152, where institutions **rewrite the description** between an interim and a later export of the same event. A fingerprint over date + amount + description would differ across those exports (so it wouldn't collapse the same event), and hashing *without* the description would risk false-merging genuinely distinct same-amount/same-day rows (the #117 safety `Reconcile` protects). So content-hash is both ineffective and risky here.

## Changes

- `app/helpers/application_helper.rb` — `transaction_source_badges` dedupes by `source_badge_label`; `uniq` preserves first-occurrence order so badge ordering is unchanged.

## Test plan

- [x] `test/helpers/application_helper_test.rb` — two same-label sources collapse to one chip; distinct labels survive while a repeat collapses. Existing SimpleFIN + Lunch Flow test untouched.
- [x] `test/system/transactions_test.rb` — a ledger transaction with two `Csv::Transaction` sources renders a single "CSV" badge (`count: 1`).
- [x] `bin/rubocop` clean on changed files.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)