### PR TITLE
Add merging of expense and revenue accounts from the accounts index

### DIFF
--- a/app/assets/stylesheets/accounts.css
+++ b/app/assets/stylesheets/accounts.css
@@ -70,6 +70,21 @@
   align-items: stretch;
 }
 
+/* Expense/revenue groups carry a leading checkbox column for merging. */
+.accounts--selectable .row {
+  grid-template-columns:
+    44px                  /* Select */
+    minmax(140px, 2fr)    /* Account */
+    minmax(90px,  1fr)    /* Balance */
+    minmax(120px, 1.5fr)  /* Sources */
+    minmax(160px, 1.5fr); /* Actions */
+}
+
+.accounts .row > .select {
+  justify-content: center;
+  padding: 7px 4px;
+}
+
 .accounts .row.header {
   background-color: var(--honey-pale);
   font-weight: 600;
@@ -152,6 +167,50 @@
 
 .accounts .actions button:hover {
   text-decoration: underline;
+}
+
+/* Merge confirmation — "keep this account" radio list. The surrounding
+   .selection-bar / .selection-confirmation chrome is shared (transactions.css).
+   Note: this list lives outside .selection-confirmation__field on purpose, so the
+   shared `input { width: 100% }` rule there doesn't stretch the radio buttons. */
+.selection-confirmation__keep {
+  margin-bottom: 12px;
+}
+
+.selection-confirmation__label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-text);
+}
+
+.selection-confirmation__targets {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.selection-confirmation__target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--bark);
+  cursor: pointer;
+}
+
+.selection-confirmation__target input[type="radio"] {
+  width: auto;
+  flex: none;
+  margin: 0;
+}
+
+.selection-confirmation__target-count {
+  margin-left: auto;
+  color: var(--bark-light);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Empty state */

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,15 +19,20 @@ class AccountsController < ApplicationController
         @accounts = @accounts.includes(:currency, account_sources: :sourceable)
         @grouped_accounts = @accounts.group_by(&:kind)
 
+        # Tally non-opening-balance transactions touching each account. The key set drives
+        # delete-gating (any account that still has a transaction can't be destroyed via
+        # restrict_with_error), and the per-account count seeds the default "keep this one"
+        # choice when merging duplicates.
         account_ids = @accounts.map(&:id)
-        @accounts_with_transactions =
-          if account_ids.empty?
-            Set.new
-          else
-            Transaction.where(opening_balance: false)
-              .where("src_account_id IN (:ids) OR dest_account_id IN (:ids)", ids: account_ids)
-              .pluck(:src_account_id, :dest_account_id).flatten.to_set
-          end
+        @transaction_counts = Hash.new(0)
+        unless account_ids.empty?
+          Transaction.where(opening_balance: false)
+            .where("src_account_id IN (:ids) OR dest_account_id IN (:ids)", ids: account_ids)
+            .pluck(:src_account_id, :dest_account_id).each do |ids|
+              ids.each { |id| @transaction_counts[id] += 1 }
+            end
+        end
+        @accounts_with_transactions = @transaction_counts.keys.to_set
       end
       format.json
     end
@@ -97,6 +102,21 @@ class AccountsController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @account.errors, status: :unprocessable_entity }
       end
+    end
+  end
+
+  # POST /accounts/merge
+  # Folds the selected expense/revenue accounts into the chosen target, then redirects back
+  # (Turbo Drive re-renders the whole index, reflecting the removed rows and new balance).
+  def merge
+    accounts = current_user.accounts.where(id: Array(params[:account_ids]))
+    target = accounts.find { |account| account.id.to_s == params[:target_account_id].to_s }
+    service = Account::Merge.new(target: target, sources: accounts, user: current_user)
+
+    if target && service.call
+      redirect_to accounts_path, notice: "Accounts merged into #{target.name}.", status: :see_other
+    else
+      redirect_to accounts_path, alert: service.errors.first || "Pick a target account to keep.", status: :see_other
     end
   end
 

--- a/app/javascript/controllers/accounts/selection_controller.js
+++ b/app/javascript/controllers/accounts/selection_controller.js
@@ -1,0 +1,145 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the expense/revenue account checkboxes on the accounts index. Selecting two or more
+// accounts of the same kind and currency reveals a Merge action; the user then picks which
+// account to keep before confirming. Mirrors transactions--selection, minus the merge-pair
+// and exclude/restore logic.
+export default class extends Controller {
+  static targets = [ "checkbox", "bar", "count", "message", "mergeButton", "confirmation", "targetList" ]
+
+  connect() {
+    // The browser restores checkbox state across a reload, so seed the selection from whatever
+    // is already checked and reflect it in the action bar — otherwise the bar stays hidden while
+    // boxes appear checked.
+    this.selectedIds = this.checkboxTargets.filter(checkbox => checkbox.checked).map(checkbox => checkbox.dataset.accountId)
+    this.updateBar()
+  }
+
+  toggle(event) {
+    const id = event.target.dataset.accountId
+
+    if (event.target.checked) {
+      this.selectedIds.push(id)
+    } else {
+      this.selectedIds = this.selectedIds.filter(selectedId => selectedId !== id)
+    }
+
+    this.updateBar()
+  }
+
+  updateBar() {
+    if (this.selectedIds.length < 1) {
+      this.hideBar()
+      this.hideConfirmation()
+      return
+    }
+
+    const noun = this.selectedIds.length === 1 ? "account" : "accounts"
+    this.countTarget.textContent = `${this.selectedIds.length} ${noun} selected`
+
+    const validation = this.validateSelection()
+    this.mergeButtonTarget.disabled = !validation.valid
+    this.messageTarget.textContent = validation.valid ? "" : validation.reason
+
+    this.barTarget.hidden = false
+  }
+
+  // Merge requires two or more accounts that all share one kind and one currency.
+  validateSelection() {
+    if (this.selectedIds.length < 2) {
+      return { valid: false, reason: "Select two or more accounts to merge" }
+    }
+
+    const rows = this.selectedRows()
+    const kinds = new Set(rows.map(row => row.dataset.kind))
+    const currencies = new Set(rows.map(row => row.dataset.currencyId))
+
+    if (kinds.size > 1) {
+      return { valid: false, reason: "Selected accounts must be the same type" }
+    }
+    if (currencies.size > 1) {
+      return { valid: false, reason: "Selected accounts must use the same currency" }
+    }
+    return { valid: true }
+  }
+
+  selectedRows() {
+    return this.selectedIds.map(id => this.checkboxFor(id)).filter(Boolean)
+  }
+
+  checkboxFor(id) {
+    return this.checkboxTargets.find(checkbox => checkbox.dataset.accountId === id)
+  }
+
+  showConfirmation() {
+    if (!this.validateSelection().valid) return
+
+    const rows = this.selectedRows()
+    // Default to the account with the most transactions, tie-broken by the lowest id (oldest).
+    const defaultId = rows
+      .slice()
+      .sort((a, b) => {
+        const byCount = Number(b.dataset.transactionCount) - Number(a.dataset.transactionCount)
+        return byCount !== 0 ? byCount : Number(a.dataset.accountId) - Number(b.dataset.accountId)
+      })[0].dataset.accountId
+
+    const form = this.confirmationTarget.querySelector("form")
+    form.querySelectorAll("input[name='account_ids[]']").forEach(input => input.remove())
+    this.targetListTarget.innerHTML = ""
+
+    rows.forEach(row => {
+      const id = row.dataset.accountId
+
+      const label = document.createElement("label")
+      label.className = "selection-confirmation__target"
+
+      const radio = document.createElement("input")
+      radio.type = "radio"
+      radio.name = "target_account_id"
+      radio.value = id
+      radio.checked = id === defaultId
+      label.appendChild(radio)
+
+      const name = document.createElement("span")
+      name.className = "selection-confirmation__target-name"
+      name.textContent = row.dataset.accountName
+      label.appendChild(name)
+
+      const count = Number(row.dataset.transactionCount)
+      const meta = document.createElement("span")
+      meta.className = "selection-confirmation__target-count"
+      meta.textContent = `${count} ${count === 1 ? "transaction" : "transactions"}`
+      label.appendChild(meta)
+
+      this.targetListTarget.appendChild(label)
+
+      const hidden = document.createElement("input")
+      hidden.type = "hidden"
+      hidden.name = "account_ids[]"
+      hidden.value = id
+      form.appendChild(hidden)
+    })
+
+    const noun = rows.length === 1 ? "account" : "accounts"
+    this.confirmationTarget.querySelector(".selection-confirmation__preview").textContent =
+      `${rows.length} ${noun} will be merged into the one you keep.`
+
+    this.confirmationTarget.hidden = false
+    this.barTarget.hidden = true
+  }
+
+  hideBar() {
+    this.barTarget.hidden = true
+  }
+
+  hideConfirmation() {
+    this.confirmationTarget.hidden = true
+  }
+
+  cancel() {
+    this.selectedIds = []
+    this.checkboxTargets.forEach(checkbox => { checkbox.checked = false })
+    this.hideBar()
+    this.hideConfirmation()
+  }
+}

--- a/app/services/account/merge.rb
+++ b/app/services/account/merge.rb
@@ -1,0 +1,68 @@
+class Account::Merge
+  attr_reader :target, :errors
+
+  def initialize(target:, sources:, user:)
+    @target  = target
+    @sources = Array(sources).reject { |source| source.id == target&.id }
+    @user    = user
+    @errors  = []
+  end
+
+  def call
+    validate!
+    return false if @errors.any?
+
+    source_ids = @sources.map(&:id)
+
+    ActiveRecord::Base.transaction do
+      # Repoint every transaction off the source accounts onto the target. update_all skips the
+      # balance-maintenance callbacks (Transaction#transfer_account_balances), so we recompute
+      # the target's balance from scratch below. Excluded and already-merged rows (amount_minor
+      # 0) are moved too, so the sources end up truly empty and destroy! won't trip
+      # restrict_with_error.
+      Transaction.where(src_account_id: source_ids).update_all(src_account_id: @target.id)
+      Transaction.where(dest_account_id: source_ids).update_all(dest_account_id: @target.id)
+
+      # Preserve the user's existing import rules: move any pointing at a soon-to-be-deleted
+      # account onto the kept account, otherwise dependent: :destroy would silently drop them.
+      # The (user_id, match_type, lower(match_pattern)) unique index excludes account_id, so
+      # repointing can never collide.
+      @user.import_rules.where(account_id: source_ids).update_all(account_id: @target.id)
+
+      # Only the target's balance changes: every moved transaction keeps its balance-sheet
+      # counterpart (and per-row amount) on the other side, so those balances stay correct.
+      @target.reset_balance
+
+      @sources.each(&:destroy!)
+    end
+
+    # reset_balance uses update_column, so broadcast the refreshed balance to the sidebar.
+    # The source removals broadcast on their own after_destroy_commit.
+    @target.broadcast_sidebar_update
+    true
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed => e
+    @errors << e.message
+    false
+  end
+
+  private
+
+    def validate!
+      @errors << "Select a target account to keep" if @target.nil?
+      @errors << "Select at least one other account to merge" if @sources.empty?
+
+      accounts = [ @target, *@sources ].compact
+      unless accounts.all? { |account| account.user_id == @user.id }
+        @errors << "All accounts must belong to you"
+      end
+
+      kinds = accounts.map(&:kind).uniq
+      unless kinds.size == 1 && %w[ expense revenue ].include?(kinds.first)
+        @errors << "Only expense or revenue accounts of the same kind can be merged"
+      end
+
+      if accounts.map(&:currency_id).uniq.size > 1
+        @errors << "All accounts must use the same currency"
+      end
+    end
+end

--- a/app/views/accounts/_account_row.html.erb
+++ b/app/views/accounts/_account_row.html.erb
@@ -1,5 +1,19 @@
 <% deletable = accounts_with_transactions.exclude?(account.id) %>
 <div id="<%= dom_id(account) %>" class="row">
+  <% if account.expense? || account.revenue? %>
+    <div class="select">
+      <input type="checkbox"
+             class="selection-checkbox"
+             data-accounts--selection-target="checkbox"
+             data-action="change->accounts--selection#toggle"
+             data-account-id="<%= account.id %>"
+             data-account-name="<%= account.name %>"
+             data-kind="<%= account.kind %>"
+             data-currency-id="<%= account.currency_id %>"
+             data-transaction-count="<%= transaction_counts[account.id] %>"
+             aria-label="Select <%= account.name %> for merging">
+    </div>
+  <% end %>
   <div data-label="Account">
     <%= link_to account.name, account %>
   </div>

--- a/app/views/accounts/_selection_bar.html.erb
+++ b/app/views/accounts/_selection_bar.html.erb
@@ -1,0 +1,47 @@
+<%# Merge action bar — appears when one or more expense/revenue accounts are checked. Merge
+    enables only when two or more accounts of the same kind and currency are selected. %>
+<div class="selection-bar" data-accounts--selection-target="bar" hidden>
+  <span class="selection-bar__count" data-accounts--selection-target="count"></span>
+  <span class="selection-bar__message" data-accounts--selection-target="message"></span>
+
+  <button type="button" class="selection-bar__btn selection-bar__btn--primary"
+          data-accounts--selection-target="mergeButton"
+          data-action="accounts--selection#showConfirmation"
+          disabled>
+    Merge
+  </button>
+
+  <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
+          data-action="accounts--selection#cancel">
+    Cancel
+  </button>
+</div>
+
+<%# Merge confirmation panel — pick which account to keep. The controller fills the target
+    radio list and injects the account_ids[] hidden inputs before this form is submitted. %>
+<div class="selection-confirmation" data-accounts--selection-target="confirmation" hidden>
+  <div class="selection-confirmation__content">
+    <h3>Merge accounts</h3>
+    <p class="selection-confirmation__preview"></p>
+
+    <%= form_with url: merge_accounts_path, method: :post,
+          data: { action: "turbo:submit-end->accounts--selection#cancel" } do %>
+      <div class="selection-confirmation__keep">
+        <span class="selection-confirmation__label">Keep this account</span>
+        <div class="selection-confirmation__targets" data-accounts--selection-target="targetList"></div>
+      </div>
+
+      <p class="selection-confirmation__note">
+        Transactions and import rules from the other accounts move to the kept account, and the
+        others are deleted. Already-imported transactions stay merged; a new import whose
+        description exactly matches a removed account's name may recreate it.
+      </p>
+
+      <div class="selection-confirmation__actions">
+        <button type="submit" class="selection-bar__btn selection-bar__btn--primary">Confirm merge</button>
+        <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
+                data-action="accounts--selection#cancel">Cancel</button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -18,20 +18,27 @@
     </div>
   </div>
 <% else %>
-  <% Account.kinds.keys.each do |kind| %>
-    <% accounts = @grouped_accounts[kind] || [] %>
-    <section class="accounts-group">
-      <h2><%= kind.humanize.pluralize %></h2>
-      <div class="accounts">
-        <div class="row header">
-          <div>Account</div>
-          <div>Balance</div>
-          <div>Sources</div>
-          <div>Actions</div>
+  <div data-controller="accounts--selection">
+    <% Account.kinds.keys.each do |kind| %>
+      <% accounts = @grouped_accounts[kind] || [] %>
+      <% selectable = %w[ expense revenue ].include?(kind) %>
+      <section class="accounts-group">
+        <h2><%= kind.humanize.pluralize %></h2>
+        <div class="accounts<%= " accounts--selectable" if selectable %>">
+          <div class="row header">
+            <% if selectable %><div class="select"></div><% end %>
+            <div>Account</div>
+            <div>Balance</div>
+            <div>Sources</div>
+            <div>Actions</div>
+          </div>
+          <%= render partial: "accounts/account_row", collection: accounts, as: :account,
+                locals: { accounts_with_transactions: @accounts_with_transactions,
+                          transaction_counts: @transaction_counts } %>
         </div>
-        <%= render partial: "accounts/account_row", collection: accounts, as: :account,
-              locals: { accounts_with_transactions: @accounts_with_transactions } %>
-      </div>
-    </section>
-  <% end %>
+      </section>
+    <% end %>
+
+    <%= render "accounts/selection_bar" %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :accounts do
+    collection do
+      post :merge
+    end
     resources :transactions, only: %i[ index ]
     resources :csv_imports, controller: "csv/imports", except: %i[ edit ] do
       member do

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -402,4 +402,53 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # errors are present in the JSON body.
     assert_includes JSON.parse(response.body).keys, "base"
   end
+
+  test "should merge selected accounts into the chosen target" do
+    target = Account.create!(user: @user, name: "Amazon", kind: :expense, currency: currencies(:usd))
+    source = Account.create!(user: @user, name: "Amazon Marketplace", kind: :expense, currency: currencies(:usd))
+    transaction = Transaction.create!(
+      user: @user, src_account: accounts(:asset_account), dest_account: source,
+      amount_minor: 800, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+
+    post merge_accounts_url, params: { account_ids: [ target.id, source.id ], target_account_id: target.id }
+
+    assert_redirected_to accounts_url
+    assert_equal "Accounts merged into Amazon.", flash[:notice]
+    assert_nil Account.find_by(id: source.id)
+    assert_equal target.id, transaction.reload.dest_account_id
+  end
+
+  test "should not merge accounts belonging to another user" do
+    target = Account.create!(user: @user, name: "Amazon", kind: :expense, currency: currencies(:usd))
+    other = Account.create!(user: users(:two), name: "Theirs", kind: :expense, currency: currencies(:usd))
+
+    post merge_accounts_url, params: { account_ids: [ target.id, other.id ], target_account_id: target.id }
+
+    # The other user's account is scoped out, leaving no real source to merge.
+    assert_redirected_to accounts_url
+    assert_equal "Select at least one other account to merge", flash[:alert]
+    assert Account.exists?(other.id)
+  end
+
+  test "should not merge accounts of different kinds" do
+    target = Account.create!(user: @user, name: "Foo", kind: :expense, currency: currencies(:usd))
+    source = Account.create!(user: @user, name: "Bar", kind: :revenue, currency: currencies(:usd))
+
+    post merge_accounts_url, params: { account_ids: [ target.id, source.id ], target_account_id: target.id }
+
+    assert_redirected_to accounts_url
+    assert_equal "Only expense or revenue accounts of the same kind can be merged", flash[:alert]
+    assert Account.exists?(source.id)
+  end
+
+  test "should require a target account to merge" do
+    source = Account.create!(user: @user, name: "Bar", kind: :expense, currency: currencies(:usd))
+
+    post merge_accounts_url, params: { account_ids: [ source.id ] }
+
+    assert_redirected_to accounts_url
+    assert_equal "Pick a target account to keep.", flash[:alert]
+    assert Account.exists?(source.id)
+  end
 end

--- a/test/services/account/merge_test.rb
+++ b/test/services/account/merge_test.rb
@@ -1,0 +1,224 @@
+require "test_helper"
+
+class Account::MergeTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @bank = accounts(:asset_account)
+    @bank_b = accounts(:linked_asset)
+
+    @target = Account.create!(user: @user, name: "Amazon", kind: :expense, currency: @currency)
+    @source = Account.create!(user: @user, name: "Amazon Marketplace", kind: :expense, currency: @currency)
+
+    @target_txn = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @target,
+      amount_minor: 300, currency: @currency, description: "Amazon", transacted_at: 2.days.ago
+    )
+    @source_txn = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @source,
+      amount_minor: 500, currency: @currency, description: "Amazon Marketplace", transacted_at: 1.day.ago
+    )
+  end
+
+  test "moves transactions from the sources onto the target" do
+    service = Account::Merge.new(target: @target, sources: [ @source ], user: @user)
+
+    assert service.call, service.errors.inspect
+    assert_equal @target.id, @source_txn.reload.dest_account_id
+    assert_equal @target.id, @target_txn.reload.dest_account_id
+  end
+
+  test "destroys the source accounts and keeps the target" do
+    Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+
+    assert_nil Account.find_by(id: @source.id)
+    assert Account.exists?(@target.id)
+  end
+
+  test "recomputes the target balance from all moved transactions" do
+    Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+
+    assert_equal 800, @target.reload.balance_minor # 300 + 500
+  end
+
+  test "recomputes the target balance using the fx amount on the source leg" do
+    revenue_target = Account.create!(user: @user, name: "Refunds", kind: :revenue, currency: @currency)
+    revenue_source = Account.create!(user: @user, name: "Rebates", kind: :revenue, currency: @currency)
+    transaction = Transaction.create!(
+      user: @user, src_account: revenue_source, dest_account: @bank,
+      amount_minor: 1000, currency: @currency, transacted_at: 1.day.ago
+    )
+    transaction.update_columns(fx_amount_minor: 900, fx_currency_id: currencies(:eur).id)
+
+    Account::Merge.new(target: revenue_target, sources: [ revenue_source ], user: @user).call
+
+    # Revenue account on the src side: balance = deposits(0) - withdrawals(COALESCE(fx, amount) = 900).
+    assert_equal(-900, revenue_target.reload.balance_minor)
+  end
+
+  test "moves excluded transactions without counting them in the balance" do
+    excluded = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @source,
+      amount_minor: 700, currency: @currency, transacted_at: 1.day.ago
+    )
+    excluded.update_columns(excluded_at: Time.current)
+
+    Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+
+    assert_equal @target.id, excluded.reload.dest_account_id
+    assert_equal 800, @target.reload.balance_minor # excluded 700 not counted
+  end
+
+  test "moves merged-away transactions so the source can be deleted" do
+    master = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @bank_b,
+      amount_minor: 500, currency: @currency, transacted_at: 1.day.ago
+    )
+    merged_away = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @source,
+      amount_minor: 500, currency: @currency, transacted_at: 1.day.ago
+    )
+    merged_away.update!(amount_minor: 0, merged_into: master)
+
+    assert Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+    assert_nil Account.find_by(id: @source.id)
+    assert_equal @target.id, merged_away.reload.dest_account_id
+  end
+
+  test "moves split parent and child transactions" do
+    parent = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @source,
+      amount_minor: 1000, currency: @currency, transacted_at: 1.day.ago
+    )
+    child = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @source,
+      amount_minor: 400, currency: @currency, transacted_at: 1.day.ago, parent_transaction: parent
+    )
+
+    assert Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+    assert_equal @target.id, parent.reload.dest_account_id
+    assert_equal @target.id, child.reload.dest_account_id
+    assert parent.split?
+  end
+
+  test "merges several sources at once" do
+    other_source = Account.create!(user: @user, name: "Amazon Prime", kind: :expense, currency: @currency)
+    other_txn = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: other_source,
+      amount_minor: 200, currency: @currency, transacted_at: 1.day.ago
+    )
+
+    assert Account::Merge.new(target: @target, sources: [ @source, other_source ], user: @user).call
+    assert_nil Account.find_by(id: @source.id)
+    assert_nil Account.find_by(id: other_source.id)
+    assert_equal @target.id, other_txn.reload.dest_account_id
+    assert_equal 1000, @target.reload.balance_minor # 300 + 500 + 200
+  end
+
+  test "repoints existing import rules onto the target" do
+    rule = @user.import_rules.create!(match_type: :contains, match_pattern: "marketplace", account: @source)
+
+    Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+
+    assert_equal @target.id, rule.reload.account_id
+  end
+
+  test "does not create new import rules" do
+    assert_no_difference -> { ImportRule.count } do
+      Account::Merge.new(target: @target, sources: [ @source ], user: @user).call
+    end
+  end
+
+  test "rejects accounts of different kinds" do
+    revenue = Account.create!(user: @user, name: "Mixed Kind", kind: :revenue, currency: @currency)
+
+    service = Account::Merge.new(target: @target, sources: [ revenue ], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "Only expense or revenue accounts of the same kind can be merged"
+    assert Account.exists?(revenue.id)
+  end
+
+  test "rejects balance-sheet accounts" do
+    service = Account::Merge.new(target: @bank, sources: [ @bank_b ], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "Only expense or revenue accounts of the same kind can be merged"
+  end
+
+  test "rejects mismatched currencies" do
+    eur_source = Account.create!(user: @user, name: "EUR Amazon", kind: :expense, currency: currencies(:eur))
+
+    service = Account::Merge.new(target: @target, sources: [ eur_source ], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "All accounts must use the same currency"
+    assert Account.exists?(eur_source.id)
+  end
+
+  test "rejects accounts belonging to another user" do
+    other = Account.create!(user: users(:two), name: "Theirs", kind: :expense, currency: @currency)
+
+    service = Account::Merge.new(target: @target, sources: [ other ], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "All accounts must belong to you"
+  end
+
+  test "rejects an empty source list" do
+    service = Account::Merge.new(target: @target, sources: [], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "Select at least one other account to merge"
+  end
+
+  test "rejects a missing target" do
+    service = Account::Merge.new(target: nil, sources: [ @source ], user: @user)
+
+    assert_not service.call
+    assert_includes service.errors, "Select a target account to keep"
+  end
+
+  test "ignores the target when it is also passed as a source" do
+    service = Account::Merge.new(target: @target, sources: [ @target, @source ], user: @user)
+
+    assert service.call, service.errors.inspect
+    assert Account.exists?(@target.id)
+    assert_nil Account.find_by(id: @source.id)
+  end
+
+  test "rolls back everything when a source cannot be destroyed" do
+    Account.stub_any_instance(:reset_balance, -> { raise ActiveRecord::RecordNotDestroyed.new("boom") }) do
+      service = Account::Merge.new(target: @target, sources: [ @source ], user: @user)
+      assert_not service.call
+      assert service.errors.any?
+    end
+
+    assert_equal @source.id, @source_txn.reload.dest_account_id
+    assert Account.exists?(@source.id)
+  end
+
+  test "re-importing does not resurrect a merged-away account for already-imported transactions" do
+    bank = accounts(:linked_asset)
+    simplefin_transaction = simplefin_transactions(:transaction_one)
+    source = Account.create!(user: @user, name: "Resurrect Me", kind: :expense, currency: @currency)
+    target = Account.create!(user: @user, name: "Keeper", kind: :expense, currency: @currency)
+
+    ledger = create_sourced_transaction(
+      sourceable: simplefin_transaction,
+      user: @user, src_account: bank, dest_account: source,
+      amount_minor: 5000, currency: @currency, description: simplefin_transaction.description,
+      transacted_at: simplefin_transaction.transacted_at, synced_at: 2.days.ago
+    )
+    simplefin_transaction.update!(synced_at: 1.hour.ago)
+
+    assert Account::Merge.new(target: target, sources: [ source ], user: @user).call
+
+    assert_no_difference -> { Transaction.count } do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: simplefin_transaction.account_id)
+    end
+
+    assert_equal target.id, ledger.reload.dest_account_id
+    assert_nil @user.accounts.expense.find_by("LOWER(name) = LOWER(?)", "Resurrect Me")
+  end
+end

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -230,10 +230,88 @@ class AccountsTest < ApplicationSystemTestCase
     assert_link "Go to Integrations"
   end
 
+  test "merging two expense accounts folds one into the kept account" do
+    keeper = accounts(:expense_account) # has fixture transaction one ($50.00)
+    keeper.reset_balance
+    duplicate = Account.create!(user: @user, name: "Duplicate Expense", kind: :expense, currency: currencies(:usd))
+    Transaction.create!(
+      user: @user, src_account: accounts(:asset_account), dest_account: duplicate,
+      amount_minor: 2500, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+
+    visit accounts_path
+
+    toggle_select(keeper)
+    toggle_select(duplicate)
+
+    within ".selection-bar" do
+      assert_text "2 accounts selected"
+      click_button "Merge"
+    end
+
+    find("input[name='target_account_id'][value='#{keeper.id}']").click
+    click_button "Confirm merge"
+
+    assert_text "Accounts merged into Expense Account."
+    assert_no_selector row_for(duplicate)
+    within row_for(keeper) do
+      assert_text "$75.00" # $50.00 (fixture) + $25.00 (moved)
+    end
+  end
+
+  test "the merge confirmation shows each account's transaction count" do
+    keeper = accounts(:expense_account) # has fixture transaction one => 1 transaction
+    duplicate = Account.create!(user: @user, name: "Duplicate Expense", kind: :expense, currency: currencies(:usd))
+    2.times do |index|
+      Transaction.create!(
+        user: @user, src_account: accounts(:asset_account), dest_account: duplicate,
+        amount_minor: 100 * (index + 1), currency: currencies(:usd), transacted_at: 1.day.ago
+      )
+    end
+
+    visit accounts_path
+    toggle_select(keeper)
+    toggle_select(duplicate)
+    within(".selection-bar") { click_button "Merge" }
+
+    within ".selection-confirmation" do
+      assert_text "Expense Account"
+      assert_text "1 transaction"
+      assert_text "Duplicate Expense"
+      assert_text "2 transactions"
+    end
+  end
+
+  test "restoring a checked selection on reconnect shows the merge bar" do
+    keeper = accounts(:expense_account)
+    duplicate = Account.create!(user: @user, name: "Duplicate Expense", kind: :expense, currency: currencies(:usd))
+
+    visit accounts_path
+
+    # Reproduce a browser reload restoring checkbox state: live-check the boxes without firing a
+    # change event, then make Stimulus tear down and reconnect the controller. connect() must
+    # re-derive the selection from the already-checked boxes so the bar reappears on its own.
+    page.execute_script(<<~JS, keeper.id, duplicate.id)
+      document.querySelector("input.selection-checkbox[data-account-id='" + arguments[0] + "']").checked = true
+      document.querySelector("input.selection-checkbox[data-account-id='" + arguments[1] + "']").checked = true
+      window.__mergeWrapper = document.querySelector("[data-controller='accounts--selection']")
+      window.__mergeWrapper.removeAttribute("data-controller")
+    JS
+    page.execute_script("window.__mergeWrapper.setAttribute('data-controller', 'accounts--selection')")
+
+    within ".selection-bar" do
+      assert_text "2 accounts selected"
+    end
+  end
+
   private
 
   def row_for(account)
     "##{ActionView::RecordIdentifier.dom_id(account)}"
+  end
+
+  def toggle_select(account)
+    find("input.selection-checkbox[data-account-id='#{account.id}']").click
   end
 
   def sign_in_as(user)


### PR DESCRIPTION
## Summary

Importers auto-create an expense/revenue account per distinct transaction description, so slight variations leave duplicate accounts (e.g. several "Amazon" expense accounts) with no way to consolidate them — deletion is blocked once an account has transactions.

This adds a **merge** action on the accounts index: select several expense/revenue accounts via checkboxes, pick which one to keep, and fold the rest into it.

- **`Account::Merge` service** (`app/services/account/merge.rb`) — in one transaction it repoints every transaction (including excluded/zeroed-merged rows, so sources end up truly empty), moves existing import rules onto the kept account, recomputes the kept account's balance with `reset_balance`, deletes the now-empty sources, and broadcasts the sidebar. Validates same-kind (expense/revenue only), same-currency, and ownership.
- **`POST /accounts/merge`** (`AccountsController#merge`) — scopes all ids through `current_user.accounts`, then redirects back (Turbo Drive re-renders the index).
- **UI** — a dedicated checkbox column on the Expenses/Revenues tables and a new `accounts--selection` Stimulus controller (a trimmed copy of the transactions one). It reveals a fixed action bar when 2+ same-kind/same-currency accounts are checked, then a confirmation panel with a radio list to pick the surviving account — defaulting to the one with the most transactions and showing each account's transaction count.

### Scope & re-import behavior

Expense/revenue accounts only: they have no integration source links and no opening balances, and two income/expense accounts can never be the two sides of one transaction, which removes the hard edge cases. Asset/liability/equity merging is intentionally out of scope.

Already-imported transactions keep their `TransactionSource`, so importers re-sync scalars only and never re-derive the counterpart account — they stay on the kept account after a merge. Only a brand-new future import whose description exactly matches a removed account's name could recreate it; the confirmation panel says as much, and no import rules are auto-created (you'd add one manually if needed).

## Test plan

- `test/services/account/merge_test.rb` — moves src/dest transactions incl. FX/excluded/merged/split rows; recomputes balance; deletes sources; repoints existing import rules; creates **no** new rules; validations (mixed kind, mixed currency, cross-user, empty sources, missing target); rollback on failure; and a regression test that re-runs `Simplefin::ImportTransactionsJob` after a merge and asserts the merged-away account is **not** resurrected.
- `test/controllers/accounts_controller_test.rb` — success (303 + notice, sources gone), cross-user ids scoped out, mixed-kind rejected, missing-target rejected.
- `test/system/accounts_test.rb` — select two expense accounts → Merge → pick target → Confirm (duplicate row gone, balance updated); the confirmation shows each account's transaction count (singular/plural); and a restored-selection-on-reconnect case so the action bar reappears when the browser restores checked boxes after a reload.

### Checks
- `bin/rails test` → 811 runs, 0 failures, 100% line coverage
- `bin/rails test:system` → 57 runs, 0 failures
- `bin/rubocop`, `bin/brakeman`, `bin/bundler-audit`, `bin/importmap audit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)