### PR TITLE
Add a friendlier accounts index with inline management

### DIFF
--- a/app/assets/stylesheets/accounts.css
+++ b/app/assets/stylesheets/accounts.css
@@ -1,0 +1,241 @@
+/* Accounts index — grouped grid-table.
+   Mirrors transactions.css's grid-collapses-to-card mechanic; every generic
+   selector is namespaced under .accounts to avoid colliding with the
+   transactions table and the sidebar's .account* rules. */
+
+/* Page header band: title + in-context CTAs */
+.accounts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.accounts-header h1 {
+  margin: 0;
+}
+
+.accounts-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.accounts-header__actions a {
+  color: var(--honey-dark);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.accounts-header__actions a:hover {
+  color: var(--honey);
+  text-decoration: underline;
+}
+
+/* Per-kind section — hidden until it has at least one data row,
+   mirroring .sidebar-kind-group:has(li) */
+.accounts-group {
+  display: none;
+  margin-bottom: 24px;
+}
+
+.accounts-group:has(.accounts .row:not(.header)) {
+  display: block;
+}
+
+.accounts-group h2 {
+  font-size: 0.95rem;
+  margin: 0 0 8px;
+}
+
+/* Table wrapper */
+.accounts {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+}
+
+.accounts .row {
+  display: grid;
+  grid-template-columns:
+    minmax(140px, 2fr)    /* Account */
+    minmax(90px,  1fr)    /* Balance */
+    minmax(120px, 1.5fr)  /* Sources */
+    minmax(160px, 1.5fr); /* Actions */
+  gap: 0;
+  align-items: stretch;
+}
+
+.accounts .row.header {
+  background-color: var(--honey-pale);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: var(--accent-text);
+}
+
+/* Cells */
+.accounts .row > div {
+  border-right: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
+  padding: 7px 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: var(--bark-medium);
+  font-size: 0.875rem;
+}
+
+.accounts .row > div:last-child {
+  border-right: 0;
+}
+
+.accounts .row:last-child > div {
+  border-bottom: 0;
+}
+
+.accounts .numeric {
+  justify-content: flex-end;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.accounts__not-linked {
+  color: var(--bark-light);
+  font-size: 0.8rem;
+}
+
+/* Row hover on desktop only */
+@media (min-width: 768px) {
+  .accounts .row:hover:not(.header) {
+    background-color: var(--honey-light);
+  }
+}
+
+/* Action cluster (adjacent controls, no delimiter) */
+.accounts .actions {
+  gap: 12px;
+}
+
+.accounts .actions a {
+  color: var(--honey-dark);
+  text-decoration: none;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.accounts .actions a:hover {
+  color: var(--honey);
+  text-decoration: underline;
+}
+
+.accounts .actions form.button_to {
+  margin: 0;
+  display: inline;
+}
+
+.accounts .actions button {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-family: inherit;
+  font-size: 0.8rem;
+  color: var(--color-negative);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.accounts .actions button:hover {
+  text-decoration: underline;
+}
+
+/* Empty state */
+.empty-state {
+  background-color: var(--honey-pale);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+}
+
+.empty-state h2 {
+  margin: 0 0 8px;
+}
+
+.empty-state p {
+  margin: 0 0 16px;
+  color: var(--bark-medium);
+}
+
+.empty-state__actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+/* ========== Mobile (< 768px): collapse each row to a card ========== */
+@media (max-width: 767px) {
+  .accounts {
+    border: none;
+    border-radius: 0;
+    overflow-x: visible;
+  }
+
+  /* Hide the desktop header row */
+  .accounts .row.header {
+    display: none;
+  }
+
+  /* Stack cells as a card */
+  .accounts .row {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    border: 1px solid var(--divider);
+    border-radius: 8px;
+    margin-bottom: 10px;
+    padding: 10px 14px;
+    background-color: var(--cream);
+  }
+
+  .accounts .row > div {
+    border: none;
+    padding: 3px 0;
+  }
+
+  /* Surface the column name as an inline label */
+  .accounts .row > div[data-label]::before {
+    content: attr(data-label) ": ";
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: var(--accent-text);
+    min-width: 70px;
+    display: inline;
+  }
+
+  /* Balance sits next to its label in card view (not pushed to the right).
+     .account__balance is shared with the sidebar, where it carries
+     margin-left: auto — undo that here so flex-start actually left-aligns it. */
+  .accounts .numeric {
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .accounts .numeric .account__balance {
+    margin-left: 0;
+  }
+
+  /* Actions row across the bottom of the card */
+  .accounts .actions {
+    padding-top: 6px;
+    margin-top: 4px;
+    border-top: 1px solid var(--divider);
+    flex-wrap: wrap;
+  }
+}

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,7 +6,24 @@ class AccountsController < ApplicationController
 
   # GET /accounts or /accounts.json
   def index
-    @accounts = current_user.accounts.real.includes(:currency)
+    @grouped_accounts = current_user.accounts.real
+      .includes(:currency, account_sources: :sourceable)
+      .order(:kind, :name)
+      .group_by(&:kind)
+
+    # Accounts referenced by a non-opening-balance transaction can't be destroyed
+    # (dependent: :restrict_with_error). A lone opening-balance transaction is
+    # auto-removed by Account#before_destroy, so it doesn't count. One query feeds
+    # a Set the row partial checks to decide whether to render the Delete button.
+    account_ids = @grouped_accounts.values.flatten.map(&:id)
+    @accounts_with_transactions =
+      if account_ids.empty?
+        Set.new
+      else
+        Transaction.where(opening_balance: false)
+          .where("src_account_id IN (:ids) OR dest_account_id IN (:ids)", ids: account_ids)
+          .pluck(:src_account_id, :dest_account_id).flatten.to_set
+      end
   end
 
   # GET /accounts/1 or /accounts/1.json
@@ -78,11 +95,18 @@ class AccountsController < ApplicationController
 
   # DELETE /accounts/1 or /accounts/1.json
   def destroy
-    @account.destroy!
-
+    # Non-bang destroy: dependent: :restrict_with_error returns false (without
+    # raising) when the account still has transactions, so it degrades to a flash
+    # instead of a 500. The index hides Delete in that case, but this guards
+    # direct requests and races.
     respond_to do |format|
-      format.html { redirect_to accounts_path, notice: "Account was successfully destroyed.", status: :see_other }
-      format.json { head :no_content }
+      if @account.destroy
+        format.html { redirect_to accounts_path, notice: "Account was successfully destroyed.", status: :see_other }
+        format.json { head :no_content }
+      else
+        format.html { redirect_to accounts_path, alert: "This account still has transactions, so it can't be deleted.", status: :see_other }
+        format.json { render json: @account.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,16 +6,18 @@ class AccountsController < ApplicationController
 
   # GET /accounts or /accounts.json
   def index
-    @grouped_accounts = current_user.accounts.real
+    # @accounts backs the JSON view (index.json.jbuilder); the HTML view reads
+    # the kind grouping derived from the same loaded relation.
+    @accounts = current_user.accounts.real
       .includes(:currency, account_sources: :sourceable)
       .order(:kind, :name)
-      .group_by(&:kind)
+    @grouped_accounts = @accounts.group_by(&:kind)
 
     # Accounts referenced by a non-opening-balance transaction can't be destroyed
     # (dependent: :restrict_with_error). A lone opening-balance transaction is
     # auto-removed by Account#before_destroy, so it doesn't count. One query feeds
     # a Set the row partial checks to decide whether to render the Delete button.
-    account_ids = @grouped_accounts.values.flatten.map(&:id)
+    account_ids = @accounts.map(&:id)
     @accounts_with_transactions =
       if account_ids.empty?
         Set.new

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,26 +6,31 @@ class AccountsController < ApplicationController
 
   # GET /accounts or /accounts.json
   def index
-    # @accounts backs the JSON view (index.json.jbuilder); the HTML view reads
-    # the kind grouping derived from the same loaded relation.
-    @accounts = current_user.accounts.real
-      .includes(:currency, account_sources: :sourceable)
-      .order(:kind, :name)
-    @grouped_accounts = @accounts.group_by(&:kind)
+    @accounts = current_user.accounts.real.order(:kind, :name)
 
-    # Accounts referenced by a non-opening-balance transaction can't be destroyed
-    # (dependent: :restrict_with_error). A lone opening-balance transaction is
-    # auto-removed by Account#before_destroy, so it doesn't count. One query feeds
-    # a Set the row partial checks to decide whether to render the Delete button.
-    account_ids = @accounts.map(&:id)
-    @accounts_with_transactions =
-      if account_ids.empty?
-        Set.new
-      else
-        Transaction.where(opening_balance: false)
-          .where("src_account_id IN (:ids) OR dest_account_id IN (:ids)", ids: account_ids)
-          .pluck(:src_account_id, :dest_account_id).flatten.to_set
+    respond_to do |format|
+      format.html do
+        # HTML-only work: eager-load for the balance/sources columns, group by
+        # kind, and find which accounts can't be deleted (they still have a
+        # non-opening-balance transaction; restrict_with_error). A lone
+        # opening-balance transaction is auto-removed by Account#before_destroy,
+        # so it doesn't count. The JSON format skips all of this and just renders
+        # @accounts via index.json.jbuilder.
+        @accounts = @accounts.includes(:currency, account_sources: :sourceable)
+        @grouped_accounts = @accounts.group_by(&:kind)
+
+        account_ids = @accounts.map(&:id)
+        @accounts_with_transactions =
+          if account_ids.empty?
+            Set.new
+          else
+            Transaction.where(opening_balance: false)
+              .where("src_account_id IN (:ids) OR dest_account_id IN (:ids)", ids: account_ids)
+              .pluck(:src_account_id, :dest_account_id).flatten.to_set
+          end
       end
+      format.json
+    end
   end
 
   # GET /accounts/1 or /accounts/1.json

--- a/app/views/accounts/_account_row.html.erb
+++ b/app/views/accounts/_account_row.html.erb
@@ -1,0 +1,37 @@
+<% deletable = accounts_with_transactions.exclude?(account.id) %>
+<div id="<%= dom_id(account) %>" class="row">
+  <div data-label="Account">
+    <%= link_to account.name, account %>
+  </div>
+
+  <div data-label="Balance" class="numeric">
+    <% balance_minor = account.balance_minor %>
+    <% modifier = balance_minor && (balance_minor >= 0 ? "account__balance--positive" : "account__balance--negative") %>
+    <span class="account__balance <%= modifier %>">
+      <%= balance_minor ? amount_to_currency(balance_minor, account.currency) : "N/A" %>
+    </span>
+  </div>
+
+  <div data-label="Sources">
+    <% account_sources = account.account_sources %>
+    <% if account_sources.any? %>
+      <% account_sources.each do |account_source| %>
+        <% sourceable = account_source.sourceable %>
+        <%= tag.span source_badge_label(sourceable), class: class_names("source-badge", source_badge_modifier(sourceable)) %>
+      <% end %>
+    <% else %>
+      <span class="accounts__not-linked">Not linked</span>
+      <% if account.asset? || account.liability? %>
+        <%= link_to "Link", integrations_path, "aria-label": "Link #{account.name} to an integration" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="actions">
+    <%= link_to "Transactions", account_transactions_path(account), "aria-label": "View transactions for #{account.name}" %>
+    <%= link_to "Edit", edit_account_path(account), "aria-label": "Edit #{account.name}" %>
+    <% if deletable %>
+      <%= button_to "Delete", account, method: :delete, "aria-label": "Delete #{account.name}", data: { turbo_confirm: "Delete #{account.name}? This cannot be undone." } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,14 +1,37 @@
 <% content_for :title, "Accounts" %>
 
-<h1>Accounts</h1>
-
-<div id="accounts">
-  <% @accounts.each do |account| %>
-    <%= render account %>
-    <p>
-      <%= link_to "Show this account", account %>
-    </p>
-  <% end %>
+<div class="accounts-header">
+  <h1>Accounts</h1>
+  <div class="accounts-header__actions">
+    <%= link_to "+ New account", new_account_path %>
+    <%= link_to "Integrations", integrations_path %>
+  </div>
 </div>
 
-<%= link_to "New account", new_account_path %>
+<% if @grouped_accounts.blank? %>
+  <div class="empty-state">
+    <h2>No accounts yet</h2>
+    <p>Add your first account, or link one from Integrations to start tracking balances.</p>
+    <div class="empty-state__actions">
+      <%= link_to "New account", new_account_path %>
+      <%= link_to "Go to Integrations", integrations_path %>
+    </div>
+  </div>
+<% else %>
+  <% Account.kinds.keys.each do |kind| %>
+    <% accounts = @grouped_accounts[kind] || [] %>
+    <section class="accounts-group">
+      <h2><%= kind.humanize.pluralize %></h2>
+      <div class="accounts">
+        <div class="row header">
+          <div>Account</div>
+          <div>Balance</div>
+          <div>Sources</div>
+          <div>Actions</div>
+        </div>
+        <%= render partial: "accounts/account_row", collection: accounts, as: :account,
+              locals: { accounts_with_transactions: @accounts_with_transactions } %>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -398,5 +398,8 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_entity
+    # restrict_with_error adds a :base error before halting, so the model's
+    # errors are present in the JSON body.
+    assert_includes JSON.parse(response.body).keys, "base"
   end
 end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -15,6 +15,15 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get index for a user with no accounts" do
+    empty_user = User.create!(email: "empty-index@example.com", password: "password123")
+    sign_in empty_user
+
+    get accounts_url
+
+    assert_response :success
+  end
+
   test "should get new" do
     get new_account_url
 

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -361,4 +361,25 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to accounts_url
   end
+
+  test "should not destroy account that still has transactions" do
+    account = accounts(:asset_account) # referenced by transactions(:one)
+
+    assert_no_difference("Account.count") do
+      delete account_url(account)
+    end
+
+    assert_redirected_to accounts_url
+    assert_equal "This account still has transactions, so it can't be deleted.", flash[:alert]
+  end
+
+  test "should respond unprocessable entity for JSON destroy of an account with transactions" do
+    account = accounts(:asset_account)
+
+    assert_no_difference("Account.count") do
+      delete account_url(account), as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
 end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -24,6 +24,14 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should get index as JSON" do
+    get accounts_url(format: :json)
+
+    assert_response :success
+    names = JSON.parse(response.body).map { |account| account["name"] }
+    assert_includes names, accounts(:asset_account).name
+  end
+
   test "should get new" do
     get new_account_url
 

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -97,11 +97,15 @@ class AccountsTest < ApplicationSystemTestCase
   test "the accounts index groups accounts by kind" do
     visit accounts_path
 
-    assert_text "Assets"
-    assert_text "Liabilities"
-    assert_text "Expenses"
-    assert_text "Revenues"
-    assert_no_text "Equities" # user one has no equity accounts
+    # Scope to the page content so the sidebar (which renders the same kind
+    # headings) can't make these assertions pass on its own.
+    within "main" do
+      assert_text "Assets"
+      assert_text "Liabilities"
+      assert_text "Expenses"
+      assert_text "Revenues"
+      assert_no_text "Equities" # user one has no equity accounts
+    end
   end
 
   test "account rows show color-coded balances" do

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -94,7 +94,143 @@ class AccountsTest < ApplicationSystemTestCase
     assert_no_selector "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_item)}"
   end
 
+  test "the accounts index groups accounts by kind" do
+    visit accounts_path
+
+    assert_text "Assets"
+    assert_text "Liabilities"
+    assert_text "Expenses"
+    assert_text "Revenues"
+    assert_no_text "Equities" # user one has no equity accounts
+  end
+
+  test "account rows show color-coded balances" do
+    accounts(:asset_account).update_column(:balance_minor, 12345)
+    accounts(:liability_account).update_column(:balance_minor, -5000)
+
+    visit accounts_path
+
+    within row_for(accounts(:asset_account)) do
+      assert_selector ".account__balance--positive"
+      assert_text "$123.45"
+    end
+    within row_for(accounts(:liability_account)) do
+      assert_selector ".account__balance--negative"
+    end
+  end
+
+  test "account rows show linked source badges" do
+    visit accounts_path
+
+    within row_for(accounts(:linked_asset)) do
+      assert_text "SimpleFIN"
+    end
+    within row_for(accounts(:lunchflow_linked_asset)) do
+      assert_text "Lunch Flow"
+    end
+  end
+
+  test "unlinked asset and liability rows offer a Link action" do
+    visit accounts_path
+
+    within row_for(accounts(:unlinked_liability)) do
+      assert_text "Not linked"
+      assert_link "Link", exact: true
+    end
+
+    within row_for(accounts(:linked_asset)) do
+      assert_no_link "Link", exact: true # account name "Linked Asset" contains "Link"
+    end
+  end
+
+  test "unlinked expense and revenue rows show Not linked without a Link action" do
+    visit accounts_path
+
+    within row_for(accounts(:expense_account)) do
+      assert_text "Not linked"
+      assert_no_link "Link", exact: true
+    end
+  end
+
+  test "clicking an account name opens its detail page" do
+    account = accounts(:unlinked_liability)
+    visit accounts_path
+
+    within row_for(account) do
+      click_link account.name
+    end
+
+    assert_current_path account_path(account)
+  end
+
+  test "the Transactions action opens the account's transactions" do
+    account = accounts(:unlinked_liability)
+    visit accounts_path
+
+    within row_for(account) do
+      click_link "Transactions"
+    end
+
+    assert_current_path account_transactions_path(account)
+  end
+
+  test "the Edit action opens the account edit form" do
+    account = accounts(:unlinked_liability)
+    visit accounts_path
+
+    within row_for(account) do
+      click_link "Edit"
+    end
+
+    assert_current_path edit_account_path(account)
+  end
+
+  test "Delete is hidden for accounts that still have transactions" do
+    visit accounts_path
+
+    within row_for(accounts(:asset_account)) do
+      assert_no_button "Delete"
+    end
+  end
+
+  test "deleting an account with no transactions removes it from the index and sidebar" do
+    account = Account.create!(user: @user, currency: currencies(:usd), name: "Index Delete Probe", kind: :asset)
+    visit accounts_path
+
+    row = row_for(account)
+    sidebar_item = "##{ActionView::RecordIdentifier.dom_id(account, :sidebar_item)}"
+    assert_selector row
+
+    within(row) do
+      accept_confirm do
+        click_button "Delete"
+      end
+    end
+
+    assert_text "Account was successfully destroyed."
+    assert_no_selector row
+    assert_no_selector sidebar_item
+  end
+
+  test "shows a friendly empty state when there are no accounts" do
+    empty_user = User.create!(email: "empty@example.com", password: "password123")
+
+    accept_confirm { click_link "Logout" }
+    assert_no_link "Logout"
+
+    sign_in_as(empty_user)
+    visit accounts_path
+
+    assert_text "No accounts yet"
+    assert_link "New account"
+    assert_link "Go to Integrations"
+  end
+
   private
+
+  def row_for(account)
+    "##{ActionView::RecordIdentifier.dom_id(account)}"
+  end
 
   def sign_in_as(user)
     visit new_user_session_path


### PR DESCRIPTION
## Summary

The `/accounts` index was a bare key:value dump (Name / Kind / Currency / Balance / Opening Balance per account) with management actions hidden away on each account's show page. This reworks it into a grouped grid-table that's easy to read and manage.

- **Grouped by kind** (Assets, Liabilities, Equity, Expenses, Revenues) like the sidebar, with empty groups hidden via `:has()`. Reuses the transactions grid→mobile-card responsive mechanic (new `accounts.css`, auto-included alongside `transactions.css`).
- **Per row:** name → detail page, color-coded balance, linked source badges (or `Not linked` + a `Link` CTA for asset/liability accounts), and inline **Transactions · Edit · Delete** actions.
- **Delete is gated:** hidden for accounts that still have transactions (computed in one query), so it never leads to a dead end. The Delete action is styled red.
- **Friendly empty state** when there are no accounts, with `New account` / `Integrations` CTAs.

### Bug fix bundled in
`destroy` called unguarded `@account.destroy!`, which **raises → 500** for any account with transactions (`dependent: :restrict_with_error`). Switched to non-bang `@account.destroy` so it degrades to a flash. Surfacing inline Delete made this reachable for typical accounts, so the fix ships here.

### Notes
- The shared `accounts/_account.html.erb` partial is **untouched** (still drives the show page); the index renders a new `accounts/_account_row.html.erb`.
- The index uses a distinct `@grouped_accounts` ivar so it doesn't clobber the sidebar's `@accounts_by_kind` (set by `ApplicationController`).
- **No net-worth/totals** in this pass — balances are multi-currency (USD/EUR/JPY/BTC) with no FX layer, so any combined total would be wrong. Deferred to a follow-up.

## Test plan

**Controller (`accounts_controller_test.rb`)** — flow/status/flash:
- [x] Destroying an account with no transactions still succeeds (existing).
- [x] Destroying an account that has transactions doesn't raise → redirects with an alert, count unchanged.
- [x] JSON destroy of an account with transactions → `:unprocessable_entity`.

**System (`accounts_test.rb`)** — rendered UI:
- [x] Accounts grouped under kind headings; empty kinds not shown.
- [x] Balances render with `--positive` / `--negative` color classes and formatted amounts.
- [x] Linked accounts show `SimpleFIN` / `Lunch Flow` badges; unlinked asset/liability show `Not linked` + `Link`; unlinked expense/revenue show `Not linked` without `Link`.
- [x] Account name → detail; `Transactions` → transactions; `Edit` → edit form.
- [x] Delete hidden for accounts with transactions; deleting a transaction-free account removes its index row and sidebar item.
- [x] Empty state copy + CTAs render for a user with no accounts.

All green locally: `bin/rails test` (786 runs, 0 failures), `bin/rails test:system` (54 runs, 0 failures), `bin/rubocop` (no offenses), `bin/brakeman` (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)