### PR TITLE
Group account options for linking by kind

### DIFF
--- a/app/views/integrations/_lunchflow_link_form.html.erb
+++ b/app/views/integrations/_lunchflow_link_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: lf_account, url: link_lunchflow_account_path(lf_account), method: :post do |form| %>
     <%= form.label :ledger_account_id, "Account to link", class: "sr-only" %>
     <span>
-      <%= form.collection_select :ledger_account_id, linkable_accounts, :id, :name, prompt: "Not linked" %>
+      <%= form.select :ledger_account_id, grouped_account_options_for_select(linkable_accounts, Account.kinds.keys), { include_blank: "Not linked" } %>
     </span>
     <span>
       <%= form.submit "Link", "aria-label": "Link Lunch Flow account" %>

--- a/app/views/integrations/_simplefin_link_form.html.erb
+++ b/app/views/integrations/_simplefin_link_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: sf_account, url: link_simplefin_account_path(sf_account), method: :post do |form| %>
     <%= form.label :ledger_account_id, "Account to link", class: "sr-only" %>
     <span>
-      <%= form.collection_select :ledger_account_id, linkable_accounts, :id, :name, prompt: "Not linked" %>
+      <%= form.select :ledger_account_id, grouped_account_options_for_select(linkable_accounts, Account.kinds.keys), { include_blank: "Not linked" } %>
     </span>
     <span>
       <%= form.submit "Link", "aria-label": "Link SimpleFIN account" %>

--- a/test/controllers/integrations_controller_test.rb
+++ b/test/controllers/integrations_controller_test.rb
@@ -41,4 +41,22 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     get integrations_url
     assert_response :success
   end
+
+  test "simplefin link form groups linkable accounts by kind" do
+    get integrations_url
+
+    assert_select "form[action=?]", link_simplefin_account_path(simplefin_accounts(:unlinked_one)) do
+      assert_select "select[name=?] optgroup[label=?]", "simplefin_account[ledger_account_id]", "Asset"
+      assert_select "select[name=?] optgroup[label=?]", "simplefin_account[ledger_account_id]", "Liability"
+    end
+  end
+
+  test "lunchflow link form groups linkable accounts by kind" do
+    get integrations_url
+
+    assert_select "form[action=?]", link_lunchflow_account_path(lunchflow_accounts(:unlinked_one)) do
+      assert_select "select[name=?] optgroup[label=?]", "lunchflow_account[ledger_account_id]", "Asset"
+      assert_select "select[name=?] optgroup[label=?]", "lunchflow_account[ledger_account_id]", "Liability"
+    end
+  end
 end

--- a/test/controllers/integrations_controller_test.rb
+++ b/test/controllers/integrations_controller_test.rb
@@ -41,22 +41,4 @@ class IntegrationsControllerTest < ActionDispatch::IntegrationTest
     get integrations_url
     assert_response :success
   end
-
-  test "simplefin link form groups linkable accounts by kind" do
-    get integrations_url
-
-    assert_select "form[action=?]", link_simplefin_account_path(simplefin_accounts(:unlinked_one)) do
-      assert_select "select[name=?] optgroup[label=?]", "simplefin_account[ledger_account_id]", "Asset"
-      assert_select "select[name=?] optgroup[label=?]", "simplefin_account[ledger_account_id]", "Liability"
-    end
-  end
-
-  test "lunchflow link form groups linkable accounts by kind" do
-    get integrations_url
-
-    assert_select "form[action=?]", link_lunchflow_account_path(lunchflow_accounts(:unlinked_one)) do
-      assert_select "select[name=?] optgroup[label=?]", "lunchflow_account[ledger_account_id]", "Asset"
-      assert_select "select[name=?] optgroup[label=?]", "lunchflow_account[ledger_account_id]", "Liability"
-    end
-  end
 end

--- a/test/system/integrations_test.rb
+++ b/test/system/integrations_test.rb
@@ -42,12 +42,38 @@ class IntegrationsTest < ApplicationSystemTestCase
     assert_link "Import"
   end
 
+  test "SimpleFIN link form groups linkable accounts by kind" do
+    sf_account = simplefin_accounts(:unlinked_one)
+
+    visit integrations_path
+
+    within("tr", text: sf_account.name) do
+      within("select[name='simplefin_account[ledger_account_id]']") do
+        assert_selector "optgroup[label='Asset']", visible: :all
+        assert_selector "optgroup[label='Liability']", visible: :all
+      end
+    end
+  end
+
   test "displays Lunch Flow accounts with status" do
     visit integrations_path
 
     assert_text "Lunch Flow Accounts"
     assert_text "Test Bank Checking"
     assert_text "ACTIVE"
+  end
+
+  test "Lunch Flow link form groups linkable accounts by kind" do
+    lf_account = lunchflow_accounts(:unlinked_one)
+
+    visit integrations_path
+
+    within("tr", text: lf_account.name) do
+      within("select[name='lunchflow_account[ledger_account_id]']") do
+        assert_selector "optgroup[label='Asset']", visible: :all
+        assert_selector "optgroup[label='Liability']", visible: :all
+      end
+    end
   end
 
   test "displays Lunch Flow ERROR status with action link" do


### PR DESCRIPTION
In the Lunch Flow and SimpleFIN link form partials, the account select field now uses the `grouped_account_options_for_select` helper to show linkable account options by kind in the dropdown.