### PR TITLE
Attach re-imported CSV rows to merged ledger transactions instead of duplicating

### DIFF
--- a/app/jobs/csv/import_transactions_job.rb
+++ b/app/jobs/csv/import_transactions_job.rb
@@ -169,9 +169,11 @@ class Csv::ImportTransactionsJob < ApplicationJob
         .where(transacted_at: csv_transaction.transacted_at.beginning_of_day..csv_transaction.transacted_at.end_of_day)
         .select(:id)
 
+      # Only the 0 / 1 / 2+ distinction matters below, so cap the scan at two rows.
       ledger_transaction_ids = TransactionSource
         .where(sourceable_type: "Csv::Transaction", sourceable_id: prior_csv_ids)
         .distinct
+        .limit(2)
         .pluck(:transaction_id)
 
       # 0 or 2+ distinct matches: ambiguous, fall through and create a new

--- a/app/jobs/csv/import_transactions_job.rb
+++ b/app/jobs/csv/import_transactions_job.rb
@@ -72,6 +72,20 @@ class Csv::ImportTransactionsJob < ApplicationJob
             # Another import handled this source; skip this iteration.
           end
           next
+        elsif (target = find_merged_duplicate_target(csv_transaction, ledger_account))
+          # The row was already imported and then consolidated into a transfer,
+          # so Transaction::Reconcile excludes its (now zeroed, merged) ledger
+          # transaction from the candidate set. Attach this re-imported row to
+          # the same merged original instead of creating a duplicate (#184).
+          begin
+            Transaction.transaction do
+              TransactionSource::Attach.call(transaction: target, sourceable: csv_transaction)
+              target.update!(synced_at: Time.current)
+            end
+          rescue TransactionSource::Attach::MismatchedTransaction
+            # Another import handled this source; skip this iteration.
+          end
+          next
         else
           transaction = Transaction.new
         end
@@ -130,4 +144,46 @@ class Csv::ImportTransactionsJob < ApplicationJob
 
     import.update!(state: "imported", imported_at: Time.current, error: nil)
   end
+
+  private
+
+    # Recognize a re-imported statement line whose prior CSV row was already
+    # consolidated (merged) into a transfer. Transaction::Reconcile excludes
+    # merged transactions and merge results from its candidate set, so an
+    # overlapping re-import of an already-merged row would otherwise create a
+    # duplicate ledger transaction and double-count the balance (#184). Find a
+    # prior Csv::Transaction from a *different* import into the *same* ledger
+    # account with identical content (signed amount, same calendar day,
+    # case-insensitively equal description) whose ledger transaction reconcile
+    # skipped only because it is a zeroed merged original, and return that single
+    # transaction so the new row attaches there instead of duplicating.
+    def find_merged_duplicate_target(csv_transaction, ledger_account)
+      return nil if csv_transaction.description.blank?
+
+      prior_csv_ids = Csv::Transaction
+        .joins(:import)
+        .where(csv_imports: { account_id: ledger_account.id })
+        .where.not(import_id: csv_transaction.import_id)
+        .where(amount_minor: csv_transaction.amount_minor)
+        .where("LOWER(csv_transactions.description) = LOWER(?)", csv_transaction.description)
+        .where(transacted_at: csv_transaction.transacted_at.beginning_of_day..csv_transaction.transacted_at.end_of_day)
+        .select(:id)
+
+      ledger_transaction_ids = TransactionSource
+        .where(sourceable_type: "Csv::Transaction", sourceable_id: prior_csv_ids)
+        .distinct
+        .pluck(:transaction_id)
+
+      # 0 or 2+ distinct matches: ambiguous, fall through and create a new
+      # transaction rather than guess (mirrors reconcile's conservative nil).
+      return nil unless ledger_transaction_ids.size == 1
+
+      target = Transaction.find(ledger_transaction_ids.first)
+      # Only act on reconcile's gap: a zeroed *original* (merged_into_id set),
+      # which is also the row that survives a later Transaction::Unmerge. A CSV
+      # source is never attached to a merge *result* (results are created
+      # sourceless and reconcile excludes them). A live/unmerged single match
+      # means reconcile deliberately abstained, so defer to it and fall through.
+      target.merged_into_id.present? ? target : nil
+    end
 end

--- a/test/jobs/csv/import_transactions_job_test.rb
+++ b/test/jobs/csv/import_transactions_job_test.rb
@@ -5,6 +5,7 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
     @user = users(:one)
     @currency = currencies(:usd)
     @bank_account = accounts(:asset_account)
+    @bank_b = accounts(:linked_asset) # counterpart balance-sheet account for transfers
   end
 
   test "imports an expense (negative amount_minor)" do
@@ -310,7 +311,193 @@ class Csv::ImportTransactionsJobTest < ActiveJob::TestCase
     end
   end
 
+  # --- #184: re-importing an overlapping row whose ledger transaction was merged ---
+
+  test "re-importing a row whose ledger transaction was merged attaches instead of duplicating (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    charge = import_then_merge_charge(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+    assert_equal 0, charge.amount_minor, "merge zeroes the original"
+    assert charge.merged_into_id.present?, "merge sets merged_into_id"
+
+    balance_before = @bank_account.reload.balance_minor
+
+    import_b = create_csv_import
+    csv_b = import_b.transactions.create!(
+      row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current
+    )
+
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+
+    assert_equal charge, csv_b.reload.ledger_transactions.first, "the re-imported row attaches to the merged original"
+    assert_equal balance_before, @bank_account.reload.balance_minor, "the account balance does not double-count"
+  end
+
+  test "a genuinely new row in the same re-import is still created (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    import_then_merge_charge(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+
+    import_b = create_csv_import
+    import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    import_b.transactions.create!(row_index: 1, transacted_at: same_at, description: "Grocery Store", amount_minor: -3000, synced_at: Time.current)
+
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+    assert_equal "Grocery Store", Transaction.order(:id).last.description
+  end
+
+  test "an ambiguous match against multiple merged transactions falls through to a new transaction (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    build_merged_csv_charge_directly(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+    build_merged_csv_charge_directly(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+
+    import_b = create_csv_import
+    import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+  end
+
+  test "a single unmerged match is left to Reconcile and not adopted by the merge fallback (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+
+    # A prior CSV-sourced, still-unmerged charge.
+    import_a = create_csv_import
+    import_a.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(import_a.id)
+
+    # A second identical-content unmerged charge with no CSV source, so Reconcile
+    # sees two candidates and abstains (size == 2 -> nil), reaching the fallback.
+    Transaction.create!(
+      user: @user, currency: @currency, src_account: @bank_account, dest_account: accounts(:expense_account),
+      amount_minor: 5000, description: "Coffee Shop", transacted_at: same_at
+    )
+
+    import_b = create_csv_import
+    import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+
+    # The single match is unmerged, so the fallback returns nil and a new transaction is created.
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+  end
+
+  test "a blank-description re-import is not deduped by the merge fallback (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    import_then_merge_charge(description: "", amount_minor: -5000, transacted_at: same_at)
+
+    import_b = create_csv_import
+    import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "", amount_minor: -5000, synced_at: Time.current)
+
+    assert_difference "Transaction.count", 1 do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+    assert_equal "(no description)", Transaction.order(:id).last.description
+  end
+
+  test "re-running the re-import job after a merge-fallback attach is idempotent (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    import_then_merge_charge(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+
+    import_b = create_csv_import
+    import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(import_b.id)
+
+    assert_no_difference [ "Transaction.count", "TransactionSource.count" ] do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+  end
+
+  test "an overlapping re-import of an unmerged transaction is still reconciled, not duplicated (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    import_a = create_csv_import
+    csv_a = import_a.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(import_a.id)
+    charge = csv_a.reload.ledger_transactions.first
+
+    import_b = create_csv_import
+    csv_b = import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(import_b.id)
+    end
+    assert_equal charge, csv_b.reload.ledger_transactions.first, "Reconcile adopts the unmerged original"
+  end
+
+  test "the merge-fallback attachment survives an unmerge of the transfer (#184)" do
+    same_at = 1.day.ago.beginning_of_day + 12.hours
+    charge = import_then_merge_charge(description: "Coffee Shop", amount_minor: -5000, transacted_at: same_at)
+    transfer = Transaction.find(charge.merged_into_id)
+
+    import_b = create_csv_import
+    csv_b = import_b.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    Csv::ImportTransactionsJob.perform_now(import_b.id)
+    assert_equal charge, csv_b.reload.ledger_transactions.first
+
+    assert Transaction::Unmerge.new(transfer, user: @user).call
+    charge.reload
+    assert_nil charge.merged_into_id, "unmerge restores the original"
+    assert_equal 5000, charge.amount_minor
+    assert_equal 2, charge.transaction_sources.where(sourceable_type: "Csv::Transaction").count,
+      "both CSV sources survive on the restored original"
+
+    # A later overlapping re-import now reconciles to the restored original.
+    import_c = create_csv_import
+    import_c.transactions.create!(row_index: 0, transacted_at: same_at, description: "Coffee Shop", amount_minor: -5000, synced_at: Time.current)
+    assert_no_difference "Transaction.count" do
+      Csv::ImportTransactionsJob.perform_now(import_c.id)
+    end
+  end
+
   private
+
+    # Import a charge through the job, then consolidate it into a BS->BS transfer
+    # via Transaction::Merge. Returns the now-zeroed, merged original.
+    def import_then_merge_charge(description:, amount_minor:, transacted_at:)
+      import = create_csv_import
+      csv_row = import.transactions.create!(
+        row_index: 0, transacted_at: transacted_at, description: description,
+        amount_minor: amount_minor, synced_at: Time.current
+      )
+      Csv::ImportTransactionsJob.perform_now(import.id)
+      charge = csv_row.reload.ledger_transactions.first
+
+      revenue = Account.create!(user: @user, currency: @currency, name: "Transfer In #{import.id}", kind: :revenue)
+      counterpart = Transaction.create!(
+        user: @user, currency: @currency, src_account: revenue, dest_account: @bank_b,
+        amount_minor: amount_minor.abs, description: description.presence || "Transfer", transacted_at: transacted_at
+      )
+      assert Transaction::Merge.new(charge, counterpart, user: @user).call
+      charge.reload
+    end
+
+    # Build a CSV-sourced charge that is already merged, WITHOUT going through the
+    # import job's dedup, so multiple identical-content merged transactions can
+    # coexist (for the ambiguity test).
+    def build_merged_csv_charge_directly(description:, amount_minor:, transacted_at:)
+      import = create_csv_import
+      csv_row = import.transactions.create!(
+        row_index: 0, transacted_at: transacted_at, description: description,
+        amount_minor: amount_minor, synced_at: Time.current
+      )
+      expense = Account.create!(user: @user, currency: @currency, name: "Expense #{import.id}", kind: :expense)
+      charge = Transaction.create!(
+        user: @user, currency: @currency, src_account: @bank_account, dest_account: expense,
+        amount_minor: amount_minor.abs, description: description, transacted_at: transacted_at
+      )
+      TransactionSource.create!(ledger_transaction: charge, sourceable: csv_row)
+
+      revenue = Account.create!(user: @user, currency: @currency, name: "Revenue #{import.id}", kind: :revenue)
+      counterpart = Transaction.create!(
+        user: @user, currency: @currency, src_account: revenue, dest_account: @bank_b,
+        amount_minor: amount_minor.abs, description: description, transacted_at: transacted_at
+      )
+      assert Transaction::Merge.new(charge, counterpart, user: @user).call
+      charge.reload
+    end
 
     def create_csv_import
       csv_import = Csv::Import.new(user: @user, account: @bank_account, state: "parsed")


### PR DESCRIPTION
## Summary

Re-importing an overlapping CSV statement that contains a row whose ledger transaction had been **merged/consolidated** into a transfer created a brand-new **duplicate** ledger transaction and **double-counted** the account balance.

`Transaction::Reconcile#candidate_query` deliberately excludes merged transactions (`merged_into_id: nil`) and merge results (`where.missing(:merged_sources)`) from its dedup candidate set — correct for the cross-aggregator paths it shares, but it means a re-imported row whose prior ledger transaction was merged finds no match, falls through, and is created fresh. Reconcile already handles overlapping CSV re-imports for *unmerged* transactions; this fills the *merged* gap.

## Approach

Add a fallback in `Csv::ImportTransactionsJob` that runs **after** `Transaction::Reconcile` returns `nil` and **before** a new `Transaction` is built. A new `find_merged_duplicate_target` helper finds a prior `Csv::Transaction` from a *different import into the same ledger account* with identical content (signed amount, same calendar day, case-insensitive description) whose ledger transaction is a **zeroed merged original**, and attaches the re-imported row there instead of duplicating.

`Transaction::Reconcile` and the SimpleFIN/Lunch Flow refresh paths are untouched (loosening reconcile was rejected: the merged original is zeroed so its amount filter can never match it, and the change would risk the cross-aggregator regressions #159/#117/#183 tuned against). No model/schema/migration changes.

### Safety invariants
- **Balance unchanged** — the branch only attaches the source and bumps `synced_at`, which doesn't trigger `transfer_account_balances`.
- **Idempotent** — once attached, the row's ledger transaction has `merged_into_id` set, so the job's top-level SQL gate excludes it from all future runs; the merge is never re-entered or un-zeroed.
- **Unmerge-durable** — attaches to the zeroed *original* (restored on unmerge), never the merge *result* (which `Unmerge` `destroy!`s, cascading `dependent: :destroy`).
- **Surgical** — an ambiguity guard (0 or 2+ matches → fall through) and merged-only scoping leave reconcile's tuned live-transaction behavior alone.

## Test plan

All in `test/jobs/csv/import_transactions_job_test.rb`:

- [x] Re-importing a merged row attaches to the original — no new `Transaction`, account balance unchanged
- [x] A genuinely-new row in the same re-import is still created
- [x] Ambiguous match against 2+ merged transactions falls through to a new transaction
- [x] A single *unmerged* match is left to Reconcile (fallback returns nil)
- [x] Blank-description re-import is not deduped
- [x] Re-running the re-import job is idempotent (`Transaction`/`TransactionSource` counts stable)
- [x] Regression: overlapping re-import of an *unmerged* transaction is still reconciled
- [x] The attachment survives a later `Transaction::Unmerge` of the transfer

Full suite green (840 runs, 0 failures), 100% line coverage; `bin/rubocop` and `bin/brakeman` clean.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)