### PR TITLE
Add bulk cleanup of empty expense and revenue accounts

### DIFF
--- a/app/assets/stylesheets/accounts.css
+++ b/app/assets/stylesheets/accounts.css
@@ -35,6 +35,23 @@
   text-decoration: underline;
 }
 
+/* Bulk "clean up empty accounts" trigger — a danger-tinted text button that sits beside the
+   sibling header links (matches the per-row Delete color). */
+.accounts-header__cleanup {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-negative);
+  cursor: pointer;
+}
+
+.accounts-header__cleanup:hover {
+  text-decoration: underline;
+}
+
 /* Per-kind section — hidden until it has at least one data row,
    mirroring .sidebar-kind-group:has(li) */
 .accounts-group {
@@ -225,6 +242,21 @@
   color: var(--bark-light);
   font-size: 0.8rem;
   font-variant-numeric: tabular-nums;
+}
+
+/* Cleanup confirmation — the reviewable list of accounts the bulk delete will remove. Scrolls
+   so a long list can't push the confirmation panel past the viewport. */
+.selection-confirmation__cleanup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.selection-confirmation__cleanup-item {
+  font-size: 0.875rem;
+  color: var(--bark);
 }
 
 /* Empty state */

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -34,12 +34,19 @@ class AccountsController < ApplicationController
         end
         @accounts_with_transactions = @transaction_counts.keys.to_set
 
+        # An account that is the target of an import rule is an in-use mapping, not clutter —
+        # destroying it would also destroy the rule (dependent: :destroy), so keep it out of the
+        # cleanup set even when it currently has no transactions.
+        rule_target_ids = current_user.import_rules.where(account_id: account_ids).distinct.pluck(:account_id).to_set
+
         # Expense/revenue accounts that no transaction references accumulate from imports and
         # merges. They're the ones safe to bulk-delete, so surface them to the header "Clean up"
         # affordance. (A merge-reference account still holds its zeroed, merged-away transaction,
         # so it stays in @accounts_with_transactions and is correctly excluded here.)
         @empty_cleanup_accounts = @accounts.select do |account|
-          (account.expense? || account.revenue?) && @accounts_with_transactions.exclude?(account.id)
+          (account.expense? || account.revenue?) &&
+            @accounts_with_transactions.exclude?(account.id) &&
+            rule_target_ids.exclude?(account.id)
         end
       end
       format.json
@@ -140,13 +147,16 @@ class AccountsController < ApplicationController
   # DELETE /accounts/cleanup_empty
   # Bulk-deletes the user's empty expense/revenue accounts, then redirects back (Turbo Drive
   # re-renders the index, so the removed rows and the header affordance both update). Never
-  # trusts the posted ids: every candidate is re-scoped to the user's expense/revenue accounts
-  # and re-checked with empty? at delete time, so a stale list can't delete a non-empty account
-  # (including a merge reference, whose merged-away transaction keeps it non-empty so unmerge
-  # stays possible).
+  # trusts the posted ids: every candidate is re-scoped to the user's expense/revenue accounts,
+  # excludes import-rule targets (destroying one would also destroy the rule via
+  # dependent: :destroy and silently drop a future mapping), and is re-checked with empty? at
+  # delete time, so a stale list can't delete a non-empty account (including a merge reference,
+  # whose merged-away transaction keeps it non-empty so unmerge stays possible).
   def cleanup_empty
     account_ids = Array(params[:account_ids]).uniq
-    candidates = current_user.accounts.where(id: account_ids, kind: %i[ expense revenue ], virtual: false)
+    candidates = current_user.accounts
+                             .where(id: account_ids, kind: %i[ expense revenue ], virtual: false)
+                             .where.missing(:import_rules)
 
     deleted_count = 0
     Account.transaction do

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -33,6 +33,14 @@ class AccountsController < ApplicationController
             end
         end
         @accounts_with_transactions = @transaction_counts.keys.to_set
+
+        # Expense/revenue accounts that no transaction references accumulate from imports and
+        # merges. They're the ones safe to bulk-delete, so surface them to the header "Clean up"
+        # affordance. (A merge-reference account still holds its zeroed, merged-away transaction,
+        # so it stays in @accounts_with_transactions and is correctly excluded here.)
+        @empty_cleanup_accounts = @accounts.select do |account|
+          (account.expense? || account.revenue?) && @accounts_with_transactions.exclude?(account.id)
+        end
       end
       format.json
     end
@@ -127,6 +135,36 @@ class AccountsController < ApplicationController
     else
       redirect_to accounts_path, alert: service.errors.first || "Pick a target account to keep.", status: :see_other
     end
+  end
+
+  # DELETE /accounts/cleanup_empty
+  # Bulk-deletes the user's empty expense/revenue accounts, then redirects back (Turbo Drive
+  # re-renders the index, so the removed rows and the header affordance both update). Never
+  # trusts the posted ids: every candidate is re-scoped to the user's expense/revenue accounts
+  # and re-checked with empty? at delete time, so a stale list can't delete a non-empty account
+  # (including a merge reference, whose merged-away transaction keeps it non-empty so unmerge
+  # stays possible).
+  def cleanup_empty
+    account_ids = Array(params[:account_ids]).uniq
+    candidates = current_user.accounts.where(id: account_ids, kind: %i[ expense revenue ], virtual: false)
+
+    deleted_count = 0
+    Account.transaction do
+      candidates.each do |account|
+        next unless account.empty?
+        # Non-bang destroy: restrict_with_error returns false (without raising) if a transaction
+        # landed since the empty? check, so a race degrades gracefully instead of 500ing.
+        deleted_count += 1 if account.destroy
+      end
+    end
+
+    notice =
+      if deleted_count.zero?
+        "No empty accounts to clean up."
+      else
+        "Deleted #{deleted_count} empty #{"account".pluralize(deleted_count)}."
+      end
+    redirect_to accounts_path, notice: notice, status: :see_other
   end
 
   # DELETE /accounts/1 or /accounts/1.json

--- a/app/javascript/controllers/accounts/selection_controller.js
+++ b/app/javascript/controllers/accounts/selection_controller.js
@@ -2,10 +2,14 @@ import { Controller } from "@hotwired/stimulus"
 
 // Drives the expense/revenue account checkboxes on the accounts index. Selecting two or more
 // accounts of the same kind and currency reveals a Merge action; the user then picks which
-// account to keep before confirming. Mirrors transactions--selection, minus the merge-pair
-// and exclude/restore logic.
+// account to keep before confirming. Empty accounts (no transactions) can also be cleaned up:
+// the header "Clean up" button selects every empty account at once, and a bar Delete button
+// removes a hand-picked subset — both open the same reviewable confirmation before deleting.
+// Mirrors transactions--selection, minus the merge-pair and exclude/restore logic.
 export default class extends Controller {
-  static targets = [ "checkbox", "bar", "count", "message", "mergeButton", "confirmation", "targetList", "targetTemplate" ]
+  static targets = [ "checkbox", "bar", "count", "message", "mergeButton", "confirmation",
+    "targetList", "targetTemplate", "deleteButton", "cleanupButton", "cleanupForm",
+    "cleanupConfirmation", "cleanupList", "cleanupItemTemplate" ]
 
   connect() {
     // The browser restores checkbox state across a reload, so seed the selection from whatever
@@ -31,6 +35,7 @@ export default class extends Controller {
     if (this.selectedIds.length < 1) {
       this.hideBar()
       this.hideConfirmation()
+      this.hideCleanupConfirmation()
       return
     }
 
@@ -40,6 +45,12 @@ export default class extends Controller {
     const validation = this.validateSelection()
     this.mergeButtonTarget.disabled = !validation.valid
     this.messageTarget.textContent = validation.valid ? "" : validation.reason
+
+    // Delete is offered only when every checked account is empty — the per-row checkbox carries
+    // its transaction count, and "0" means it can be destroyed (restrict_with_error otherwise).
+    if (this.hasDeleteButtonTarget) {
+      this.deleteButtonTarget.hidden = !this.selectedRows().every(row => row.dataset.transactionCount === "0")
+    }
 
     this.barTarget.hidden = false
   }
@@ -111,12 +122,63 @@ export default class extends Controller {
     this.barTarget.hidden = true
   }
 
+  // Header "Clean up" affordance: check every empty account the server flagged, then open the
+  // reviewable confirmation listing exactly what will be deleted.
+  confirmCleanup() {
+    const ids = JSON.parse(this.cleanupButtonTarget.dataset.emptyAccountIds || "[]").map(String)
+    this.selectedIds = ids
+    this.checkboxTargets.forEach(checkbox => { checkbox.checked = ids.includes(checkbox.dataset.accountId) })
+    this.openCleanupConfirmation(ids)
+  }
+
+  // Bar Delete: confirm the hand-picked subset (only shown when every checked account is empty).
+  confirmDeleteSelected() {
+    this.openCleanupConfirmation(this.selectedIds)
+  }
+
+  openCleanupConfirmation(ids) {
+    const rows = ids.map(id => this.checkboxFor(id)).filter(Boolean)
+
+    this.cleanupListTarget.replaceChildren()
+    rows.forEach(row => {
+      const fragment = this.cleanupItemTemplateTarget.content.cloneNode(true)
+      fragment.querySelector(".selection-confirmation__cleanup-name").textContent = row.dataset.accountName
+      this.cleanupListTarget.appendChild(fragment)
+    })
+
+    const noun = rows.length === 1 ? "account" : "accounts"
+    this.cleanupConfirmationTarget.querySelector(".selection-confirmation__preview").textContent =
+      `${rows.length} empty expense/revenue ${noun} will be permanently deleted.`
+
+    this.cleanupConfirmationTarget.hidden = false
+    this.hideBar()
+  }
+
+  submitCleanup() {
+    const form = this.cleanupFormTarget
+    form.querySelectorAll("input[name='account_ids[]']").forEach(input => input.remove())
+    this.selectedIds.forEach(id => {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = "account_ids[]"
+      input.value = id
+      form.appendChild(input)
+    })
+    form.requestSubmit()
+  }
+
+  // The header button can be present on a page whose selection bar isn't rendered (the empty
+  // accounts state), so guard the bar/confirmation targets here.
   hideBar() {
-    this.barTarget.hidden = true
+    if (this.hasBarTarget) this.barTarget.hidden = true
   }
 
   hideConfirmation() {
-    this.confirmationTarget.hidden = true
+    if (this.hasConfirmationTarget) this.confirmationTarget.hidden = true
+  }
+
+  hideCleanupConfirmation() {
+    if (this.hasCleanupConfirmationTarget) this.cleanupConfirmationTarget.hidden = true
   }
 
   cancel() {
@@ -124,5 +186,6 @@ export default class extends Controller {
     this.checkboxTargets.forEach(checkbox => { checkbox.checked = false })
     this.hideBar()
     this.hideConfirmation()
+    this.hideCleanupConfirmation()
   }
 }

--- a/app/views/accounts/_selection_bar.html.erb
+++ b/app/views/accounts/_selection_bar.html.erb
@@ -93,8 +93,9 @@
 
     <p class="selection-confirmation__note">
       Only empty expense and revenue accounts are listed — your asset, liability, and equity
-      accounts are never touched by this action. Deleting these cannot be undone; a future import
-      whose description exactly matches a removed account's name may recreate it.
+      accounts are never touched, and neither is any account used by an import rule. Deleting
+      these cannot be undone; a future import whose description exactly matches a removed
+      account's name may recreate it.
     </p>
 
     <div class="selection-confirmation__actions">

--- a/app/views/accounts/_selection_bar.html.erb
+++ b/app/views/accounts/_selection_bar.html.erb
@@ -11,6 +11,14 @@
     Merge
   </button>
 
+  <%# Delete is revealed only when every checked account is empty (see updateBar). %>
+  <button type="button" class="selection-bar__btn selection-bar__btn--danger"
+          data-accounts--selection-target="deleteButton"
+          data-action="accounts--selection#confirmDeleteSelected"
+          hidden>
+    Delete
+  </button>
+
   <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
           data-action="accounts--selection#cancel">
     Cancel
@@ -54,5 +62,46 @@
                 data-action="accounts--selection#cancel">Cancel</button>
       </div>
     <% end %>
+  </div>
+</div>
+
+<%# Cleanup form — the controller injects account_ids[] before submitting it. Resetting on
+    submit-end clears the selection after Turbo Drive re-renders the index. %>
+<%= form_with url: cleanup_empty_accounts_path, method: :delete,
+      data: { accounts__selection_target: "cleanupForm",
+              action: "turbo:submit-end->accounts--selection#cancel" } do %>
+<% end %>
+
+<%# Cleanup confirmation panel — lists each empty account that will be deleted so the action is
+    reviewable, not blind. The controller clones cleanupItemTemplate once per account. %>
+<div class="selection-confirmation" data-accounts--selection-target="cleanupConfirmation" hidden>
+  <div class="selection-confirmation__content">
+    <h3>Clean up empty expense/revenue accounts</h3>
+    <p class="selection-confirmation__preview"></p>
+
+    <div class="selection-confirmation__keep">
+      <span class="selection-confirmation__label">These accounts will be deleted</span>
+      <div class="selection-confirmation__cleanup-list"
+           data-accounts--selection-target="cleanupList"></div>
+    </div>
+
+    <template data-accounts--selection-target="cleanupItemTemplate">
+      <div class="selection-confirmation__cleanup-item">
+        <span class="selection-confirmation__cleanup-name"></span>
+      </div>
+    </template>
+
+    <p class="selection-confirmation__note">
+      Only empty expense and revenue accounts are listed — your asset, liability, and equity
+      accounts are never touched by this action. Deleting these cannot be undone; a future import
+      whose description exactly matches a removed account's name may recreate it.
+    </p>
+
+    <div class="selection-confirmation__actions">
+      <button type="button" class="selection-bar__btn selection-bar__btn--danger"
+              data-action="accounts--selection#submitCleanup">Delete empty accounts</button>
+      <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
+              data-action="accounts--selection#cancel">Cancel</button>
+    </div>
   </div>
 </div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,24 +1,36 @@
 <% content_for :title, "Accounts" %>
 
-<div class="accounts-header">
-  <h1>Accounts</h1>
-  <div class="accounts-header__actions">
-    <%= link_to "+ New account", new_account_path %>
-    <%= link_to "Integrations", integrations_path %>
-  </div>
-</div>
-
-<% if @grouped_accounts.blank? %>
-  <div class="empty-state">
-    <h2>No accounts yet</h2>
-    <p>Add your first account, or link one from Integrations to start tracking balances.</p>
-    <div class="empty-state__actions">
-      <%= link_to "New account", new_account_path %>
-      <%= link_to "Go to Integrations", integrations_path %>
+<%# The accounts--selection controller wraps the header too, so its "Clean up" button is in
+    scope. The selection bar (with the cleanup form/confirmation) only renders when there are
+    accounts; the button only renders when there are empties — so they always appear together. %>
+<div data-controller="accounts--selection">
+  <div class="accounts-header">
+    <h1>Accounts</h1>
+    <div class="accounts-header__actions">
+      <%= link_to "+ New account", new_account_path %>
+      <%= link_to "Integrations", integrations_path %>
+      <% if @empty_cleanup_accounts.present? %>
+        <button type="button" class="accounts-header__cleanup"
+                title="Only empty expense and revenue accounts"
+                data-accounts--selection-target="cleanupButton"
+                data-action="accounts--selection#confirmCleanup"
+                data-empty-account-ids="<%= @empty_cleanup_accounts.map(&:id).to_json %>">
+          <%= "Clean up #{pluralize(@empty_cleanup_accounts.size, "empty account")}" %>
+        </button>
+      <% end %>
     </div>
   </div>
-<% else %>
-  <div data-controller="accounts--selection">
+
+  <% if @grouped_accounts.blank? %>
+    <div class="empty-state">
+      <h2>No accounts yet</h2>
+      <p>Add your first account, or link one from Integrations to start tracking balances.</p>
+      <div class="empty-state__actions">
+        <%= link_to "New account", new_account_path %>
+        <%= link_to "Go to Integrations", integrations_path %>
+      </div>
+    </div>
+  <% else %>
     <% Account.kinds.keys.each do |kind| %>
       <% accounts = @grouped_accounts[kind] || [] %>
       <% selectable = %w[ expense revenue ].include?(kind) %>
@@ -41,5 +53,5 @@
     <% end %>
 
     <%= render "accounts/selection_bar" %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :accounts do
     collection do
       post :merge
+      delete :cleanup_empty
     end
     resources :transactions, only: %i[ index ]
     resources :csv_imports, controller: "csv/imports", except: %i[ edit ] do

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -517,6 +517,18 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert Transaction::Unmerge.new(merger.merged_transaction, user: @user).call, "unmerge should still be possible"
   end
 
+  test "cleanup_empty keeps an empty account that is an import-rule target" do
+    rule_target = Account.create!(user: @user, name: "Coffee", kind: :expense, currency: currencies(:usd))
+    rule = ImportRule.create!(user: @user, account: rule_target, match_pattern: "Coffee Shop", match_type: :contains, priority: 0)
+
+    assert_no_difference("Account.count") do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ rule_target.id ] }
+    end
+
+    assert Account.exists?(rule_target.id), "an import-rule target must not be cleaned up"
+    assert ImportRule.exists?(rule.id), "its import rule mapping must survive"
+  end
+
   test "cleanup_empty ignores accounts belonging to another user" do
     other = Account.create!(user: users(:two), name: "Theirs", kind: :expense, currency: currencies(:usd))
 

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -469,4 +469,91 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Pick a target account to keep.", flash[:alert]
     assert Account.exists?(source.id)
   end
+
+  test "should clean up empty expense and revenue accounts" do
+    empty_expense = Account.create!(user: @user, name: "Empty Expense", kind: :expense, currency: currencies(:usd))
+    empty_revenue = Account.create!(user: @user, name: "Empty Revenue", kind: :revenue, currency: currencies(:usd))
+
+    assert_difference("Account.count", -2) do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ empty_expense.id, empty_revenue.id ] }
+    end
+
+    assert_redirected_to accounts_url
+    assert_equal "Deleted 2 empty accounts.", flash[:notice]
+  end
+
+  test "cleanup_empty keeps an account that still has transactions" do
+    account = accounts(:expense_account) # dest of transactions(:one)
+
+    assert_no_difference("Account.count") do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ account.id ] }
+    end
+
+    assert Account.exists?(account.id)
+    assert_equal "No empty accounts to clean up.", flash[:notice]
+  end
+
+  test "cleanup_empty keeps a merge-reference account so its merge can be undone" do
+    expense = Account.create!(user: @user, name: "Merge Reference Expense", kind: :expense, currency: currencies(:usd))
+    revenue = Account.create!(user: @user, name: "Merge Reference Revenue", kind: :revenue, currency: currencies(:usd))
+    withdrawal = Transaction.create!(
+      user: @user, src_account: accounts(:asset_account), dest_account: expense,
+      amount_minor: 750, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+    deposit = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: accounts(:linked_asset),
+      amount_minor: 750, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+    merger = Transaction::Merge.new(withdrawal, deposit, user: @user)
+    assert merger.call, "Merge setup failed: #{merger.errors.join(", ")}"
+
+    # Both accounts now hold only their zeroed, merged-away originals, so cleanup must skip them.
+    assert_no_difference("Account.count") do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ expense.id, revenue.id ] }
+    end
+
+    assert Account.exists?(expense.id)
+    assert Account.exists?(revenue.id)
+    assert Transaction::Unmerge.new(merger.merged_transaction, user: @user).call, "unmerge should still be possible"
+  end
+
+  test "cleanup_empty ignores accounts belonging to another user" do
+    other = Account.create!(user: users(:two), name: "Theirs", kind: :expense, currency: currencies(:usd))
+
+    assert_no_difference("Account.count") do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ other.id ] }
+    end
+
+    assert Account.exists?(other.id)
+  end
+
+  test "cleanup_empty ignores asset and liability accounts" do
+    asset = Account.create!(user: @user, name: "Empty Asset", kind: :asset, currency: currencies(:usd))
+
+    assert_no_difference("Account.count") do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ asset.id ] }
+    end
+
+    assert Account.exists?(asset.id)
+  end
+
+  test "cleanup_empty deletes only the empty accounts when given a mix" do
+    empty_expense = Account.create!(user: @user, name: "Empty Expense", kind: :expense, currency: currencies(:usd))
+    non_empty = accounts(:expense_account) # dest of transactions(:one)
+
+    assert_difference("Account.count", -1) do
+      delete cleanup_empty_accounts_url, params: { account_ids: [ empty_expense.id, non_empty.id ] }
+    end
+
+    assert_not Account.exists?(empty_expense.id)
+    assert Account.exists?(non_empty.id)
+    assert_equal "Deleted 1 empty account.", flash[:notice]
+  end
+
+  test "cleanup_empty reports nothing to clean up when no ids match" do
+    delete cleanup_empty_accounts_url, params: { account_ids: [] }
+
+    assert_redirected_to accounts_url
+    assert_equal "No empty accounts to clean up.", flash[:notice]
+  end
 end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -327,6 +327,26 @@ class AccountTest < ActiveSupport::TestCase
     assert @account.empty?
   end
 
+  test "empty? counts merged-away transactions so a merge reference is not empty" do
+    # A merged transaction keeps its original src/dest accounts (zeroed, merged_into set), and
+    # unmerge restores them in place — so the account must stay non-empty even though the
+    # transaction is hidden from the unmerged scope. Bulk cleanup depends on this invariant.
+    expense = Account.create!(user: users(:one), name: "Merge Reference Expense", kind: :expense, currency: currencies(:usd))
+    revenue = Account.create!(user: users(:one), name: "Merge Reference Revenue", kind: :revenue, currency: currencies(:usd))
+    withdrawal = Transaction.create!(
+      user: users(:one), src_account: accounts(:asset_account), dest_account: expense,
+      amount_minor: 750, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+    deposit = Transaction.create!(
+      user: users(:one), src_account: revenue, dest_account: accounts(:linked_asset),
+      amount_minor: 750, currency: currencies(:usd), transacted_at: 1.day.ago
+    )
+    assert Transaction::Merge.new(withdrawal, deposit, user: users(:one)).call
+
+    assert_equal 0, Transaction.unmerged.where(dest_account: expense).count, "the merged-away transaction is hidden from the unmerged scope"
+    assert_not expense.empty?, "a merge reference still references its zeroed transaction, so it is not empty"
+  end
+
   test "empty? is true if account only has an opening balance transaction" do
     @account.src_transactions.destroy_all
     @account.dest_transactions.destroy_all

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -346,6 +346,7 @@ class AccountsTest < ApplicationSystemTestCase
     within ".selection-confirmation" do
       assert_text "2 empty expense/revenue accounts will be permanently deleted."
       assert_text "asset, liability, and equity accounts are never touched"
+      assert_text "any account used by an import rule"
       assert_text "Stale Vendor"
       assert_text "Stale Income"
       click_button "Delete empty accounts"

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -405,6 +405,26 @@ class AccountsTest < ApplicationSystemTestCase
     end
   end
 
+  test "the cleanup affordance excludes import-rule targets" do
+    cleanable = Account.create!(user: @user, name: "Stale Vendor", kind: :expense, currency: currencies(:usd))
+    rule_target = Account.create!(user: @user, name: "Coffee", kind: :expense, currency: currencies(:usd))
+    ImportRule.create!(user: @user, account: rule_target, match_pattern: "Coffee Shop", match_type: :contains, priority: 0)
+
+    visit accounts_path
+
+    # Only the rule-free empty account is offered; the rule target is an in-use mapping, not clutter.
+    click_button "Clean up 1 empty account"
+    within ".selection-confirmation" do
+      assert_text "Stale Vendor"
+      assert_no_text "Coffee"
+      click_button "Delete empty accounts"
+    end
+
+    assert_text "Deleted 1 empty account."
+    assert_no_selector row_for(cleanable)
+    assert_selector row_for(rule_target)
+  end
+
   private
 
   def row_for(account)

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -325,6 +325,86 @@ class AccountsTest < ApplicationSystemTestCase
     end
   end
 
+  test "the cleanup affordance is hidden when there are no empty accounts" do
+    # users(:one)'s expense_account and revenue_account both carry fixture transactions.
+    visit accounts_path
+
+    within "main" do
+      assert_no_button "Clean up"
+    end
+  end
+
+  test "single-click cleanup deletes all empty expense and revenue accounts" do
+    empty_expense = Account.create!(user: @user, name: "Stale Vendor", kind: :expense, currency: currencies(:usd))
+    empty_revenue = Account.create!(user: @user, name: "Stale Income", kind: :revenue, currency: currencies(:usd))
+
+    visit accounts_path
+    assert_selector row_for(empty_expense)
+
+    click_button "Clean up 2 empty accounts"
+
+    within ".selection-confirmation" do
+      assert_text "2 empty expense/revenue accounts will be permanently deleted."
+      assert_text "asset, liability, and equity accounts are never touched"
+      assert_text "Stale Vendor"
+      assert_text "Stale Income"
+      click_button "Delete empty accounts"
+    end
+
+    assert_text "Deleted 2 empty accounts."
+    assert_no_selector row_for(empty_expense)
+    assert_no_selector row_for(empty_revenue)
+    within "main" do
+      assert_no_button "Clean up"
+    end
+  end
+
+  test "canceling the cleanup confirmation keeps the empty accounts" do
+    empty_expense = Account.create!(user: @user, name: "Stale Vendor", kind: :expense, currency: currencies(:usd))
+    empty_revenue = Account.create!(user: @user, name: "Stale Income", kind: :revenue, currency: currencies(:usd))
+
+    visit accounts_path
+    click_button "Clean up 2 empty accounts"
+
+    within ".selection-confirmation" do
+      click_button "Cancel"
+    end
+
+    assert_no_selector ".selection-confirmation"
+    assert_selector row_for(empty_expense)
+    assert_selector row_for(empty_revenue)
+  end
+
+  test "the selection bar Delete removes manually checked empty accounts" do
+    empty_expense = Account.create!(user: @user, name: "Stale Vendor", kind: :expense, currency: currencies(:usd))
+
+    visit accounts_path
+    toggle_select(empty_expense)
+
+    within ".selection-bar" do
+      assert_text "1 account selected"
+      click_button "Delete"
+    end
+
+    within ".selection-confirmation" do
+      assert_text "1 empty expense/revenue account will be permanently deleted."
+      click_button "Delete empty accounts"
+    end
+
+    assert_text "Deleted 1 empty account."
+    assert_no_selector row_for(empty_expense)
+  end
+
+  test "the selection bar Delete stays hidden when a checked account still has transactions" do
+    visit accounts_path
+    toggle_select(accounts(:expense_account)) # carries a fixture transaction
+
+    within ".selection-bar" do
+      assert_text "1 account selected"
+      assert_no_button "Delete"
+    end
+  end
+
   private
 
   def row_for(account)


### PR DESCRIPTION
## Summary

Aggregator imports and account merges leave behind expense/revenue accounts with no transactions. Until now they could only be removed one row at a time. This adds a bulk cleanup on the accounts index.

- **Two entry points:** a header **"Clean up N empty accounts"** button (rendered only when empties exist) that targets every empty expense/revenue account, and a **"Delete"** button in the existing selection bar for a hand-picked subset (enabled only when all checked accounts are empty).
- **Reviewable confirmation:** both open the same panel listing each account by name. The header button stays compact (with a tooltip); the dialog spells out the scope — only **expense and revenue** accounts are removed; **asset, liability, and equity accounts are never touched** (and can still be deleted individually from their row).
- **Server-side safety:** `DELETE /accounts/cleanup_empty` re-validates every id (ownership + kind + `Account#empty?`) inside a transaction and never trusts the client list. Because `empty?` counts merged-away transactions, a merge-reference account is never eligible — so unmerge stays possible.

## Implementation

- Route: `delete :cleanup_empty` (collection).
- `AccountsController#cleanup_empty`, plus `@empty_cleanup_accounts` computed in `#index`.
- Extends the existing `accounts--selection` Stimulus controller (merge flow unchanged) and reuses the `.selection-confirmation` `<template>` chrome.
- Redirects on completion so Turbo Drive re-renders the index, matching the existing `#merge` flow.

## Test plan

- [x] `cleanup_empty` deletes empty expense and revenue accounts (controller)
- [x] keeps an account that still has transactions (server-side `empty?` re-check)
- [x] keeps a merge-reference account, and `Transaction::Unmerge` still works afterward
- [x] ignores another user's accounts (authorization)
- [x] ignores asset/liability accounts (kind scope)
- [x] deletes only the empty subset given a mix; correct singular/plural notice
- [x] reports "nothing to clean up" when no ids match
- [x] model: `empty?` counts merged-away transactions (pins the invariant the feature relies on)
- [x] system: single-click cleanup deletes all empties; dialog lists names and states the expense/revenue scope
- [x] system: canceling keeps the accounts; affordance hidden when there are no empties
- [x] system: bar "Delete" removes manually checked empties; stays hidden when a checked account still has transactions

All green locally: `bin/rails test` (824 runs, 100% line coverage), `bin/rails test:system` (64 runs), `bin/rubocop`, `bin/brakeman`.

## Notes

While investigating an orphaned account during this work, I filed #177 (AutoMerge clones an existing transfer and orphans its aggregator source) — a separate, pre-existing bug, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
