### PR TITLE
Leave ambiguous balance-sheet rule matches untouched to avoid double-counting

### DIFF
--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -68,8 +68,8 @@ class ImportRule::RetroactiveApply
         merge_candidate = nil
         if rule.account.balance_sheet?
           candidates = merge_candidates(transaction, rule.account)
-          # Ambiguous balance-sheet match: Transaction::AutoMerge leaves it untouched (#182),
-          # so don't surface it as a reassignment that never resolves.
+          # Ambiguous balance-sheet match (2+ mergeable counterparts): Transaction::AutoMerge
+          # leaves it untouched (#182), so don't surface it as a reassignment that never resolves.
           next if candidates.size > 1
 
           merge_candidate = candidates.first
@@ -142,6 +142,8 @@ class ImportRule::RetroactiveApply
     end
 
     # Non-transfer transactions involving rule_account that this transaction could merge with.
+    # Only opposite-side rows are real counterparts (mirrors Transaction::Merge); same-direction
+    # rows can't form a transfer and so are not ambiguity.
     def merge_candidates(transaction, rule_account)
       @user.transactions
         .unmerged
@@ -156,6 +158,14 @@ class ImportRule::RetroactiveApply
         .where.missing(:merged_sources)
         .to_a
         .select { |t| !t.src_account.balance_sheet? || !t.dest_account.balance_sheet? }
+        .select { |candidate| mergeable?(transaction, candidate) }
+    end
+
+    # Mirrors Transaction::Merge: a candidate can merge into a transfer only when one side has a
+    # balance-sheet account as source and the other as destination.
+    def mergeable?(transaction, candidate)
+      (transaction.src_account.balance_sheet? && candidate.dest_account.balance_sheet?) ||
+        (candidate.src_account.balance_sheet? && transaction.dest_account.balance_sheet?)
     end
 
     def rule_scope

--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -65,8 +65,14 @@ class ImportRule::RetroactiveApply
 
         next if rule.account_id == counterpart.id
 
-        merge_candidate = if rule.account.balance_sheet?
-          find_merge_candidate(transaction, rule.account)
+        merge_candidate = nil
+        if rule.account.balance_sheet?
+          candidates = merge_candidates(transaction, rule.account)
+          # Ambiguous balance-sheet match: Transaction::AutoMerge leaves it untouched (#182),
+          # so don't surface it as a reassignment that never resolves.
+          next if candidates.size > 1
+
+          merge_candidate = candidates.first
         end
 
         changes << Change.new(
@@ -135,8 +141,9 @@ class ImportRule::RetroactiveApply
       @rule_cache[normalized] = rule_scope.for_description(description).first
     end
 
-    def find_merge_candidate(transaction, rule_account)
-      candidates = @user.transactions
+    # Non-transfer transactions involving rule_account that this transaction could merge with.
+    def merge_candidates(transaction, rule_account)
+      @user.transactions
         .unmerged
         .unexcluded
         .includes(:src_account, :dest_account)
@@ -149,8 +156,6 @@ class ImportRule::RetroactiveApply
         .where.missing(:merged_sources)
         .to_a
         .select { |t| !t.src_account.balance_sheet? || !t.dest_account.balance_sheet? }
-
-      candidates.size == 1 ? candidates.first : nil
     end
 
     def rule_scope

--- a/app/services/transaction/auto_merge.rb
+++ b/app/services/transaction/auto_merge.rb
@@ -31,14 +31,22 @@ class Transaction::AutoMerge
 
     # Find a matching expense/revenue transaction involving the rule account and merge via Transaction::Merge.
     # Returns true if merged, :candidate_found if a candidate existed but merge failed, :ambiguous if 2+
-    # candidates matched (can't safely pick one), false if no candidate.
+    # mergeable counterparts matched (can't safely pick one), false if none.
     def merge_with_counterpart
-      candidates = expense_revenue_candidates
+      candidates = expense_revenue_candidates.select { |candidate| mergeable_counterpart?(candidate) }
       return false if candidates.empty?
       return :ambiguous if candidates.size > 1
 
       merger = Transaction::Merge.new(@transaction, candidates.first, user: @transaction.user)
       merger.call || :candidate_found
+    end
+
+    # A candidate can merge with @transaction into a transfer only when one side holds a
+    # balance-sheet account as source and the other as destination (mirrors Transaction::Merge).
+    # Same-direction rows (e.g. two deposits) are not counterparts and must not count as ambiguity.
+    def mergeable_counterpart?(candidate)
+      (@transaction.src_account.balance_sheet? && candidate.dest_account.balance_sheet?) ||
+        (candidate.src_account.balance_sheet? && @transaction.dest_account.balance_sheet?)
     end
 
     # Find an existing BS-to-BS transfer that this transaction duplicates and absorb into it

--- a/app/services/transaction/auto_merge.rb
+++ b/app/services/transaction/auto_merge.rb
@@ -15,22 +15,29 @@ class Transaction::AutoMerge
               @transaction.has_fx? || @transaction.amount_minor == 0 ||
               @transaction.merged_sources.exists?
 
-    if @rule_account
-      merge_with_counterpart || absorb_into_existing_transfer || apply_rule_account
-    else
-      absorb_into_existing_transfer
-    end
+    return absorb_into_existing_transfer unless @rule_account
+
+    result = merge_with_counterpart
+    # Ambiguous: 2+ equal-amount counterparts on the rule account — we can't tell which one
+    # this transaction pairs with. Leave it untouched for manual review rather than fall
+    # through to absorb_into_existing_transfer (which clones a transfer and double-counts a
+    # still-live charge) or apply_rule_account (which reassigns arbitrarily). See #182.
+    return if result == :ambiguous
+
+    result || absorb_into_existing_transfer || apply_rule_account
   end
 
   private
 
     # Find a matching expense/revenue transaction involving the rule account and merge via Transaction::Merge.
-    # Returns true if merged, :candidate_found if a candidate existed but merge failed, false if no candidate.
+    # Returns true if merged, :candidate_found if a candidate existed but merge failed, :ambiguous if 2+
+    # candidates matched (can't safely pick one), false if no candidate.
     def merge_with_counterpart
-      candidate = find_expense_revenue_candidate
-      return false unless candidate
+      candidates = expense_revenue_candidates
+      return false if candidates.empty?
+      return :ambiguous if candidates.size > 1
 
-      merger = Transaction::Merge.new(@transaction, candidate, user: @transaction.user)
+      merger = Transaction::Merge.new(@transaction, candidates.first, user: @transaction.user)
       merger.call || :candidate_found
     end
 
@@ -67,14 +74,12 @@ class Transaction::AutoMerge
       end
     end
 
-    # Find expense/revenue transactions involving the rule_account
-    def find_expense_revenue_candidate
-      candidates = base_candidates
+    # Expense/revenue (non-transfer) transactions involving the rule_account
+    def expense_revenue_candidates
+      base_candidates
         .where("transactions.src_account_id = :id OR transactions.dest_account_id = :id", id: @rule_account.id)
         .to_a
-        .select { |t| !transfer?(t) }
-
-      candidates.size == 1 ? candidates.first : nil
+        .reject { |t| transfer?(t) }
     end
 
     # Find BS-to-BS transfers involving the same ledger account

--- a/test/services/import_rule/retroactive_apply_test.rb
+++ b/test/services/import_rule/retroactive_apply_test.rb
@@ -296,6 +296,37 @@ class ImportRule::RetroactiveApplyTest < ActiveSupport::TestCase
     assert_equal other_side, matching.merge_candidate
   end
 
+  test "preview skips ambiguous balance sheet match with multiple candidates" do
+    savings = Account.create!(user: @user, name: "Savings", kind: :asset, currency: @currency)
+    bs_rule = ImportRule.create!(user: @user, account: savings, match_pattern: "TRANSFER", match_type: :contains, priority: 20)
+
+    transfer_out = create_sourced_transaction(
+      user: @user, src_account: @bank_account, dest_account: @original_expense,
+      amount_minor: 5000, currency: @currency, description: "TRANSFER TO SAVINGS",
+      transacted_at: 1.day.ago, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    # Two equal-amount counterparts on the savings (rule) account — can't tell which one
+    # transfer_out pairs with, so AutoMerge would leave it untouched (#182). The preview must
+    # not surface a reassignment that never resolves.
+    revenue = Account.create!(user: @user, name: "Transfer In", kind: :revenue, currency: @currency)
+    Transaction.create!(
+      user: @user, src_account: revenue, dest_account: savings,
+      amount_minor: 5000, currency: @currency, description: "TRANSFER FROM CHECKING 1",
+      transacted_at: 1.day.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: revenue, dest_account: savings,
+      amount_minor: 5000, currency: @currency, description: "TRANSFER FROM CHECKING 2",
+      transacted_at: 1.day.ago
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: bs_rule)
+    changes = service.preview
+
+    assert_nil changes.find { |c| c.transaction.id == transfer_out.id }
+  end
+
   test "preview has nil merge candidate when no match exists for balance sheet rule" do
     savings = Account.create!(user: @user, name: "Savings", kind: :asset, currency: @currency)
     bs_rule = ImportRule.create!(user: @user, account: savings, match_pattern: "TRANSFER", match_type: :contains, priority: 20)

--- a/test/services/import_rule/retroactive_apply_test.rb
+++ b/test/services/import_rule/retroactive_apply_test.rb
@@ -327,6 +327,39 @@ class ImportRule::RetroactiveApplyTest < ActiveSupport::TestCase
     assert_nil changes.find { |c| c.transaction.id == transfer_out.id }
   end
 
+  test "preview keeps balance sheet match when same-amount rows on the rule account are same-direction" do
+    savings = Account.create!(user: @user, name: "Savings", kind: :asset, currency: @currency)
+    bs_rule = ImportRule.create!(user: @user, account: savings, match_pattern: "TRANSFER", match_type: :contains, priority: 20)
+
+    transfer_out = create_sourced_transaction(
+      user: @user, src_account: @bank_account, dest_account: @original_expense,
+      amount_minor: 5000, currency: @currency, description: "TRANSFER TO SAVINGS",
+      transacted_at: 1.day.ago, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    # Two same-amount withdrawals FROM savings — same direction as transfer_out's bank side
+    # (balance-sheet account on src), so not mergeable counterparts. They must not trigger the
+    # ambiguity skip; the change stays actionable (AutoMerge falls back to reassignment).
+    expense_b = Account.create!(user: @user, name: "B Expense", kind: :expense, currency: @currency)
+    Transaction.create!(
+      user: @user, src_account: savings, dest_account: expense_b,
+      amount_minor: 5000, currency: @currency, description: "From savings 1",
+      transacted_at: 1.day.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: savings, dest_account: expense_b,
+      amount_minor: 5000, currency: @currency, description: "From savings 2",
+      transacted_at: 1.day.ago
+    )
+
+    service = ImportRule::RetroactiveApply.new(user: @user, rule: bs_rule)
+    matching = service.preview.find { |c| c.transaction.id == transfer_out.id }
+
+    assert_not_nil matching
+    assert_equal savings, matching.new_account
+    assert_nil matching.merge_candidate
+  end
+
   test "preview has nil merge candidate when no match exists for balance sheet rule" do
     savings = Account.create!(user: @user, name: "Savings", kind: :asset, currency: @currency)
     bs_rule = ImportRule.create!(user: @user, account: savings, match_pattern: "TRANSFER", match_type: :contains, priority: 20)

--- a/test/services/transaction/auto_merge_test.rb
+++ b/test/services/transaction/auto_merge_test.rb
@@ -328,6 +328,39 @@ class Transaction::AutoMergeTest < ActiveSupport::TestCase
     assert_equal bank_b_before, @bank_b.reload.balance_minor
   end
 
+  test "applies rule account when same-amount rows on the rule account are same-direction" do
+    # Imported deposit: revenue -> @bank_a (balance-sheet account on the dest side).
+    revenue = Account.create!(user: @user, name: "Funding", kind: :revenue, currency: @currency)
+    transaction = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: @bank_a,
+      amount_minor: 500, currency: @currency, description: "Funding",
+      transacted_at: 2.days.ago
+    )
+
+    # Two same-amount deposits on the rule account (@bank_b) — same direction as the import
+    # (balance-sheet account on dest), so NOT mergeable counterparts. They must not be treated
+    # as ambiguity; the rule account should still be applied. See #182 review.
+    revenue_b = Account.create!(user: @user, name: "B Funding", kind: :revenue, currency: @currency)
+    Transaction.create!(
+      user: @user, src_account: revenue_b, dest_account: @bank_b,
+      amount_minor: 500, currency: @currency, description: "B Funding 1",
+      transacted_at: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: revenue_b, dest_account: @bank_b,
+      amount_minor: 500, currency: @currency, description: "B Funding 2",
+      transacted_at: 2.days.ago
+    )
+
+    Transaction::AutoMerge.call(transaction, rule_account: @bank_b)
+
+    transaction.reload
+    # No mergeable counterpart exists, so revenue -> @bank_a becomes a @bank_b -> @bank_a transfer.
+    assert_equal @bank_b, transaction.src_account
+    assert_equal @bank_a, transaction.dest_account
+    assert_nil transaction.merged_into_id
+  end
+
   test "does not merge opening balance transactions" do
     expense = Account.create!(user: @user, name: "Transfer Out", kind: :expense, currency: @currency)
     transaction = Transaction.create!(

--- a/test/services/transaction/auto_merge_test.rb
+++ b/test/services/transaction/auto_merge_test.rb
@@ -259,11 +259,73 @@ class Transaction::AutoMergeTest < ActiveSupport::TestCase
       transacted_at: 2.days.ago
     )
 
-    Transaction::AutoMerge.call(transaction, rule_account: @bank_b)
+    bank_a_before = @bank_a.reload.balance_minor
+    bank_b_before = @bank_b.reload.balance_minor
+
+    # Ambiguous: two equal-amount counterparts on the rule account. AutoMerge must leave the
+    # transaction untouched rather than clone a transfer or reassign arbitrarily (#182).
+    assert_no_difference "Transaction.count" do
+      Transaction::AutoMerge.call(transaction, rule_account: @bank_b)
+    end
 
     transaction.reload
-    assert_equal @bank_b, transaction.dest_account # Fell back to apply_rule_account
+    assert_equal expense, transaction.dest_account # Left untouched — not reassigned
     assert_nil transaction.merged_into_id
+    assert_equal bank_a_before, @bank_a.reload.balance_minor
+    assert_equal bank_b_before, @bank_b.reload.balance_minor
+  end
+
+  test "does not clone an existing transfer when multiple candidates exist" do
+    @bank_a.reset_balance
+    @bank_b.reset_balance
+
+    # Two equal-amount, non-transfer charges on the rule account (@bank_a) — ambiguous.
+    expense_1 = Account.create!(user: @user, name: "Charge 1", kind: :expense, currency: @currency)
+    expense_2 = Account.create!(user: @user, name: "Charge 2", kind: :expense, currency: @currency)
+    Transaction.create!(
+      user: @user, src_account: @bank_a, dest_account: expense_1,
+      amount_minor: 500, currency: @currency, description: "Charge 1",
+      transacted_at: 2.days.ago
+    )
+    Transaction.create!(
+      user: @user, src_account: @bank_a, dest_account: expense_2,
+      amount_minor: 500, currency: @currency, description: "Charge 2",
+      transacted_at: 2.days.ago
+    )
+
+    # A pre-existing balance-sheet -> balance-sheet transfer that absorb would clone.
+    existing_transfer = Transaction.create!(
+      user: @user, src_account: @bank_a, dest_account: @bank_b,
+      amount_minor: 500, currency: @currency, description: "Existing transfer",
+      transacted_at: 2.days.ago
+    )
+
+    # Incoming deposit (the funding side) whose ledger account is @bank_b.
+    revenue = Account.create!(user: @user, name: "Funding", kind: :revenue, currency: @currency)
+    incoming = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: @bank_b,
+      amount_minor: 500, currency: @currency, description: "Funding",
+      transacted_at: 2.days.ago
+    )
+
+    bank_a_before = @bank_a.reload.balance_minor
+    bank_b_before = @bank_b.reload.balance_minor
+
+    # @bank_a has two equal-amount charges -> ambiguous, so AutoMerge must NOT fall through
+    # to absorb_into_existing_transfer and clone existing_transfer (which would leave the real
+    # charges live and double-count @bank_a). See #182.
+    assert_no_difference "Transaction.count" do
+      Transaction::AutoMerge.call(incoming, rule_account: @bank_a)
+    end
+
+    incoming.reload
+    existing_transfer.reload
+    assert_equal 500, incoming.amount_minor
+    assert_nil incoming.merged_into_id
+    assert_equal 500, existing_transfer.amount_minor
+    assert_nil existing_transfer.merged_into_id
+    assert_equal bank_a_before, @bank_a.reload.balance_minor
+    assert_equal bank_b_before, @bank_b.reload.balance_minor
   end
 
   test "does not merge opening balance transactions" do


### PR DESCRIPTION
## Summary

`Transaction::AutoMerge` could double-count a balance-sheet account when a balance-sheet import rule matched a transaction with two or more equal-amount counterpart candidates. `merge_with_counterpart` only merges on a *unique* counterpart, so an ambiguous match fell through to `absorb_into_existing_transfer`, which clones a pre-existing transfer and zeroes it + the incoming transaction while leaving the real charge live — silently overstating the balance. (Observed live: a credit-card account read $88.72 high.)

## Changes

- **`Transaction::AutoMerge`** — distinguish *ambiguous* (2+ candidates) from *absent* (zero). On ambiguity, leave the transaction untouched for manual review rather than clone a transfer or reassign arbitrarily.
- **`ImportRule::RetroactiveApply`** — mirror the count-aware check so ambiguous balance-sheet matches are no longer surfaced as pending reassignments that never resolve (and would re-create the double-count if applied).

## Test plan

- [x] `auto_merge_test.rb` — ambiguous match leaves the transaction untouched (no reassign), balances unchanged
- [x] `auto_merge_test.rb` — ambiguous match does **not** clone an existing transfer; no new transaction, balances unchanged (direct regression for the double-count)
- [x] `retroactive_apply_test.rb` — preview skips ambiguous balance-sheet matches
- [x] All three new/updated tests fail before the fix and pass after (verified by reverting the service edits)
- [x] Full suite green (830 runs, 100% line coverage); `import_rules` system test green; `rubocop` clean

Out of scope (tracked by #177): hardening `absorb_into_existing_transfer` against the no-rule import-time dedup path, and the upstream pre-forming of phantom transfers that seeds the stray transfer the clone latches onto.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
