### PR TITLE
Order source badges and drop the Sources column for unlinkable accounts

### DIFF
--- a/app/assets/stylesheets/accounts.css
+++ b/app/assets/stylesheets/accounts.css
@@ -59,25 +59,39 @@
   border-radius: 8px;
 }
 
+/* Account is the only flexing column; Balance, Sources, and Actions are pinned to
+   fixed widths so they stay flush against the right edge identically across every
+   group. That keeps Actions aligned down the whole page (and Balance aligned across
+   the groups without a Sources column), no matter which columns a group carries.
+
+   Base layout: Account, Balance, Actions. Equity groups use this as-is, since
+   they're neither linkable (no Sources) nor selectable (no checkbox). */
 .accounts .row {
   display: grid;
   grid-template-columns:
-    minmax(140px, 2fr)    /* Account */
-    minmax(90px,  1fr)    /* Balance */
-    minmax(120px, 1.5fr)  /* Sources */
-    minmax(160px, 1.5fr); /* Actions */
+    minmax(140px, 1fr)    /* Account */
+    130px                 /* Balance */
+    220px;                /* Actions */
   gap: 0;
   align-items: stretch;
+}
+
+/* Asset/liability groups add a Sources column (only they can link sources). */
+.accounts--linkable .row {
+  grid-template-columns:
+    minmax(140px, 1fr)    /* Account */
+    130px                 /* Balance */
+    200px                 /* Sources */
+    220px;                /* Actions */
 }
 
 /* Expense/revenue groups carry a leading checkbox column for merging. */
 .accounts--selectable .row {
   grid-template-columns:
     44px                  /* Select */
-    minmax(140px, 2fr)    /* Account */
-    minmax(90px,  1fr)    /* Balance */
-    minmax(120px, 1.5fr)  /* Sources */
-    minmax(160px, 1.5fr); /* Actions */
+    minmax(140px, 1fr)    /* Account */
+    130px                 /* Balance */
+    220px;                /* Actions */
 }
 
 .accounts .row > .select {

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -68,15 +68,24 @@ class AccountsController < ApplicationController
     sourceable = @simplefin_account || @lunchflow_account
 
     saved =
-      begin
-        Account.transaction do
-          @account.save.tap do |ok|
-            AccountSource::Attach.call(account: @account, sourceable: sourceable) if ok && sourceable
-          end
-        end
-      rescue AccountSource::Attach::MismatchedAccount
-        @account.errors.add(:base, "is already linked to another integration")
+      if sourceable && !@account.linkable?
+        # Only asset/liability accounts can back an aggregator source. Refuse the
+        # link rather than create an expense/revenue/equity account that the index
+        # would treat as unlinkable and hide the source badge for (see the Sources
+        # column gating in accounts/_account_row and Account#linkable?).
+        @account.errors.add(:kind, "must be an asset or liability account to link an integration")
         false
+      else
+        begin
+          Account.transaction do
+            @account.save.tap do |ok|
+              AccountSource::Attach.call(account: @account, sourceable: sourceable) if ok && sourceable
+            end
+          end
+        rescue AccountSource::Attach::MismatchedAccount
+          @account.errors.add(:base, "is already linked to another integration")
+          false
+        end
       end
 
     respond_to do |format|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,17 @@ module ApplicationHelper
     end
   end
 
+  # Sort rank for source badges, matching the aggregator order on the integrations
+  # page (SimpleFIN, then Lunch Flow, then CSV) rather than sorting alphabetically.
+  def source_badge_order(sourceable)
+    case sourceable
+    when Simplefin::Account, Simplefin::Transaction then 0
+    when Lunchflow::Account, Lunchflow::Transaction then 1
+    when Csv::Transaction then 2
+    else 3
+    end
+  end
+
   # Caller is responsible for passing a collection where each TransactionSource's
   # sourceable is already loaded (e.g., array from `includes(:sourceable)`).
   # An unloaded relation will N+1 on the per-source sourceable access below.

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -73,6 +73,12 @@ class Account < ApplicationRecord
     asset? || liability? || equity?
   end
 
+  # Only asset and liability accounts can be backed by an aggregator source; the
+  # `linkable` scope is the collection-level counterpart.
+  def linkable?
+    asset? || liability?
+  end
+
   def build_opening_balance_transaction(transaction_attributes = {})
     @opening_balance_transaction = Transaction.new({
       user: user,

--- a/app/views/accounts/_account_row.html.erb
+++ b/app/views/accounts/_account_row.html.erb
@@ -26,20 +26,21 @@
     </span>
   </div>
 
-  <div data-label="Sources">
-    <% account_sources = account.account_sources %>
-    <% if account_sources.any? %>
-      <% account_sources.each do |account_source| %>
-        <% sourceable = account_source.sourceable %>
-        <%= tag.span source_badge_label(sourceable), class: class_names("source-badge", source_badge_modifier(sourceable)) %>
-      <% end %>
-    <% else %>
-      <span class="accounts__not-linked">Not linked</span>
-      <% if account.asset? || account.liability? %>
+  <%# Only asset/liability accounts can carry an aggregator source, so the whole
+      Sources column is dropped from expense/revenue/equity groups (see index). %>
+  <% if account.linkable? %>
+    <div data-label="Sources">
+      <% sourceables = account.account_sources.map(&:sourceable).sort_by { |sourceable| source_badge_order(sourceable) } %>
+      <% if sourceables.any? %>
+        <% sourceables.each do |sourceable| %>
+          <%= tag.span source_badge_label(sourceable), class: class_names("source-badge", source_badge_modifier(sourceable)) %>
+        <% end %>
+      <% else %>
+        <span class="accounts__not-linked">Not linked</span>
         <%= link_to "Link", integrations_path, "aria-label": "Link #{account.name} to an integration" %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <div class="actions">
     <%= link_to "Transactions", account_transactions_path(account), "aria-label": "View transactions for #{account.name}" %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -22,14 +22,15 @@
     <% Account.kinds.keys.each do |kind| %>
       <% accounts = @grouped_accounts[kind] || [] %>
       <% selectable = %w[ expense revenue ].include?(kind) %>
+      <% linkable = %w[ asset liability ].include?(kind) %>
       <section class="accounts-group">
         <h2><%= kind.humanize.pluralize %></h2>
-        <div class="accounts<%= " accounts--selectable" if selectable %>">
+        <div class="accounts<%= " accounts--selectable" if selectable %><%= " accounts--linkable" if linkable %>">
           <div class="row header">
             <% if selectable %><div class="select"></div><% end %>
             <div>Account</div>
             <div>Balance</div>
-            <div>Sources</div>
+            <% if linkable %><div>Sources</div><% end %>
             <div>Actions</div>
           </div>
           <%= render partial: "accounts/account_row", collection: accounts, as: :account,

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -152,6 +152,24 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_includes Account.last.account_sources.map(&:sourceable), simplefin_account
   end
 
+  test "should not link a SimpleFIN account to a non-linkable kind" do
+    simplefin_account = simplefin_accounts(:unlinked_one)
+
+    assert_no_difference([ "Account.count", "AccountSource.count" ]) do
+      post accounts_url, params: {
+        account: {
+          name: "Groceries",
+          kind: "expense",
+          currency_id: @account.currency_id
+        },
+        simplefin_account_id: simplefin_account.id
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_not simplefin_account.reload.linked?
+  end
+
   test "rolls back account creation when AccountSource::Attach hits a concurrent-link race" do
     simplefin_account = simplefin_accounts(:unlinked_one)
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -119,6 +119,24 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_nil source_badge_modifier(currencies(:usd))
   end
 
+  # source_badge_order
+
+  test "source_badge_order ranks SimpleFIN ahead of Lunch Flow and CSV" do
+    sources = [
+      lunchflow_accounts(:linked_one),
+      Csv::Transaction.new,
+      simplefin_accounts(:linked_one)
+    ]
+
+    ordered = sources.sort_by { |source| source_badge_order(source) }.map { |source| source_badge_label(source) }
+
+    assert_equal [ "SimpleFIN", "Lunch Flow", "CSV" ], ordered
+  end
+
+  test "source_badge_order sorts unknown sourceable types last" do
+    assert_operator source_badge_order(currencies(:usd)), :>, source_badge_order(Csv::Transaction.new)
+  end
+
   # transaction_source_badges
 
   test "transaction_source_badges renders one styled span per source with aggregator modifiers" do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -301,6 +301,19 @@ class AccountTest < ActiveSupport::TestCase
     assert_not accounts(:revenue_account).balance_sheet?
   end
 
+  test "linkable? is true for asset and liability accounts" do
+    assert accounts(:asset_account).linkable?
+    assert accounts(:liability_account).linkable?
+  end
+
+  test "linkable? is false for equity, expense, and revenue accounts" do
+    equity = Account.create!(user: users(:one), currency: currencies(:usd), name: "Equity", kind: :equity)
+
+    assert_not equity.linkable?
+    assert_not accounts(:expense_account).linkable?
+    assert_not accounts(:revenue_account).linkable?
+  end
+
   test "empty? is false if account contains transactions" do
     @account.dest_transactions << transactions(:one)
 

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -134,6 +134,18 @@ class AccountsTest < ApplicationSystemTestCase
     end
   end
 
+  test "account rows order source badges like the integrations page (SimpleFIN first)" do
+    account = accounts(:linked_asset) # already carries a SimpleFIN source
+    AccountSource.create!(account: account, sourceable: lunchflow_accounts(:unlinked_one))
+
+    visit accounts_path
+
+    within row_for(account) do
+      labels = all(".source-badge").map(&:text)
+      assert_equal [ "SimpleFIN", "Lunch Flow" ], labels
+    end
+  end
+
   test "unlinked asset and liability rows offer a Link action" do
     visit accounts_path
 
@@ -147,12 +159,21 @@ class AccountsTest < ApplicationSystemTestCase
     end
   end
 
-  test "unlinked expense and revenue rows show Not linked without a Link action" do
+  test "expense and revenue groups drop the Sources column, since they can't be linked" do
     visit accounts_path
 
     within row_for(accounts(:expense_account)) do
-      assert_text "Not linked"
+      assert_no_text "Not linked"
       assert_no_link "Link", exact: true
+      assert_no_selector ".source-badge"
+    end
+
+    # The column header is gone for these groups but stays for linkable ones.
+    within find("section.accounts-group", text: "Expenses") do
+      within(".row.header") { assert_no_text "Sources" }
+    end
+    within find("section.accounts-group", text: "Assets") do
+      within(".row.header") { assert_text "Sources" }
     end
   end
 


### PR DESCRIPTION
## Summary

Two refinements to the accounts index, both about the **Sources** column:

- **Ordered source badges.** When an account links more than one integration, its badges now sort with a new `source_badge_order` helper so they follow the same aggregator order as the integrations page — **SimpleFIN, then Lunch Flow, then CSV** — instead of an arbitrary order.
- **Dropped the Sources column for unlinkable accounts.** Only asset and liability accounts can carry an aggregator source, so the entire Sources column (header + cells) is now removed from the **expense, revenue, and equity** groups, rather than showing a meaningless "Not linked" cell that can never become linked.

A new `Account#linkable?` instance method backs the row-level check, mirroring the existing `linkable` scope.

## Layout

With the column gone from some groups, the index grid is reworked so **Account is the only flexing column** and **Balance / Sources / Actions are pinned to fixed widths**. Because the flexing Account column absorbs all the slack (including the merge-checkbox column on expense/revenue groups), the fixed columns sit flush against the right edge identically in every group — so **Actions lines up down the whole page**, and **Balance lines up across the groups without a Sources column**.

## Test plan

- [x] `source_badge_order` ranks SimpleFIN ahead of Lunch Flow and CSV, and sorts unknown types last (helper test)
- [x] `Account#linkable?` is true for asset/liability and false for equity/expense/revenue (model test)
- [x] Account rows render multiple source badges in SimpleFIN-first order (system test)
- [x] Expense/revenue groups drop the Sources column header and cells, while linkable groups keep it (system test)
- [x] `bin/rubocop`, `bin/rails test`, `bin/rails test:system` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)