### PR TITLE
Build the merge confirmation account list from a <template>

### DIFF
--- a/app/javascript/controllers/accounts/selection_controller.js
+++ b/app/javascript/controllers/accounts/selection_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus"
 // account to keep before confirming. Mirrors transactions--selection, minus the merge-pair
 // and exclude/restore logic.
 export default class extends Controller {
-  static targets = [ "checkbox", "bar", "count", "message", "mergeButton", "confirmation", "targetList" ]
+  static targets = [ "checkbox", "bar", "count", "message", "mergeButton", "confirmation", "targetList", "targetTemplate" ]
 
   connect() {
     // The browser restores checkbox state across a reload, so seed the selection from whatever
@@ -83,41 +83,24 @@ export default class extends Controller {
         return byCount !== 0 ? byCount : Number(a.dataset.accountId) - Number(b.dataset.accountId)
       })[0].dataset.accountId
 
-    const form = this.confirmationTarget.querySelector("form")
-    form.querySelectorAll("input[name='account_ids[]']").forEach(input => input.remove())
-    this.targetListTarget.innerHTML = ""
-
+    this.targetListTarget.replaceChildren()
     rows.forEach(row => {
       const id = row.dataset.accountId
+      const fragment = this.targetTemplateTarget.content.cloneNode(true)
 
-      const label = document.createElement("label")
-      label.className = "selection-confirmation__target"
-
-      const radio = document.createElement("input")
-      radio.type = "radio"
-      radio.name = "target_account_id"
+      const radio = fragment.querySelector("input[name='target_account_id']")
       radio.value = id
       radio.checked = id === defaultId
-      label.appendChild(radio)
 
-      const name = document.createElement("span")
-      name.className = "selection-confirmation__target-name"
-      name.textContent = row.dataset.accountName
-      label.appendChild(name)
+      fragment.querySelector(".selection-confirmation__target-name").textContent = row.dataset.accountName
 
       const count = Number(row.dataset.transactionCount)
-      const meta = document.createElement("span")
-      meta.className = "selection-confirmation__target-count"
-      meta.textContent = `${count} ${count === 1 ? "transaction" : "transactions"}`
-      label.appendChild(meta)
+      fragment.querySelector(".selection-confirmation__target-count").textContent =
+        `${count} ${count === 1 ? "transaction" : "transactions"}`
 
-      this.targetListTarget.appendChild(label)
+      fragment.querySelector("input[name='account_ids[]']").value = id
 
-      const hidden = document.createElement("input")
-      hidden.type = "hidden"
-      hidden.name = "account_ids[]"
-      hidden.value = id
-      form.appendChild(hidden)
+      this.targetListTarget.appendChild(fragment)
     })
 
     const noun = rows.length === 1 ? "account" : "accounts"

--- a/app/views/accounts/_selection_bar.html.erb
+++ b/app/views/accounts/_selection_bar.html.erb
@@ -31,6 +31,17 @@
         <div class="selection-confirmation__targets" data-accounts--selection-target="targetList"></div>
       </div>
 
+      <%# Cloned once per selected account by accounts--selection#showConfirmation. The hidden
+          account_ids[] input rides along inside each label so the whole selection posts. %>
+      <template data-accounts--selection-target="targetTemplate">
+        <label class="selection-confirmation__target">
+          <input type="radio" name="target_account_id">
+          <span class="selection-confirmation__target-name"></span>
+          <span class="selection-confirmation__target-count"></span>
+          <input type="hidden" name="account_ids[]">
+        </label>
+      </template>
+
       <p class="selection-confirmation__note">
         Transactions and import rules from the other accounts move to the kept account, and the
         others are deleted. Already-imported transactions stay merged; a new import whose


### PR DESCRIPTION
## Summary

Follow-up cleanup to #173. The merge confirmation's "keep this account" list was built imperatively in `accounts--selection#showConfirmation` with ~25 lines of `document.createElement`/`appendChild`. This moves the row markup into a `<template>` in the partial and reduces the controller to clone-and-fill.

- The row structure (radio, name, transaction count, hidden `account_ids[]` input) now lives declaratively in `app/views/accounts/_selection_bar.html.erb`.
- `showConfirmation()` clones `targetTemplate` per selected account and sets three fields.
- The hidden `account_ids[]` input rides inside each label, so `replaceChildren()` clears it (the separate form-cleanup is gone), and wrapping the row in the `<label>` means clicking an account's name/count now selects its radio.

No behavior change — purely a readability refactor of the same dialog.

## Test plan

Existing system tests in `test/system/accounts_test.rb` cover the refactored path:
- selecting two expense accounts → Merge → pick target → Confirm (duplicate gone, balance updated)
- the confirmation shows each account's transaction count (singular/plural)

### Checks
- `bin/rails test:system` (accounts) → 57 runs, 0 failures
- `bin/rubocop` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)