### PR TITLE
Seed the transactions selection bar from restored checkboxes on reload

### DIFF
--- a/app/javascript/controllers/transactions/selection_controller.js
+++ b/app/javascript/controllers/transactions/selection_controller.js
@@ -14,7 +14,11 @@ export default class extends Controller {
   static BALANCE_SHEET_KINDS = [ "asset", "liability", "equity" ]
 
   connect() {
-    this.selectedIds = []
+    // The browser restores checkbox state across a reload, so seed the selection from whatever
+    // is already checked and reflect it in the action bar — otherwise the bar stays hidden while
+    // boxes appear checked.
+    this.selectedIds = this.checkboxTargets.filter(checkbox => checkbox.checked).map(checkbox => checkbox.dataset.transactionId)
+    this.updateBar()
   }
 
   toggle(event) {

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -141,6 +141,28 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "restoring a checked selection on reconnect shows the bulk action bar" do
+    first = manual_transaction("Reconnect probe one", 100)
+    second = manual_transaction("Reconnect probe two", 200)
+
+    visit transactions_path
+
+    # Reproduce a browser reload restoring checkbox state: live-check the boxes without firing a
+    # change event, then make Stimulus tear down and reconnect the controller. connect() must
+    # re-derive the selection from the already-checked boxes so the bar reappears on its own.
+    page.execute_script(<<~JS, first.id, second.id)
+      document.querySelector("input.selection-checkbox[data-transaction-id='" + arguments[0] + "']").checked = true
+      document.querySelector("input.selection-checkbox[data-transaction-id='" + arguments[1] + "']").checked = true
+      window.__selectionWrapper = document.querySelector("[data-controller='transactions--selection']")
+      window.__selectionWrapper.removeAttribute("data-controller")
+    JS
+    page.execute_script("window.__selectionWrapper.setAttribute('data-controller', 'transactions--selection')")
+
+    within ".selection-bar" do
+      assert_text "2 transactions selected"
+    end
+  end
+
   test "bulk deleting selected transactions removes them from the list" do
     first = manual_transaction("Bulk delete one", 100)
     second = manual_transaction("Bulk delete two", 200)


### PR DESCRIPTION
## Summary

Applies the same fix shipped for the accounts merge selection (#173) to the transactions bulk-selection controller. The browser restores checkbox state across a reload, but `transactions--selection#connect()` always reset `selectedIds = []`, so the bulk action bar stayed hidden while the boxes appeared checked — and unchecking one at a time did nothing until every box was cleared.

`connect()` now derives the selection from whatever checkboxes are already checked and refreshes the bar, so it reappears (with the correct count and button states) on its own.

## Test plan

- `test/system/transactions_test.rb` — new test reproduces a reload restoring checked boxes (live-check without firing `change`, then force the Stimulus controller to reconnect) and asserts the bulk action bar reappears showing "2 transactions selected".

### Checks
- `bin/rails test:system` (transactions) → 58 runs, 0 failures
- `bin/rubocop` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)