### PR TITLE
Match import rules against CSV-sourced transactions retroactively

### DIFF
--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -114,9 +114,17 @@ class ImportRule::RetroactiveApply
       ids << transaction.dest_account_id if transaction.dest_account.account_sources.any?
       transaction.transaction_sources.each do |source|
         sourceable = source.sourceable
-        ids << sourceable.account&.id if sourceable.is_a?(Csv::Transaction)
+        # Read import_id off the already-preloaded Csv::Transaction and resolve the
+        # account through a cached map, rather than walking sourceable.account
+        # (import -> account) per row inside find_each.
+        ids << csv_import_account_ids[sourceable.import_id] if sourceable.is_a?(Csv::Transaction)
       end
-      ids.compact
+      ids.compact.uniq
+    end
+
+    # import_id => ledger account_id for this user's CSV imports, loaded once.
+    def csv_import_account_ids
+      @csv_import_account_ids ||= Csv::Import.where(user_id: @user.id).pluck(:id, :account_id).to_h
     end
 
     def find_matching_rule(description)

--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -86,19 +86,37 @@ class ImportRule::RetroactiveApply
       @user.transactions
         .joins(:transaction_sources)
         .where(merged_into_id: nil, excluded_at: nil, split: false, opening_balance: false, parent_transaction_id: nil)
-        .includes(src_account: :account_sources, dest_account: :account_sources)
+        .includes(src_account: :account_sources, dest_account: :account_sources, transaction_sources: :sourceable)
         .distinct
     end
 
     def identify_counterpart(transaction)
-      src_linked = transaction.src_account.account_sources.any?
-      dest_linked = transaction.dest_account.account_sources.any?
+      source_account_ids = import_side_account_ids(transaction)
+      src_linked = source_account_ids.include?(transaction.src_account_id)
+      dest_linked = source_account_ids.include?(transaction.dest_account_id)
 
       if src_linked && !dest_linked
         [ :expense, transaction.dest_account ]
       elsif dest_linked && !src_linked
         [ :revenue, transaction.src_account ]
       end
+    end
+
+    # The ledger accounts that sit on the import side of a transaction. Aggregator
+    # accounts (SimpleFIN, Lunch Flow) carry an AccountSource, so the import side is
+    # whichever account is linked. CSV imports never create AccountSource records —
+    # their import side is the Csv::Import's chosen ledger account, reached through
+    # the transaction's Csv::Transaction source. Without this, CSV-sourced
+    # transactions have no recognized counterpart and rules never match them.
+    def import_side_account_ids(transaction)
+      ids = []
+      ids << transaction.src_account_id if transaction.src_account.account_sources.any?
+      ids << transaction.dest_account_id if transaction.dest_account.account_sources.any?
+      transaction.transaction_sources.each do |source|
+        sourceable = source.sourceable
+        ids << sourceable.account&.id if sourceable.is_a?(Csv::Transaction)
+      end
+      ids.compact
     end
 
     def find_matching_rule(description)

--- a/test/services/import_rule/retroactive_apply_test.rb
+++ b/test/services/import_rule/retroactive_apply_test.rb
@@ -411,4 +411,104 @@ class ImportRule::RetroactiveApplyTest < ActiveSupport::TestCase
     changes = service.preview
     assert_equal 0, changes.size
   end
+
+  # --- CSV-sourced transactions ---
+  #
+  # CSV imports never create AccountSource records; their import side is the
+  # Csv::Import's ledger account. These transactions used to be skipped entirely
+  # because identify_counterpart only recognized aggregator-linked accounts, so
+  # no rule (exclude or reassign) could ever match a CSV-imported transaction.
+
+  test "preview matches CSV-sourced transaction for exclude rule" do
+    csv_transaction = create_csv_sourced_transaction(
+      counterpart: @original_expense,
+      description: "Acme Wallet Account Hold for Open Authorization"
+    )
+
+    @rule.destroy!
+    exclude_rule = ImportRule.create!(
+      user: @user, match_pattern: "Acme Wallet Account Hold", match_type: :contains, exclude: true
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: exclude_rule)
+    changes = service.preview
+
+    matching = changes.find { |c| c.transaction.id == csv_transaction.id }
+    assert_not_nil matching, "expected the CSV-sourced transaction to match the exclude rule"
+    assert_equal :exclude, matching.action
+    assert_nil matching.new_account
+  end
+
+  test "apply excludes CSV-sourced transaction for exclude rule" do
+    csv_transaction = create_csv_sourced_transaction(
+      counterpart: @original_expense,
+      description: "Acme Wallet Account Hold for Open Authorization"
+    )
+
+    @rule.destroy!
+    exclude_rule = ImportRule.create!(
+      user: @user, match_pattern: "Acme Wallet Account Hold", match_type: :contains, exclude: true
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: exclude_rule)
+    count = service.apply
+
+    assert_equal 1, count
+    assert csv_transaction.reload.excluded?
+  end
+
+  test "preview reassigns counterpart for CSV-sourced transaction" do
+    csv_transaction = create_csv_sourced_transaction(
+      counterpart: @original_expense,
+      description: "GROCERY STORE #789"
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: @rule)
+    changes = service.preview
+
+    matching = changes.find { |c| c.transaction.id == csv_transaction.id }
+    assert_not_nil matching, "expected the CSV-sourced transaction to match the reassign rule"
+    assert_equal @original_expense, matching.old_account
+    assert_equal @new_expense, matching.new_account
+    assert_equal :expense, matching.direction
+  end
+
+  private
+
+    # Build a ledger transaction sourced from a CSV import, mirroring how
+    # Csv::ImportTransactionsJob wires up the import account and its expense/
+    # revenue counterpart. The import-side ledger account is deliberately NOT
+    # aggregator-linked (no AccountSource), which is the case that exposed the
+    # bug: only Csv::Transaction#account identifies it as the import side.
+    def create_csv_sourced_transaction(counterpart:, description:)
+      ledger_account = Account.create!(user: @user, name: "Acme Wallet", kind: :asset, currency: @currency)
+      assert_empty ledger_account.account_sources, "CSV import account must not be aggregator-linked"
+
+      import = Csv::Import.new(user: @user, account: ledger_account, state: "imported")
+      import.file.attach(
+        io: StringIO.new("date,amount\n2026-01-01,-50.00\n"),
+        filename: "import.csv",
+        content_type: "text/csv"
+      )
+      import.save!
+
+      csv_transaction = Csv::Transaction.create!(
+        import: import,
+        row_index: 0,
+        amount_minor: -5000,
+        description: description,
+        transacted_at: 1.day.ago
+      )
+
+      create_sourced_transaction(
+        user: @user,
+        src_account: ledger_account,
+        dest_account: counterpart,
+        amount_minor: 5000,
+        currency: @currency,
+        description: description,
+        transacted_at: 1.day.ago,
+        sourceable: csv_transaction
+      )
+    end
 end


### PR DESCRIPTION
## Summary

Retroactively applying an import rule never matched CSV-imported transactions. An exclude rule like `contains "Account Hold"` (or any reassign rule) would report zero matches even when transaction descriptions clearly contained the pattern.

The root cause is in `ImportRule::RetroactiveApply#identify_counterpart`, which decided a transaction's "import side" purely from `Account#account_sources`. Only SimpleFIN and Lunch Flow accounts get `AccountSource` records — CSV imports never do. So for a CSV-sourced transaction, both sides looked unlinked, `identify_counterpart` returned `nil`, and `compute_changes` skipped the row (`next unless direction`) before the rule was ever evaluated.

Matching itself was fine; the candidate was discarded upstream of it.

## Fix

Generalize the import-side detection into `import_side_account_ids`. An account is on the import side if either:

- it carries an `AccountSource` (SimpleFIN, Lunch Flow), **or**
- it is the `Csv::Import`'s ledger account, reached through the transaction's `Csv::Transaction` source.

The `candidate_transactions` query now eager-loads `transaction_sources: :sourceable` to keep the preview batched. The `apply` path needed no changes — `Transaction::Exclude`, the direct `update!`, and `AutoMerge` all work once the counterpart is identified. The "both sides are import accounts" case (e.g. a CSV-to-CSV transfer) still returns `nil` and is skipped, matching existing aggregator behavior.

Note: this fixes *retroactive* application. New CSV imports were already handled correctly by `Csv::ImportTransactionsJob`, which calls `import_rules.for_description` directly at import time.

## Test plan

Added three tests to `ImportRule::RetroactiveApplyTest`, each backed by a `create_csv_sourced_transaction` helper that builds a CSV import whose ledger account is deliberately **not** aggregator-linked (the case that exposed the bug):

- [x] preview matches a CSV-sourced transaction for an exclude rule
- [x] apply excludes a CSV-sourced transaction for an exclude rule
- [x] preview reassigns the counterpart for a CSV-sourced transaction (non-exclude rule)

Verified the tests fail without the fix (3 failures) and pass with it. Full file: 26 runs, 0 failures. `bin/rubocop` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)