### PR TITLE
Show source badges on merged transfer transactions

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -556,6 +556,10 @@
   margin-bottom: 2px;
 }
 
+.merged-details__content li .source-badge {
+  margin-left: 4px;
+}
+
 /* Select column */
 .transactions .row > .select {
   justify-content: center;

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -10,7 +10,7 @@ class TransactionsController < ApplicationController
     @show_excluded = params[:show_excluded] == "1"
     scope = current_user.transactions.unmerged
     scope = scope.unexcluded unless @show_excluded
-    @transactions = scope.includes(:category, :src_account, :dest_account, :currency, :fx_currency, transaction_sources: :sourceable, merged_sources: [ :src_account, :dest_account ]).order(transacted_at: :desc, created_at: :desc)
+    @transactions = scope.includes(:category, :src_account, :dest_account, :currency, :fx_currency, transaction_sources: :sourceable, merged_sources: [ :src_account, :dest_account, { transaction_sources: :sourceable } ]).order(transacted_at: :desc, created_at: :desc)
     account_id = params.fetch(:account_id, nil)
     if account_id.present?
       @account = current_user.accounts.find(account_id)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,14 +36,20 @@ module ApplicationHelper
   # sourceable is already loaded (e.g., array from `includes(:sourceable)`).
   # An unloaded relation will N+1 on the per-source sourceable access below.
   #
+  # Sorted by source_badge_order first so chips always render in aggregator order
+  # (SimpleFIN, Lunch Flow, CSV) regardless of input order — merge results concatenate
+  # own and origin sources, so input order is otherwise non-deterministic.
+  #
   # Deduped by label so a ledger transaction carrying several sources of the same
   # type renders a single chip. A CSV that overlaps a prior import for the same
   # account attaches a second Csv::Transaction source (no stable external id, so
   # every import creates fresh rows) — without this, that shows as repeated "CSV"
-  # chips (#151). uniq keeps first-occurrence order, preserving badge ordering.
+  # chips (#151). Sorting before uniq is safe: equal order keys only occur for
+  # same-label records, which uniq collapses anyway.
   def transaction_source_badges(sources)
     badges = sources
       .map(&:sourceable)
+      .sort_by { |sourceable| source_badge_order(sourceable) }
       .uniq { |sourceable| source_badge_label(sourceable) }
       .map do |sourceable|
         classes = [ "source-badge", source_badge_modifier(sourceable) ].compact.join(" ")

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -94,6 +94,30 @@ class Transaction < ApplicationRecord
     [ src_account, dest_account ].find { |a| a&.real? }
   end
 
+  # This transaction's own source rows with each sourceable preloaded. Reused for the
+  # aggregated chips on the row and the per-origin chips in the "Merged from:" list.
+  # Preload-safe: reuses the loaded proxy only when transaction_sources AND every
+  # sourceable are already loaded; otherwise materializes via `.includes(:sourceable)`
+  # so neither the caller's `.any?` nor the badge helper triggers an N+1.
+  def own_badge_sources
+    if transaction_sources.loaded? && transaction_sources.all? { |s| s.association(:sourceable).loaded? }
+      transaction_sources.to_a
+    else
+      transaction_sources.includes(:sourceable).to_a
+    end
+  end
+
+  # Source rows for this row's aggregated badges: this transaction's own plus those of
+  # every merged origin. A merge result is created sourceless and inherits the aggregator
+  # provenance only through the originals it absorbed (a re-imported CSV row also attaches
+  # to the zeroed original, not the result — see Csv::ImportTransactionsJob #185). Dedup
+  # and ordering are the badge helper's job. Preload-safe so single-row re-renders
+  # (merge/unmerge/show) that skip the index preload don't N+1.
+  def badge_transaction_sources
+    origins = merged_sources.loaded? ? merged_sources : merged_sources.includes(transaction_sources: :sourceable)
+    own_badge_sources + origins.flat_map(&:own_badge_sources)
+  end
+
   private
 
     def assign_currency_from_dest_account

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -114,11 +114,25 @@ class Transaction < ApplicationRecord
   # and ordering are the badge helper's job. Preload-safe so single-row re-renders
   # (merge/unmerge/show) that skip the index preload don't N+1.
   def badge_transaction_sources
-    origins = merged_sources.loaded? ? merged_sources : merged_sources.includes(transaction_sources: :sourceable)
-    own_badge_sources + origins.flat_map(&:own_badge_sources)
+    own_badge_sources + merged_origins_for_badges.flat_map(&:own_badge_sources)
   end
 
   private
+
+    # Merged origins with each origin's sources + sourceables loaded. Mirrors
+    # own_badge_sources: reuses the loaded proxy only when merged_sources AND every
+    # origin's nested transaction_sources/sourceables are already loaded (the index
+    # preloads `merged_sources: { transaction_sources: :sourceable }`); otherwise
+    # re-issues with `.includes` so a merged_sources collection that was loaded
+    # without the nested data can't silently N+1 one query per origin.
+    def merged_origins_for_badges
+      fully_loaded = merged_sources.loaded? && merged_sources.all? do |origin|
+        origin.transaction_sources.loaded? &&
+          origin.transaction_sources.all? { |source| source.association(:sourceable).loaded? }
+      end
+
+      fully_loaded ? merged_sources : merged_sources.includes(transaction_sources: :sourceable).to_a
+    end
 
     def assign_currency_from_dest_account
       self.currency = dest_account.currency if dest_account.present? && !dest_account.virtual?

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -1,16 +1,8 @@
 <!-- Show -->
-<%# Resolve the transaction_sources collection once with sourceable preloaded.
-    Reuse the proxy only if BOTH transaction_sources and each sourceable are
-    already loaded (TransactionsController#index covers this via
-    `includes(transaction_sources: :sourceable)`). Otherwise materialize an
-    array via `.includes(:sourceable)` so neither the .any? check nor the
-    badge helper triggers an N+1 — including the case where a caller
-    preloaded transaction_sources alone without :sourceable. %>
-<% sources = if transaction.transaction_sources.loaded? && transaction.transaction_sources.all? { |s| s.association(:sourceable).loaded? }
-              transaction.transaction_sources
-            else
-              transaction.transaction_sources.includes(:sourceable).to_a
-            end %>
+<%# Aggregated source rows for this row's chips: the transaction's own sources plus,
+    for a merge result, those of every merged origin (the result itself is created
+    sourceless). Resolution and N+1-safety live in Transaction#badge_transaction_sources. %>
+<% sources = transaction.badge_transaction_sources %>
 <%= turbo_frame_tag transaction do %>
   <div class="transaction" data-controller="transactions--row" data-transactions--row-id-value="<%= transaction.id %>"
        data-selection-excluded="<%= transaction.excluded? %>"
@@ -85,7 +77,8 @@
             <strong>Merged from:</strong>
             <ul>
               <% transaction.merged_sources.each do |source| %>
-                <li><%= source.src_account&.name %> → <%= source.dest_account&.name %><% if source.description.present? %> — "<%= source.description %>"<% end %></li>
+                <% origin_sources = source.own_badge_sources %>
+                <li><%= source.src_account&.name %> → <%= source.dest_account&.name %><% if source.description.present? %> — "<%= source.description %>"<% end %><%= transaction_source_badges(origin_sources) if origin_sources.any? %></li>
               <% end %>
             </ul>
           </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -177,4 +177,19 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal 1, html.scan(/source-badge--csv">CSV<\/span>/).size
     assert_equal 1, html.scan(/source-badge--simplefin">SimpleFIN<\/span>/).size
   end
+
+  test "transaction_source_badges renders chips in aggregator order regardless of input order" do
+    fake_source = Struct.new(:sourceable)
+    # Deliberately reversed: CSV, Lunch Flow, SimpleFIN.
+    sources = [
+      fake_source.new(Csv::Transaction.new),
+      fake_source.new(lunchflow_accounts(:linked_one)),
+      fake_source.new(simplefin_accounts(:linked_one))
+    ]
+
+    html = transaction_source_badges(sources)
+
+    assert_operator html.index("source-badge--simplefin"), :<, html.index("source-badge--lunchflow")
+    assert_operator html.index("source-badge--lunchflow"), :<, html.index("source-badge--csv")
+  end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -812,4 +812,91 @@ class TransactionTest < ActiveSupport::TestCase
     child.update_columns(parent_transaction_id: transactions(:one).id)
     assert_not child.reload.excludable?, "child transactions must not be excludable"
   end
+
+  # badge_transaction_sources / own_badge_sources
+
+  test "own_badge_sources returns the transaction's own sources" do
+    transaction = create_sourced_transaction(
+      user: users(:one),
+      src_account: accounts(:linked_asset),
+      dest_account: accounts(:expense_account),
+      amount_minor: 500,
+      currency: currencies(:usd),
+      description: "Own",
+      transacted_at: 1.day.ago,
+      sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    assert_equal [ simplefin_transactions(:transaction_one) ],
+                 transaction.own_badge_sources.map(&:sourceable)
+  end
+
+  test "badge_transaction_sources returns only own sources for a non-merged transaction" do
+    transaction = create_sourced_transaction(
+      user: users(:one),
+      src_account: accounts(:linked_asset),
+      dest_account: accounts(:expense_account),
+      amount_minor: 500,
+      currency: currencies(:usd),
+      description: "Own",
+      transacted_at: 1.day.ago,
+      sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    assert_equal [ simplefin_transactions(:transaction_one) ],
+                 transaction.badge_transaction_sources.map(&:sourceable)
+  end
+
+  test "badge_transaction_sources on a merge result aggregates each merged origin's sources" do
+    result, = merged_transfer(
+      leg_a_source: simplefin_transactions(:transaction_one),
+      leg_b_source: lunchflow_transactions(:transaction_one)
+    )
+
+    sourceables = result.badge_transaction_sources.map(&:sourceable)
+    assert_equal 2, sourceables.size
+    assert_includes sourceables, simplefin_transactions(:transaction_one)
+    assert_includes sourceables, lunchflow_transactions(:transaction_one)
+  end
+
+  test "badge_transaction_sources combines a merge result's own source with its origins'" do
+    result, = merged_transfer(leg_a_source: simplefin_transactions(:transaction_one))
+    # A merge result is created sourceless, but a later attach (e.g. a manual link)
+    # can still give it its own source — both surfaces must appear.
+    TransactionSource.create!(ledger_transaction: result, sourceable: lunchflow_transactions(:transaction_one))
+
+    sourceables = result.reload.badge_transaction_sources.map(&:sourceable)
+    assert_includes sourceables, lunchflow_transactions(:transaction_one) # own
+    assert_includes sourceables, simplefin_transactions(:transaction_one) # from merged origin
+  end
+
+  test "badge_transaction_sources is empty for a sourceless merge result" do
+    result, = merged_transfer
+
+    assert_empty result.badge_transaction_sources
+  end
+
+  private
+
+    # Builds two non-transfer legs (asset→expense and revenue→asset) that pair into a
+    # transfer, attaches the given sources to the legs, and merges them. Returns
+    # [merge_result, leg_a, leg_b]; the result itself is created sourceless.
+    def merged_transfer(leg_a_source: nil, leg_b_source: nil)
+      leg_a = Transaction.create!(
+        user: users(:one), src_account: accounts(:asset_account),
+        dest_account: accounts(:expense_account), amount_minor: 5000,
+        currency: currencies(:usd), description: "Leg A", transacted_at: 2.days.ago
+      )
+      leg_b = Transaction.create!(
+        user: users(:one), src_account: accounts(:revenue_account),
+        dest_account: accounts(:linked_asset), amount_minor: 5000,
+        currency: currencies(:usd), description: "Leg B", transacted_at: 2.days.ago
+      )
+      TransactionSource.create!(ledger_transaction: leg_a, sourceable: leg_a_source) if leg_a_source
+      TransactionSource.create!(ledger_transaction: leg_b, sourceable: leg_b_source) if leg_b_source
+
+      merger = Transaction::Merge.new(leg_a, leg_b, user: users(:one))
+      assert merger.call, merger.errors.to_sentence
+      [ merger.merged_transaction, leg_a, leg_b ]
+    end
 end

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -876,6 +876,18 @@ class TransactionTest < ActiveSupport::TestCase
     assert_empty result.badge_transaction_sources
   end
 
+  test "badge_transaction_sources reuses fully preloaded merged origins" do
+    result, = merged_transfer(
+      leg_a_source: simplefin_transactions(:transaction_one),
+      leg_b_source: lunchflow_transactions(:transaction_one)
+    )
+    preloaded = Transaction
+      .includes(transaction_sources: :sourceable, merged_sources: { transaction_sources: :sourceable })
+      .find(result.id)
+
+    assert_equal 2, preloaded.badge_transaction_sources.map(&:sourceable).size
+  end
+
   private
 
     # Builds two non-transfer legs (asset→expense and revenue→asset) that pair into a

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -100,6 +100,56 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "merged transfer shows aggregated and per-origin source badges" do
+    leg_a = Transaction.create!(
+      user: @user, src_account: accounts(:asset_account),
+      dest_account: accounts(:expense_account), amount_minor: 5000,
+      currency: currencies(:usd), description: "Merge leg A", transacted_at: 1.day.ago
+    )
+    leg_b = Transaction.create!(
+      user: @user, src_account: accounts(:revenue_account),
+      dest_account: accounts(:linked_asset), amount_minor: 5000,
+      currency: currencies(:usd), description: "Merge leg B", transacted_at: 1.day.ago
+    )
+    sf_txn = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "merge_sf",
+      amount: "-50.00", description: "Merge leg A",
+      transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    lf_txn = Lunchflow::Transaction.create!(
+      account: lunchflow_accounts(:unlinked_one), remote_id: "merge_lf",
+      amount: "-50.00", currency: "USD", description: "Merge leg B",
+      pending: false, date: 1.day.ago.to_date
+    )
+    TransactionSource.create!(ledger_transaction: leg_a, sourceable: sf_txn)
+    TransactionSource.create!(ledger_transaction: leg_b, sourceable: lf_txn)
+
+    merger = Transaction::Merge.new(leg_a, leg_b, user: @user)
+    assert merger.call, merger.errors.to_sentence
+    result = merger.merged_transaction
+
+    visit transactions_path
+
+    within "##{ActionView::RecordIdentifier.dom_id(result)}" do
+      # Aggregated chips in the Date cell, ordered SimpleFIN then Lunch Flow.
+      within ".source-badges" do
+        assert_selector ".source-badge", text: "SimpleFIN"
+        assert_selector ".source-badge", text: "Lunch Flow"
+      end
+
+      # Per-origin chips in the collapsible "Merged from:" breakdown.
+      click_link "Merged"
+      within ".merged-details" do
+        assert_selector ".source-badge", text: "SimpleFIN"
+        assert_selector ".source-badge", text: "Lunch Flow"
+      end
+    end
+
+    # The zeroed originals are hidden by the unmerged scope.
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(leg_a)}"
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(leg_b)}"
+  end
+
   test "sidebar active state survives a live update" do
     account = accounts(:asset_account)
     other = accounts(:expense_account)


### PR DESCRIPTION
## Summary

Merged transfers showed the **Merged** badge but **no source chips**. Both `Transaction::Merge` and `AutoMerge#absorb_into_existing_transfer` create the merge *result* sourceless — the aggregator sources stay on the zeroed originals, which the `unmerged` scope hides from the list. The row only badged its own (empty) `transaction_sources`, so e.g. a CSV-sourced transfer rendered nothing. Re-importing the CSV doesn't help either: #185 attaches the re-imported row to the zeroed **original** (so a later `Unmerge` stays reversible), never to the result.

This surfaces the badges at the presentation layer only — no data-model or merge-service change.

## Changes

- **`Transaction#own_badge_sources`** — preload-safe own sources (lifts the N+1 guard out of the partial); reused for the row chips and the per-origin chips.
- **`Transaction#badge_transaction_sources`** — own sources **plus** every merged origin's, so a merge result inherits its origins' provenance.
- **`_transaction.html.erb`** — row chips aggregate via `badge_transaction_sources`; each "Merged from:" line now shows its origin's chip via `own_badge_sources`.
- **`transaction_source_badges`** — sorts by `source_badge_order` before dedup, so chips always render SimpleFIN → Lunch Flow → CSV regardless of merge order.
- **`TransactionsController#index`** — preload extended with `merged_sources: { transaction_sources: :sourceable }` (no N+1 for mixed lists); single-row re-renders fall back to `.includes`.
- **`transactions.css`** — small left margin for the inline per-line chips.

`show.html.erb` and the turbo-stream re-renders inherit the fix automatically (same partial; model methods fall back when not preloaded).

## Test plan

- [x] `badge_transaction_sources` returns only own sources for a non-merged transaction — `test/models/transaction_test.rb`
- [x] `badge_transaction_sources` on a merge result aggregates each origin's sources — `test/models/transaction_test.rb`
- [x] `badge_transaction_sources` combines a result's own source with its origins' — `test/models/transaction_test.rb`
- [x] `badge_transaction_sources` is empty for a sourceless merge result (no-chip empty state) — `test/models/transaction_test.rb`
- [x] `own_badge_sources` returns a transaction's own sources (per-line path) — `test/models/transaction_test.rb`
- [x] `transaction_source_badges` renders chips in aggregator order regardless of input order — `test/helpers/application_helper_test.rb`
- [x] Merged transfer shows aggregated row chips **and** per-origin chips in the expanded "Merged from:" breakdown, with originals hidden — `test/system/transactions_test.rb`

Full suite: 846 non-system + 66 system runs, 0 failures, 100% line coverage. `bin/rubocop` and `bin/brakeman` clean.

## Notes

Related to #168 (a separate enhancement: expand a transaction's *own* sources into a per-record detail list) — this PR only fixes the missing merged-transfer chips and reuses the existing badge helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)