### PR TITLE
Sort integrations accounts by institution then account name

### DIFF
--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -17,6 +17,8 @@ class IntegrationsController < ApplicationController
       threshold = connection.refreshed_at
       connection.accounts.includes(:ledger_accounts).select do |aggregator_account|
         aggregator_account.linked? || aggregator_account.current?(threshold)
+      end.sort_by do |aggregator_account|
+        [ aggregator_account.institution_name.to_s.downcase, aggregator_account.name.to_s.downcase ]
       end
     end
 end

--- a/app/models/simplefin/account.rb
+++ b/app/models/simplefin/account.rb
@@ -6,6 +6,12 @@ class Simplefin::Account < ApplicationRecord
 
   has_many :transactions, dependent: :destroy
 
+  # Institution name, surfaced from the SimpleFIN `org` JSON so callers can treat
+  # SimpleFIN and Lunch Flow accounts uniformly (Lunch Flow has this as a column).
+  def institution_name
+    org&.[]("name")
+  end
+
   def current?(threshold = connection&.refreshed_at)
     return false if last_seen_at.nil?
     return false if threshold.nil?

--- a/app/views/integrations/show.html.erb
+++ b/app/views/integrations/show.html.erb
@@ -63,7 +63,7 @@
       </tr>
       <% @simplefin_accounts.each do |sf_account| %>
         <tr>
-          <td><%= sf_account.org&.[]("name") %></td>
+          <td><%= sf_account.institution_name %></td>
           <td>
             <%= sf_account.name %>
             <% unless sf_account.current?(@simplefin_connection.refreshed_at) %>

--- a/test/fixtures/simplefin/accounts.yml
+++ b/test/fixtures/simplefin/accounts.yml
@@ -3,7 +3,8 @@
 linked_one:
   connection: one
   remote_id: remote_id_1
-  org: Test Bank
+  org:
+    name: Test Bank
   name: Test Checking
   currency: USD
   balance: "1000.00"
@@ -14,7 +15,8 @@ linked_one:
 unlinked_one:
   connection: one
   remote_id: remote_id_2
-  org: Test Bank
+  org:
+    name: Test Bank
   name: Test Savings
   currency: USD
   balance: "5000.00"
@@ -25,7 +27,8 @@ unlinked_one:
 reconciled_one:
   connection: one
   remote_id: remote_id_3
-  org: Test Bank
+  org:
+    name: Test Bank
   name: Test Checking
   currency: USD
   balance: "50.00"

--- a/test/models/simplefin/account_test.rb
+++ b/test/models/simplefin/account_test.rb
@@ -25,6 +25,18 @@ class Simplefin::AccountTest < ActiveSupport::TestCase
     assert_not @linked_simplefin_account.unlinked?
   end
 
+  test "institution_name returns the org name" do
+    account = Simplefin::Account.new(org: { "name" => "Test Bank" })
+
+    assert_equal "Test Bank", account.institution_name
+  end
+
+  test "institution_name returns nil when org is absent" do
+    account = Simplefin::Account.new(org: nil)
+
+    assert_nil account.institution_name
+  end
+
   test "ledger_currency returns nil if app currency is not found" do
     simplefin_account = Simplefin::Account.new(currency: "unknown")
 

--- a/test/system/integrations_test.rb
+++ b/test/system/integrations_test.rb
@@ -42,6 +42,34 @@ class IntegrationsTest < ApplicationSystemTestCase
     assert_link "Import"
   end
 
+  test "sorts SimpleFIN accounts by institution then account name" do
+    # Insertion order (linked, unlinked, reconciled) deliberately differs from the
+    # expected sorted order, and account names alone sort differently than the
+    # institution-first order, so this also proves institution is the primary key.
+    simplefin_accounts(:linked_one).update!(org: { "name" => "Summit Bank" }, name: "Alpha Account")
+    simplefin_accounts(:unlinked_one).update!(org: { "name" => "Summit Bank" }, name: "Beta Account")
+    simplefin_accounts(:reconciled_one).update!(org: { "name" => "Harbor Bank" }, name: "Zulu Account")
+
+    visit integrations_path
+
+    within find("table", text: "Organization") do
+      account_names = all("tr td:nth-child(2)").map { |cell| cell.text.strip }
+      assert_equal [ "Zulu Account", "Alpha Account", "Beta Account" ], account_names
+    end
+  end
+
+  test "sorts Lunch Flow accounts by institution then account name" do
+    lunchflow_accounts(:linked_one).update!(institution_name: "Aspen Bank", name: "Yankee Account")
+    lunchflow_accounts(:unlinked_one).update!(institution_name: "Zephyr Bank", name: "Alpha Account")
+
+    visit integrations_path
+
+    within find("table", text: "Institution") do
+      account_names = all("tr td:nth-child(2)").map { |cell| cell.text.strip }
+      assert_equal [ "Yankee Account", "Alpha Account" ], account_names
+    end
+  end
+
   test "SimpleFIN link form groups linkable accounts by kind" do
     sf_account = simplefin_accounts(:unlinked_one)
 


### PR DESCRIPTION
## Summary

SimpleFIN and Lunch Flow accounts on the `/integrations` page rendered in database insertion order, which made the lists hard to scan once a user had several accounts across multiple banks. Each table now sorts by institution, then by account name within each institution, so accounts at the same bank cluster together alphabetically.

## Changes

- **`app/models/simplefin/account.rb`** — Added an `institution_name` reader that surfaces the name from the SimpleFIN `org` JSON, mirroring the column Lunch Flow already has. This makes the shared sort key uniform across both aggregators.
- **`app/controllers/integrations_controller.rb`** — `visible_aggregator_accounts` now sorts its filtered array by `[institution_name, name]`, case-insensitively and nil-safe. Both tables get identical ordering since the method is shared.
- **`app/views/integrations/show.html.erb`** — The SimpleFIN organization cell uses `sf_account.institution_name` instead of inline `org&.[]("name")`, matching the accessor the sort relies on (behavior unchanged).

## Test plan

- [x] `institution_name` returns `org["name"]` and `nil` when `org` is absent (`test/models/simplefin/account_test.rb`)
- [x] SimpleFIN accounts render sorted by institution then account name (`test/system/integrations_test.rb`)
- [x] Lunch Flow accounts render sorted by institution then account name (`test/system/integrations_test.rb`)

The system tests deliberately set up insertion order and name-only order to both differ from the expected institution-first order, proving institution is the primary sort key and name is the tiebreaker.

Verified locally: `bin/rails test test/models/simplefin/account_test.rb`, `bin/rails test test/controllers/integrations_controller_test.rb`, `bin/rails test:system test/system/integrations_test.rb` (43 runs), and `bin/rubocop` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)