### PR TITLE
Add manual duplicate-transaction combining

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -720,6 +720,43 @@
   color: var(--bark-medium);
 }
 
+.selection-confirmation__options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.selection-confirmation__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--bark-medium);
+  cursor: pointer;
+}
+
+.selection-confirmation__option input {
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
+.selection-confirmation__option-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.selection-confirmation__option-title {
+  color: var(--bark);
+  font-weight: 500;
+}
+
+.selection-confirmation__option-detail {
+  font-size: 0.8rem;
+  color: var(--bark-medium);
+}
+
 .selection-confirmation__actions {
   display: flex;
   gap: 8px;

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -138,7 +138,9 @@ class TransactionsController < ApplicationController
       return
     end
 
-    transactions = transaction_ids.map { |id| current_user.transactions.find(id) }
+    transactions = current_user.transactions.where(id: transaction_ids).to_a
+    # Any missing/foreign id leaves the set short — 404, matching find's behavior.
+    raise ActiveRecord::RecordNotFound if transactions.size != transaction_ids.size
 
     survivor = nil
     if params[:survivor_id].present?

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -127,6 +127,50 @@ class TransactionsController < ApplicationController
     end
   end
 
+  # POST /transactions/deduplicate
+  def deduplicate
+    transaction_ids = Array(params[:transaction_ids]).uniq
+    if transaction_ids.size < 2
+      @dedupe_errors = [ "You must select at least two transactions to combine." ]
+      respond_to do |format|
+        format.turbo_stream { render :dedupe_error, status: :unprocessable_entity }
+      end
+      return
+    end
+
+    transactions = transaction_ids.map { |id| current_user.transactions.find(id) }
+
+    survivor = nil
+    if params[:survivor_id].present?
+      survivor = transactions.find { |t| t.id.to_s == params[:survivor_id].to_s }
+      if survivor.nil?
+        @dedupe_errors = [ "The transaction to keep must be one of the selected transactions." ]
+        respond_to do |format|
+          format.turbo_stream { render :dedupe_error, status: :unprocessable_entity }
+        end
+        return
+      end
+    end
+
+    deduplicator = Transaction::Deduplicate.new(*transactions, user: current_user, survivor: survivor)
+
+    succeeded = false
+    Transaction.collecting_sidebar_broadcasts do
+      succeeded = deduplicator.call
+    end
+
+    respond_to do |format|
+      if succeeded
+        @survivor = deduplicator.survivor
+        @removed_ids = transactions.reject { |t| t.id == @survivor.id }.map(&:id)
+        format.turbo_stream
+      else
+        @dedupe_errors = deduplicator.errors
+        format.turbo_stream { render :dedupe_error, status: :unprocessable_entity }
+      end
+    end
+  end
+
   # DELETE /transactions/bulk_destroy
   def bulk_destroy
     transactions = current_user.transactions.where(id: bulk_transaction_ids).to_a

--- a/app/javascript/controllers/transactions/selection_controller.js
+++ b/app/javascript/controllers/transactions/selection_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
   static targets = [
     "checkbox", "bar", "count",
     "deleteButton", "excludeButton", "restoreButton", "mergeButton", "mergeMessage",
+    "combineButton", "combineConfirmation", "combineOptions", "combineForm", "combineSurvivorId",
     "confirmation", "deleteConfirmation",
     "deleteForm", "excludeForm", "restoreForm"
   ]
@@ -38,6 +39,7 @@ export default class extends Controller {
     if (this.selectedIds.length < 1) {
       this.hideBar()
       this.hideConfirmation()
+      this.hideCombineConfirmation()
       this.hideDeleteConfirmation()
       return
     }
@@ -51,6 +53,7 @@ export default class extends Controller {
     this.updateExcludeButton()
     this.updateRestoreButton()
     this.updateMergeButton()
+    this.updateCombineButton()
 
     this.barTarget.hidden = false
   }
@@ -100,6 +103,41 @@ export default class extends Controller {
     }
   }
 
+  updateCombineButton() {
+    if (!this.hasCombineButtonTarget) return
+
+    const anyExcluded = this.selectedRows().some(row => row.dataset.selectionExcluded === "true")
+
+    if (this.selectedIds.length < 2 || anyExcluded) {
+      this.combineButtonTarget.disabled = true
+      return
+    }
+
+    const rows = this.selectedIds.map(id => this.transactionData(id))
+    this.combineButtonTarget.disabled = !rows.every(Boolean) || !this.validateDuplicates(rows)
+  }
+
+  // Duplicates of one event: equal amount + currency, each a non-transfer, all
+  // sharing the same bank account on the same side (all src == BankX, or all
+  // dest == BankX). Mutually exclusive with a valid transfer pair.
+  validateDuplicates(rows) {
+    const balanceSheetKinds = this.constructor.BALANCE_SHEET_KINDS
+    const isBs = kind => balanceSheetKinds.includes(kind)
+
+    if (new Set(rows.map(r => r.amountMinor)).size !== 1) return false
+    if (new Set(rows.map(r => r.currencyCode)).size !== 1) return false
+
+    // Each must be a non-transfer: exactly one balance-sheet side.
+    if (!rows.every(r => isBs(r.srcKind) !== isBs(r.destKind))) return false
+
+    const allSrc = rows.every(r => isBs(r.srcKind))
+    const allDest = rows.every(r => isBs(r.destKind))
+
+    if (allSrc) return new Set(rows.map(r => r.srcAccountId)).size === 1
+    if (allDest) return new Set(rows.map(r => r.destAccountId)).size === 1
+    return false
+  }
+
   // --- Row data helpers -----------------------------------------------------
 
   selectedRows() {
@@ -126,6 +164,7 @@ export default class extends Controller {
       srcAccountName: row.dataset.mergeSrcAccountName,
       destAccountName: row.dataset.mergeDestAccountName,
       description: row.dataset.mergeDescription,
+      category: row.dataset.mergeCategory,
       transactedAt: row.dataset.mergeTransactedAt,
       currencyCode: row.dataset.mergeCurrencyCode,
       currencyDecimalPlaces: parseInt(row.dataset.mergeCurrencyDecimalPlaces, 10) || 2
@@ -255,6 +294,76 @@ export default class extends Controller {
     this.confirmationTarget.hidden = true
   }
 
+  // --- Combine duplicates confirmation --------------------------------------
+
+  showCombineConfirmation() {
+    if (!this.hasCombineConfirmationTarget) return
+
+    const rows = this.selectedIds.map(id => this.transactionData(id)).filter(Boolean)
+    if (rows.length < 2 || !this.validateDuplicates(rows)) return
+
+    const defaultId = this.defaultSurvivorId(rows)
+
+    this.combineOptionsTarget.innerHTML = ""
+    rows.forEach(row => {
+      const label = document.createElement("label")
+      label.className = "selection-confirmation__option"
+
+      const input = document.createElement("input")
+      input.type = "radio"
+      input.name = "combine_survivor"
+      input.value = row.id
+      input.checked = row.id === defaultId
+
+      const body = document.createElement("span")
+      body.className = "selection-confirmation__option-body"
+
+      const title = document.createElement("span")
+      title.className = "selection-confirmation__option-title"
+      title.textContent = row.description || "(no description)"
+
+      // Lead the subtext with the date — the field that distinguishes otherwise
+      // identical duplicates.
+      const details = []
+      if (row.transactedAt) details.push(row.transactedAt.replace("T", " "))
+      details.push(`${row.srcAccountName} → ${row.destAccountName}`)
+      if (row.category) details.push(row.category)
+
+      const detail = document.createElement("span")
+      detail.className = "selection-confirmation__option-detail"
+      detail.textContent = details.join(" · ")
+
+      body.appendChild(title)
+      body.appendChild(detail)
+      label.appendChild(input)
+      label.appendChild(body)
+      this.combineOptionsTarget.appendChild(label)
+    })
+
+    this.combineConfirmationTarget.hidden = false
+    this.barTarget.hidden = true
+  }
+
+  // Heuristic default (mirrors Transaction::Deduplicate): a categorized row,
+  // else the oldest by transacted_at.
+  defaultSurvivorId(rows) {
+    const categorized = rows.filter(row => row.category && row.category.length > 0)
+    const pool = categorized.length > 0 ? categorized : rows
+    return pool.reduce((best, row) => (row.transactedAt < best.transactedAt ? row : best)).id
+  }
+
+  submitCombine() {
+    const checked = this.combineOptionsTarget.querySelector("input[name='combine_survivor']:checked")
+    if (!checked) return
+    this.combineSurvivorIdTarget.value = checked.value
+    this.submitBulk(this.combineFormTarget)
+  }
+
+  hideCombineConfirmation() {
+    if (!this.hasCombineConfirmationTarget) return
+    this.combineConfirmationTarget.hidden = true
+  }
+
   hideDeleteConfirmation() {
     if (!this.hasDeleteConfirmationTarget) return
     this.deleteConfirmationTarget.hidden = true
@@ -270,6 +379,7 @@ export default class extends Controller {
     this.checkboxTargets.forEach(cb => cb.checked = false)
     this.hideBar()
     this.hideConfirmation()
+    this.hideCombineConfirmation()
     this.hideDeleteConfirmation()
   }
 

--- a/app/javascript/controllers/transactions/selection_controller.js
+++ b/app/javascript/controllers/transactions/selection_controller.js
@@ -127,6 +127,10 @@ export default class extends Controller {
     if (new Set(rows.map(r => r.amountMinor)).size !== 1) return false
     if (new Set(rows.map(r => r.currencyCode)).size !== 1) return false
 
+    // FX and split rows are rejected by Transaction::Deduplicate, so don't offer
+    // the action for them — mirror those server guards here.
+    if (rows.some(r => r.hasFx || r.isSplit)) return false
+
     // Each must be a non-transfer: exactly one balance-sheet side.
     if (!rows.every(r => isBs(r.srcKind) !== isBs(r.destKind))) return false
 
@@ -165,6 +169,8 @@ export default class extends Controller {
       destAccountName: row.dataset.mergeDestAccountName,
       description: row.dataset.mergeDescription,
       category: row.dataset.mergeCategory,
+      hasFx: row.dataset.mergeHasFx === "true",
+      isSplit: row.dataset.mergeSplit === "true",
       transactedAt: row.dataset.mergeTransactedAt,
       currencyCode: row.dataset.mergeCurrencyCode,
       currencyDecimalPlaces: parseInt(row.dataset.mergeCurrencyDecimalPlaces, 10) || 2
@@ -345,11 +351,17 @@ export default class extends Controller {
   }
 
   // Heuristic default (mirrors Transaction::Deduplicate): a categorized row,
-  // else the oldest by transacted_at.
+  // else the oldest by transacted_at. When transacted_at ties — common for
+  // duplicates — break by smallest id (the older record) so the default is
+  // stable rather than dependent on selection order.
   defaultSurvivorId(rows) {
     const categorized = rows.filter(row => row.category && row.category.length > 0)
     const pool = categorized.length > 0 ? categorized : rows
-    return pool.reduce((best, row) => (row.transactedAt < best.transactedAt ? row : best)).id
+    return pool.reduce((best, row) => {
+      if (row.transactedAt < best.transactedAt) return row
+      if (row.transactedAt === best.transactedAt && Number(row.id) < Number(best.id)) return row
+      return best
+    }).id
   }
 
   submitCombine() {

--- a/app/services/transaction/deduplicate.rb
+++ b/app/services/transaction/deduplicate.rb
@@ -1,0 +1,133 @@
+# Collapses two or more ledger transactions that record the *same* real-world
+# event (same bank account, same side, equal amount) into a single surviving
+# row. Each loser's transaction_sources are moved onto the survivor and the
+# loser is destroyed — producing the exact one-row-owns-all-sources shape that
+# Transaction::Reconcile produces automatically at import time.
+#
+# This is the manual counterpart to import-time reconciliation, and is the
+# opposite shape from Transaction::Merge (which combines a withdrawal + deposit
+# on two different accounts into one transfer). It is intentionally irreversible
+# — like Reconcile — so the controller gates it behind a confirmation panel.
+class Transaction::Deduplicate
+  attr_reader :survivor, :errors
+
+  def initialize(*transactions, user:, survivor: nil)
+    @transactions = transactions.flatten
+    @user = user
+    @survivor = survivor
+    @errors = []
+  end
+
+  def call
+    validate!
+    return false if @errors.any?
+
+    @survivor ||= heuristic_survivor
+    losers = @transactions - [ @survivor ]
+
+    ActiveRecord::Base.transaction do
+      losers.each do |loser|
+        # Move each source onto the survivor by reassigning the join row. We
+        # can't use TransactionSource::Attach here — it refuses to move a row
+        # that already points at another transaction. The unique index on
+        # (sourceable_type, sourceable_id) guarantees the survivor can't already
+        # own the same sourceable, so the reassignment never collides.
+        loser.transaction_sources.to_a.each do |source|
+          source.update!(ledger_transaction: @survivor)
+        end
+
+        # Reload so the now-stale cached transaction_sources association doesn't
+        # cascade-destroy the rows we just moved. Destroying the loser reverses
+        # its posting (after_destroy), removing the double-count.
+        loser.reload
+        loser.destroy!
+      end
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.message
+    false
+  end
+
+  private
+
+    def validate!
+      if @transactions.size < 2
+        @errors << "Select at least two transactions to combine"
+        return
+      end
+
+      unless @transactions.all? { |t| t.user_id == @user.id }
+        @errors << "All transactions must belong to you"
+      end
+
+      unless @transactions.map(&:amount_minor).uniq.size == 1
+        @errors << "Amounts must match"
+      end
+
+      unless @transactions.map(&:currency_id).uniq.size == 1
+        @errors << "Currencies must match"
+      end
+
+      if @transactions.any? { |t| t.has_fx? }
+        @errors << "Foreign exchange transactions cannot be combined"
+      end
+
+      if @transactions.any?(&:opening_balance?)
+        @errors << "Opening balance transactions cannot be combined"
+      end
+
+      if @transactions.any? { |t| t.split? || t.parent_transaction_id? }
+        @errors << "Split transactions cannot be combined"
+      end
+
+      if @transactions.any?(&:excluded?)
+        @errors << "Excluded transactions cannot be combined"
+      end
+
+      if @transactions.any? { |t| t.merged_into_id? || t.merged_sources.any? }
+        @errors << "Merged transactions cannot be combined"
+      end
+
+      if @transactions.any? { |t| transfer?(t) }
+        @errors << "Transfers cannot be combined as duplicates"
+      end
+
+      unless same_bank_side?
+        @errors << "All transactions must use the same bank account on the same side"
+      end
+
+      if @survivor && @transactions.exclude?(@survivor)
+        @errors << "The transaction to keep must be one of the selected transactions"
+      end
+    end
+
+    # A non-transfer has exactly one balance-sheet side.
+    def transfer?(transaction)
+      transaction.src_account.balance_sheet? && transaction.dest_account.balance_sheet?
+    end
+
+    # True when every transaction is a non-transfer sharing the same
+    # balance-sheet account on the same side (all src == BankX, or all dest ==
+    # BankX) — the shape of duplicate recordings of one event.
+    def same_bank_side?
+      return false if @transactions.any? { |t| transfer?(t) }
+
+      all_src = @transactions.all? { |t| t.src_account.balance_sheet? }
+      all_dest = @transactions.all? { |t| t.dest_account.balance_sheet? }
+
+      if all_src
+        @transactions.map(&:src_account_id).uniq.size == 1
+      elsif all_dest
+        @transactions.map(&:dest_account_id).uniq.size == 1
+      else
+        false
+      end
+    end
+
+    # Prefer a user-curated (categorized) row; tie-break by oldest.
+    def heuristic_survivor
+      @transactions.min_by { |t| [ t.category_id ? 0 : 1, t.transacted_at, t.created_at, t.id ] }
+    end
+end

--- a/app/views/transactions/_selection_bar.html.erb
+++ b/app/views/transactions/_selection_bar.html.erb
@@ -1,6 +1,8 @@
 <%# Selection action bar shown when one or more transactions are selected.
     Delete works on any selection; Exclude and Restore enable only when every
-    selected row is eligible; Merge enables only for a valid two-row pair. %>
+    selected row is eligible; Merge enables only for a valid two-row transfer
+    pair; Combine Duplicates enables only for two or more same-account, same-side
+    duplicates (mutually exclusive with Merge). %>
 <div class="selection-bar" data-transactions--selection-target="bar" hidden>
   <span class="selection-bar__count" data-transactions--selection-target="count"></span>
   <span class="selection-bar__message" data-transactions--selection-target="mergeMessage"></span>
@@ -10,6 +12,13 @@
           data-action="transactions--selection#showConfirmation"
           disabled>
     Merge into Transfer
+  </button>
+
+  <button type="button" class="selection-bar__btn selection-bar__btn--primary"
+          data-transactions--selection-target="combineButton"
+          data-action="transactions--selection#showCombineConfirmation"
+          disabled>
+    Combine Duplicates
   </button>
 
   <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
@@ -90,6 +99,34 @@
 
       <div class="selection-confirmation__actions">
         <button type="submit" class="selection-bar__btn selection-bar__btn--primary">Confirm Merge</button>
+        <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
+                data-action="transactions--selection#cancel">Cancel</button>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%# Combine duplicates confirmation panel. The radio options are injected by the
+    controller from the current selection; the chosen id is written into the
+    hidden survivor_id field before submit. %>
+<div class="selection-confirmation" data-transactions--selection-target="combineConfirmation" hidden>
+  <div class="selection-confirmation__content">
+    <h3>Combine duplicate transactions</h3>
+    <p class="selection-confirmation__note">
+      Choose the transaction to keep. The others are removed and their sources are
+      kept on the one you keep. This cannot be undone.
+    </p>
+
+    <div class="selection-confirmation__options" data-transactions--selection-target="combineOptions"></div>
+
+    <%= form_with url: deduplicate_transactions_path, method: :post,
+          data: { transactions__selection_target: "combineForm",
+                  action: "turbo:submit-end->transactions--selection#cancel" } do %>
+      <input type="hidden" name="survivor_id" value="" data-transactions--selection-target="combineSurvivorId">
+
+      <div class="selection-confirmation__actions">
+        <button type="button" class="selection-bar__btn selection-bar__btn--primary"
+                data-action="transactions--selection#submitCombine">Combine</button>
         <button type="button" class="selection-bar__btn selection-bar__btn--secondary"
                 data-action="transactions--selection#cancel">Cancel</button>
       </div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -16,6 +16,8 @@
        data-merge-dest-account-name="<%= transaction.dest_account&.name %>"
        data-merge-description="<%= transaction.description %>"
        data-merge-category="<%= transaction.category&.name %>"
+       data-merge-has-fx="<%= transaction.has_fx? %>"
+       data-merge-split="<%= transaction.split? || transaction.parent_transaction_id? %>"
        data-merge-transacted-at="<%= transaction.transacted_at&.strftime("%Y-%m-%dT%H:%M") %>"
        data-merge-currency-code="<%= transaction.currency.code %>"
        data-merge-currency-decimal-places="<%= transaction.currency.decimal_places %>">

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -15,6 +15,7 @@
        data-merge-src-account-name="<%= transaction.src_account&.name %>"
        data-merge-dest-account-name="<%= transaction.dest_account&.name %>"
        data-merge-description="<%= transaction.description %>"
+       data-merge-category="<%= transaction.category&.name %>"
        data-merge-transacted-at="<%= transaction.transacted_at&.strftime("%Y-%m-%dT%H:%M") %>"
        data-merge-currency-code="<%= transaction.currency.code %>"
        data-merge-currency-decimal-places="<%= transaction.currency.decimal_places %>">

--- a/app/views/transactions/dedupe_error.turbo_stream.erb
+++ b/app/views/transactions/dedupe_error.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.prepend :transactions do %>
+  <div class="selection-error" id="dedupe_error" data-controller="error">
+    <strong>Could not combine transactions:</strong>
+    <ul>
+      <% @dedupe_errors.each do |error| %>
+        <li><%= error %></li>
+      <% end %>
+    </ul>
+    <button type="button" data-action="error#close">Dismiss</button>
+  </div>
+<% end %>

--- a/app/views/transactions/deduplicate.turbo_stream.erb
+++ b/app/views/transactions/deduplicate.turbo_stream.erb
@@ -1,0 +1,5 @@
+<% @removed_ids.each do |id| %>
+  <%= turbo_stream.remove "transaction_#{id}" %>
+<% end %>
+
+<%= turbo_stream.replace @survivor %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     end
     collection do
       post :merge
+      post :deduplicate
       delete :bulk_destroy
       post :bulk_exclude
       post :bulk_unexclude

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -520,6 +520,104 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "deduplicate keeps the chosen survivor and removes the duplicate" do
+    currency = currencies(:usd)
+    bank = Account.create!(user: @user, name: "Dedupe Ctrl Bank", kind: :asset, currency: currency)
+    expense_a = Account.create!(user: @user, name: "Dedupe Ctrl Expense A", kind: :expense, currency: currency)
+    expense_b = Account.create!(user: @user, name: "Dedupe Ctrl Expense B", kind: :expense, currency: currency)
+
+    keep = Transaction.create!(user: @user, src_account: bank, dest_account: expense_a,
+                               amount_minor: 500, currency: currency, description: "Keep me",
+                               transacted_at: Time.current)
+    dup = Transaction.create!(user: @user, src_account: bank, dest_account: expense_b,
+                              amount_minor: 500, currency: currency, description: "Duplicate",
+                              transacted_at: Time.current)
+
+    assert_difference("Transaction.count", -1) do
+      post deduplicate_transactions_url, params: {
+        transaction_ids: [ keep.id, dup.id ], survivor_id: keep.id
+      }, as: :turbo_stream
+    end
+
+    assert_response :success
+    assert Transaction.exists?(keep.id)
+    assert_not Transaction.exists?(dup.id)
+  end
+
+  test "deduplicate with a survivor_id outside the selection returns error" do
+    currency = currencies(:usd)
+    bank = Account.create!(user: @user, name: "Dedupe Bad Survivor Bank", kind: :asset, currency: currency)
+    expense = Account.create!(user: @user, name: "Dedupe Bad Survivor Expense", kind: :expense, currency: currency)
+
+    a = Transaction.create!(user: @user, src_account: bank, dest_account: expense,
+                            amount_minor: 500, currency: currency, description: "A", transacted_at: Time.current)
+    b = Transaction.create!(user: @user, src_account: bank, dest_account: expense,
+                            amount_minor: 500, currency: currency, description: "B", transacted_at: Time.current)
+
+    post deduplicate_transactions_url, params: {
+      transaction_ids: [ a.id, b.id ], survivor_id: @transaction.id
+    }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+  end
+
+  test "deduplicate with fewer than two transaction IDs returns error" do
+    post deduplicate_transactions_url, params: {
+      transaction_ids: [ @transaction.id ]
+    }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+  end
+
+  test "deduplicate with an invalid selection returns error" do
+    currency = currencies(:usd)
+    a = Transaction.create!(user: @user, src_account: accounts(:asset_account),
+                            dest_account: accounts(:expense_account), amount_minor: 100,
+                            currency: currency, transacted_at: Time.current, description: "A")
+    b = Transaction.create!(user: @user, src_account: accounts(:asset_account),
+                            dest_account: accounts(:expense_account), amount_minor: 200,
+                            currency: currency, transacted_at: Time.current, description: "B")
+
+    post deduplicate_transactions_url, params: {
+      transaction_ids: [ a.id, b.id ]
+    }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+  end
+
+  test "deduplicate rejects another user's transactions" do
+    other_user_tx = transactions(:opening_balance_revenue)
+    post deduplicate_transactions_url, params: {
+      transaction_ids: [ other_user_tx.id, @transaction.id ]
+    }, as: :turbo_stream
+
+    assert_response :not_found
+  end
+
+  test "deduplicate broadcasts sidebar replaces for the affected accounts" do
+    currency = currencies(:usd)
+    bank = Account.create!(user: @user, name: "Dedupe Broadcast Bank", kind: :asset, currency: currency)
+    expense_a = Account.create!(user: @user, name: "Dedupe Broadcast Expense A", kind: :expense, currency: currency)
+    expense_b = Account.create!(user: @user, name: "Dedupe Broadcast Expense B", kind: :expense, currency: currency)
+
+    keep = Transaction.create!(user: @user, src_account: bank, dest_account: expense_a,
+                               amount_minor: 500, currency: currency, description: "Keep", transacted_at: Time.current)
+    dup = Transaction.create!(user: @user, src_account: bank, dest_account: expense_b,
+                              amount_minor: 500, currency: currency, description: "Dup", transacted_at: Time.current)
+
+    streams = capture_turbo_stream_broadcasts([ @user, :sidebar ]) do
+      post deduplicate_transactions_url, params: {
+        transaction_ids: [ keep.id, dup.id ], survivor_id: keep.id
+      }, as: :turbo_stream
+    end
+
+    targets = streams.map { |s| s["target"] }
+    # Destroying the duplicate reverses its posting, touching the bank and the
+    # duplicate's expense account. Assert the set, not a fixed count.
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(bank, :sidebar_link)
+    assert_includes targets, ActionView::RecordIdentifier.dom_id(expense_b, :sidebar_link)
+  end
+
   test "create broadcasts sidebar replaces for affected accounts" do
     assert_turbo_stream_broadcasts([ @user, :sidebar ], count: 2) do
       post transactions_url, params: { transaction: {

--- a/test/services/transaction/deduplicate_test.rb
+++ b/test/services/transaction/deduplicate_test.rb
@@ -1,0 +1,261 @@
+require "test_helper"
+
+class Transaction::DeduplicateTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @category = categories(:one)
+
+    # A fresh bank account so balance assertions are isolated from fixtures.
+    @bank = Account.create!(user: @user, name: "Dedupe Bank", kind: :asset, currency: @currency)
+    @expense_a = Account.create!(user: @user, name: "Coffee Shop", kind: :expense, currency: @currency)
+    @expense_b = Account.create!(user: @user, name: "Coffee Shop (alt)", kind: :expense, currency: @currency)
+
+    @charge_a = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "Coffee Shop",
+      transacted_at: 2.days.ago
+    )
+    @charge_b = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_b,
+      amount_minor: 500, currency: @currency, description: "COFFEE SHOP LLC",
+      transacted_at: 1.day.ago
+    )
+  end
+
+  test "combines two duplicate charges into one surviving row" do
+    assert_difference "Transaction.count", -1 do
+      service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+      assert service.call, service.errors.inspect
+    end
+
+    assert Transaction.exists?(@charge_a.id)
+    assert_not Transaction.exists?(@charge_b.id)
+  end
+
+  test "counts the event once on the bank account" do
+    # Two charges of 500 double-count the bank to -1000.
+    assert_equal(-1000, @bank.reload.balance_minor)
+
+    Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user).call
+
+    assert_equal(-500, @bank.reload.balance_minor)
+  end
+
+  test "moves the loser's sources onto the survivor" do
+    sourced = create_sourced_transaction(
+      user: @user, src_account: @bank, dest_account: @expense_b,
+      amount_minor: 500, currency: @currency, description: "Imported coffee",
+      transacted_at: 1.day.ago, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    # Keep @charge_a; the imported row's source should move onto it.
+    service = Transaction::Deduplicate.new(@charge_a, sourced, user: @user, survivor: @charge_a)
+    assert service.call, service.errors.inspect
+
+    @charge_a.reload
+    assert_equal [ simplefin_transactions(:transaction_one) ], @charge_a.transaction_sources.map(&:sourceable)
+    assert_not Transaction.exists?(sourced.id)
+  end
+
+  test "collapses three duplicates" do
+    charge_c = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "Coffee again",
+      transacted_at: 3.days.ago
+    )
+
+    assert_difference "Transaction.count", -2 do
+      service = Transaction::Deduplicate.new(@charge_a, @charge_b, charge_c, user: @user)
+      assert service.call, service.errors.inspect
+    end
+  end
+
+  test "honors an explicit survivor even when it is not the heuristic default" do
+    # @charge_b is newer, so the heuristic would prefer @charge_a; override it.
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user, survivor: @charge_b)
+    assert service.call
+
+    assert_equal @charge_b.id, service.survivor.id
+    assert Transaction.exists?(@charge_b.id)
+    assert_not Transaction.exists?(@charge_a.id)
+  end
+
+  test "heuristic prefers a categorized row when no survivor is given" do
+    @charge_b.update!(category: @category)
+
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+    assert service.call
+
+    assert_equal @charge_b.id, service.survivor.id
+  end
+
+  test "heuristic tie-breaks on the oldest row" do
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+    assert service.call
+
+    # @charge_a is older (2 days vs 1 day ago) and neither is categorized.
+    assert_equal @charge_a.id, service.survivor.id
+  end
+
+  test "rejects a survivor that is not among the selected transactions" do
+    other = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "Other",
+      transacted_at: 1.day.ago
+    )
+
+    assert_no_difference "Transaction.count" do
+      service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user, survivor: other)
+      assert_not service.call
+      assert_includes service.errors.join, "keep"
+    end
+  end
+
+  test "keeps a manual categorized row and preserves the imported source" do
+    manual = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "Manual coffee",
+      transacted_at: 1.day.ago, category: @category
+    )
+    imported = create_sourced_transaction(
+      user: @user, src_account: @bank, dest_account: @expense_b,
+      amount_minor: 500, currency: @currency, description: "SQ *COFFEE",
+      transacted_at: 1.day.ago, sourceable: simplefin_transactions(:transaction_one)
+    )
+
+    service = Transaction::Deduplicate.new(manual, imported, user: @user)
+    assert service.call
+
+    assert_equal manual.id, service.survivor.id
+    assert_equal [ simplefin_transactions(:transaction_one) ], manual.reload.transaction_sources.map(&:sourceable)
+  end
+
+  test "rejects fewer than two transactions" do
+    service = Transaction::Deduplicate.new(@charge_a, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "at least two"
+  end
+
+  test "rejects mismatched amounts" do
+    @charge_b.update!(amount_minor: 600)
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "Amounts"
+  end
+
+  test "combines two refunds posted to the bank" do
+    revenue = Account.create!(user: @user, name: "Refund Source", kind: :revenue, currency: @currency)
+    refund_a = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: @bank,
+      amount_minor: 500, currency: @currency, description: "Refund", transacted_at: 2.days.ago
+    )
+    refund_b = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: @bank,
+      amount_minor: 500, currency: @currency, description: "REFUND", transacted_at: 1.day.ago
+    )
+
+    assert_difference "Transaction.count", -1 do
+      service = Transaction::Deduplicate.new(refund_a, refund_b, user: @user)
+      assert service.call, service.errors.inspect
+    end
+  end
+
+  test "rejects mismatched currencies" do
+    # Currency is derived from the dest account, so an EUR expense account on the
+    # same bank yields a differing currency without changing the bank/side.
+    eur_expense = Account.create!(user: @user, name: "EUR Expense", kind: :expense, currency: currencies(:eur))
+    eur_charge = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: eur_expense,
+      amount_minor: 500, description: "EUR charge", transacted_at: 1.day.ago
+    )
+    assert_equal currencies(:eur), eur_charge.currency
+
+    service = Transaction::Deduplicate.new(@charge_a, eur_charge, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "Currencies"
+  end
+
+  test "rejects foreign exchange transactions" do
+    fx_charge = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "FX charge",
+      transacted_at: 1.day.ago, fx_amount_minor: 400, fx_currency: currencies(:eur)
+    )
+    service = Transaction::Deduplicate.new(@charge_a, fx_charge, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "Foreign exchange"
+  end
+
+  test "rejects split transactions" do
+    @charge_b.update_columns(split: true)
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "Split"
+  end
+
+  test "rescues a RecordInvalid raised while applying the change" do
+    @charge_b.stub(:destroy!, ->(*) { raise ActiveRecord::RecordInvalid.new(@charge_b) }) do
+      service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user, survivor: @charge_a)
+      assert_not service.call
+      assert service.errors.any?
+    end
+  end
+
+  test "rejects different bank accounts" do
+    other_bank = Account.create!(user: @user, name: "Other Bank", kind: :asset, currency: @currency)
+    other = Transaction.create!(
+      user: @user, src_account: other_bank, dest_account: @expense_a,
+      amount_minor: 500, currency: @currency, description: "Other bank charge",
+      transacted_at: 1.day.ago
+    )
+    service = Transaction::Deduplicate.new(@charge_a, other, user: @user)
+    assert_not service.call
+    assert_includes service.errors.join, "same bank account"
+  end
+
+  test "rejects opposite sides on the same account" do
+    refund = Transaction.create!(
+      user: @user, src_account: @expense_a, dest_account: @bank,
+      amount_minor: 500, currency: @currency, description: "Refund",
+      transacted_at: 1.day.ago
+    )
+    service = Transaction::Deduplicate.new(@charge_a, refund, user: @user)
+    assert_not service.call
+  end
+
+  test "rejects transfers" do
+    other_bank = Account.create!(user: @user, name: "Transfer Bank", kind: :asset, currency: @currency)
+    transfer = Transaction.create!(
+      user: @user, src_account: @bank, dest_account: other_bank,
+      amount_minor: 500, currency: @currency, description: "Transfer",
+      transacted_at: 1.day.ago
+    )
+    service = Transaction::Deduplicate.new(@charge_a, transfer, user: @user)
+    assert_not service.call
+  end
+
+  test "rejects excluded transactions" do
+    sourced = create_sourced_transaction(
+      user: @user, src_account: @bank, dest_account: @expense_b,
+      amount_minor: 500, currency: @currency, description: "Imported",
+      transacted_at: 1.day.ago, sourceable: simplefin_transactions(:transaction_one)
+    )
+    Transaction::Exclude.new(sourced, user: @user).call
+
+    service = Transaction::Deduplicate.new(@charge_a, sourced, user: @user)
+    assert_not service.call
+  end
+
+  test "rejects merged transactions" do
+    @charge_b.update_columns(merged_into_id: @charge_a.id)
+    service = Transaction::Deduplicate.new(@charge_a, @charge_b, user: @user)
+    assert_not service.call
+  end
+
+  test "rejects transactions belonging to another user" do
+    others = transactions(:opening_balance_revenue)
+    service = Transaction::Deduplicate.new(@charge_a, others, user: @user)
+    assert_not service.call
+  end
+end

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -317,6 +317,21 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "combine stays disabled when a selected row is a foreign-exchange transaction" do
+    normal = manual_transaction("FX gate normal", 500)
+    fx = Transaction.create!(
+      user: @user, src_account: accounts(:asset_account), dest_account: accounts(:expense_account),
+      amount_minor: 500, currency: currencies(:usd), description: "FX gate fx",
+      transacted_at: 1.day.ago, fx_amount_minor: 400, fx_currency: currencies(:eur)
+    )
+
+    visit transactions_path
+    toggle_select(normal)
+    toggle_select(fx)
+
+    assert_button "Combine Duplicates", disabled: true
+  end
+
   test "a cross-account transfer pair still merges into a transfer" do
     bank_b = accounts(:linked_asset)
     revenue = accounts(:revenue_account)

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -293,6 +293,56 @@ class TransactionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "combining duplicates keeps the chosen row and moves its sources onto it" do
+    sourced = sourced_transaction("Dup sourced", 500, :transaction_one)
+    manual = manual_transaction("Dup manual", 500)
+
+    visit transactions_path
+    toggle_select(sourced)
+    toggle_select(manual)
+
+    assert_button "Combine Duplicates", disabled: false
+    assert_button "Merge into Transfer", disabled: true
+
+    click_button "Combine Duplicates"
+
+    within ".selection-confirmation:not([hidden])" do
+      find("input[name='combine_survivor'][value='#{manual.id}']").click
+      click_button "Combine"
+    end
+
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(sourced)}"
+    within "##{ActionView::RecordIdentifier.dom_id(manual)}" do
+      assert_selector ".source-badge", text: "SimpleFIN"
+    end
+  end
+
+  test "a cross-account transfer pair still merges into a transfer" do
+    bank_b = accounts(:linked_asset)
+    revenue = accounts(:revenue_account)
+    withdrawal = manual_transaction("Transfer out", 700)
+    deposit = Transaction.create!(
+      user: @user, src_account: revenue, dest_account: bank_b,
+      amount_minor: 700, currency: currencies(:usd), description: "Transfer in",
+      transacted_at: 1.day.ago
+    )
+
+    visit transactions_path
+    toggle_select(withdrawal)
+    toggle_select(deposit)
+
+    assert_button "Merge into Transfer", disabled: false
+    assert_button "Combine Duplicates", disabled: true
+
+    click_button "Merge into Transfer"
+    within ".selection-confirmation:not([hidden])" do
+      click_button "Confirm Merge"
+    end
+
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(withdrawal)}"
+    assert_no_selector "##{ActionView::RecordIdentifier.dom_id(deposit)}"
+  end
+
   private
 
   def manual_transaction(description, amount_minor)


### PR DESCRIPTION
## Summary

Adds a **Combine Duplicates** action that collapses two or more ledger transactions recording the *same* real-world event — same bank account on the same side, equal amount and currency — into a single surviving row.

This is the manual counterpart to import-time reconciliation (`Transaction::Reconcile`). Reconcile only catches duplicates at import, before a second ledger row exists, by attaching the incoming source to the existing row. Anything it misses (dates a few days apart, rewritten descriptions, a hand-entry duplicating an import) leaves two full ledger rows that double-count the balance with no way to fix it.

### Approach

The feature produces the **same end-state Reconcile produces** — one live row owning all sources, no hidden rows. `Transaction::Deduplicate` moves each loser's `transaction_sources` onto a user-chosen survivor and **deletes the losers**. Because the survivor stays a normal reconcile candidate, re-imports remain safe and there's **no schema change, no badge change, and no import-job change**.

It is deliberately **separate from transfer `Transaction::Merge`** (which synthesises a new transfer from a withdrawal + deposit on two different accounts and is reversible via `Unmerge`). The two are mutually exclusive for any selection.

Combining is **irreversible** — consistent with reconcile — so it is gated behind a confirmation panel where the user **picks which row to keep** (defaulting to a categorised row, else the oldest). The survivor's source badges aggregate the moved sources automatically.

## Changes

- `Transaction::Deduplicate` service — validates the duplicate shape, selects/validates the survivor, moves sources, destroys losers in one transaction.
- `deduplicate` controller action + route, with `deduplicate`/`dedupe_error` turbo streams. Existing `merge`/`unmerge` untouched.
- Selection bar: a **Combine Duplicates** button + a confirmation panel listing each row with a "keep this one" radio (date-led subtext). One new `data-merge-category` row attribute.
- Stimulus: enable logic, the radio-building confirmation, and submit wiring.

## Test plan

- `Transaction::Deduplicate` unit tests: 2-way/3-way collapse, source-move, explicit-survivor honouring, heuristic fallback, membership guard, balance correctness, refund (dest-side) path, and every rejection path (amount/currency/account/side/transfer/fx/opening/split/excluded/merged/foreign-user), plus the `RecordInvalid` rescue.
- Controller tests: happy path with `survivor_id`, out-of-selection survivor → 422, `< 2` ids → 422, invalid selection → 422, foreign id → 404, sidebar broadcast target set.
- System tests: combine flow (Combine enables while Merge stays disabled → pick survivor → one row remains with both source badges) and a transfer-merge regression.
- `bin/rails test` (100% line coverage), `bin/rails test:system`, `bin/rubocop`, `bin/brakeman` — all green.

Closes #181