### PR TITLE
Redesign Import Rules as an interactive workbench

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -41,6 +41,13 @@
   --bg-error:           light-dark(#fff5f5, rgba(153, 27, 27, 0.2));
   --text-error:         light-dark(#7f1d1d, #fca5a5);
   --border-error:       light-dark(#fca5a5, rgba(220, 38, 38, 0.5));
+
+  /* Surfaces, card shadow, and mono stack (used by the Import Rules workbench) */
+  --surface-sheet:      light-dark(#FFFFFF, #1B1308);
+  --surface-sunken:     var(--honey-pale);
+  --shadow-card:        0 1px 2px rgba(146, 64, 14, 0.06),
+                        0 4px 12px rgba(146, 64, 14, 0.08);
+  --font-mono:          ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
 }
 
 /* User toggle — override color-scheme to force a theme */

--- a/app/assets/stylesheets/import_rules.css
+++ b/app/assets/stylesheets/import_rules.css
@@ -1,0 +1,238 @@
+/* ============================================================
+   Import Rules — workbench styles.
+   Namespaced under .ir-* because stylesheet_link_tag :app loads
+   every app stylesheet on every page. Builds on the design tokens
+   in application.css.
+   ============================================================ */
+
+.ir-wrap { max-width: 1180px; }
+
+/* ---------- Buttons (scoped so they win over `main a`) ---------- */
+.ir-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 7px 14px; background: var(--honey-dark); color: #fff;
+  border: 1px solid transparent; border-radius: 7px;
+  font-size: 0.85rem; font-weight: 600; font-family: inherit; line-height: 1.2;
+  cursor: pointer; white-space: nowrap; text-decoration: none;
+}
+.ir-btn:hover { background: var(--honey); color: #fff; }
+.ir-btn--secondary { background: var(--surface-sheet); color: var(--bark-medium); border-color: var(--divider); }
+.ir-btn--secondary:hover { background: var(--honey-light); color: var(--accent-text); }
+.ir-btn--danger { color: var(--color-negative); }
+.ir-btn--secondary.ir-btn--danger:hover { background: var(--bg-error); color: var(--text-error); border-color: var(--border-error); }
+.ir-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+.ir-btn-icon svg { width: 14px; height: 14px; }
+
+/* ---------- Page header ---------- */
+.ir-page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 6px; }
+.ir-page-head__titles h1 { margin: 0; font-size: 1.5rem; font-weight: 700; letter-spacing: -0.01em; color: var(--bark); }
+.ir-page-head__sub { margin: 4px 0 0; color: var(--bark-light); font-size: 0.875rem; max-width: 56ch; }
+.ir-page-head__actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+
+/* ---------- Summary strip ---------- */
+.ir-summary { display: flex; gap: 0; margin: 16px 0 18px; border: 1px solid var(--divider); border-radius: 10px; background: var(--surface-sheet); overflow: hidden; box-shadow: var(--shadow-card); }
+.ir-summary__cell { flex: 1; padding: 12px 16px; border-right: 1px solid var(--divider); min-width: 0; }
+.ir-summary__cell:last-child { border-right: none; }
+.ir-summary__label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--bark-light); }
+.ir-summary__value { margin-top: 4px; font-size: 1.45rem; font-weight: 600; font-variant-numeric: tabular-nums; color: var(--bark); line-height: 1.1; }
+
+/* ---------- Split workbench layout ---------- */
+.ir-layout { display: grid; grid-template-columns: minmax(340px, 1fr) minmax(380px, 0.92fr); gap: 16px; align-items: start; }
+.ir-list-col { min-width: 0; }
+
+/* ---------- List toolbar ---------- */
+.ir-list-toolbar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.ir-search { position: relative; flex: 1; min-width: 0; }
+.ir-search svg { position: absolute; left: 9px; top: 50%; transform: translateY(-50%); width: 14px; height: 14px; color: var(--bark-light); pointer-events: none; }
+.ir-search input { width: 100%; padding: 7px 9px 7px 28px; background: var(--surface-sheet); color: var(--bark); border: 1px solid var(--divider); border-radius: 7px; font-size: 0.85rem; font-family: inherit; }
+.ir-search input:focus { outline: none; border-color: var(--honey); box-shadow: 0 0 0 3px var(--honey-light); }
+.ir-seg { display: inline-flex; background: var(--surface-sunken); border: 1px solid var(--divider); border-radius: 7px; padding: 2px; gap: 2px; }
+.ir-seg button { border: none; background: none; padding: 5px 9px; font-size: 0.78rem; font-weight: 600; color: var(--bark-light); border-radius: 5px; cursor: pointer; font-family: inherit; white-space: nowrap; }
+.ir-seg button.active { background: var(--surface-sheet); color: var(--accent-text); box-shadow: 0 1px 2px rgba(146, 64, 14, 0.12); }
+.ir-seg button:hover:not(.active) { color: var(--bark-medium); }
+
+.ir-list-meta { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; padding: 0 2px; }
+.ir-list-meta__count { font-size: 0.75rem; color: var(--bark-light); font-weight: 600; }
+.ir-list-meta__sort { font-size: 0.75rem; color: var(--bark-light); }
+
+/* ---------- Rule rows ---------- */
+.ir-list { display: flex; flex-direction: column; gap: 7px; }
+.ir-rule { display: grid; grid-template-columns: 18px 1fr; align-items: center; gap: 10px; padding: 10px 12px 10px 6px; background: var(--surface-sheet); border: 1px solid var(--divider); border-radius: 9px; transition: border-color 0.12s, box-shadow 0.12s, background 0.12s; position: relative; }
+/* The display:grid above would otherwise defeat the [hidden] attribute the list filter sets. */
+.ir-rule[hidden] { display: none; }
+.ir-rule:hover { border-color: var(--honey); box-shadow: var(--shadow-card); }
+.ir-rule--selected { border-color: var(--honey-dark); box-shadow: 0 0 0 1px var(--honey-dark), var(--shadow-card); background: var(--honey-pale); }
+.ir-rule--dragging { opacity: 0.4; }
+.ir-rule--dragover { border-color: var(--honey-dark); box-shadow: 0 -2px 0 var(--honey-dark); }
+
+.ir-grip { display: flex; align-items: center; justify-content: center; color: var(--bark-light); cursor: grab; height: 100%; opacity: 0.45; transition: opacity 0.1s; }
+.ir-rule:hover .ir-grip { opacity: 0.9; }
+.ir-grip:active { cursor: grabbing; }
+.ir-grip svg { width: 12px; height: 18px; }
+
+.ir-rule__main { min-width: 0; cursor: pointer; text-decoration: none; color: inherit; display: block; }
+.ir-rule__line1 { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; }
+.ir-rule__pattern { font-family: var(--font-mono); font-size: 0.86rem; font-weight: 500; color: var(--bark); background: var(--surface-sunken); border: 1px solid var(--divider); padding: 1px 7px; border-radius: 5px; max-width: 230px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ir-rule__line2 { display: flex; align-items: center; gap: 10px; margin-top: 7px; flex-wrap: wrap; }
+.ir-rule__arrow { color: var(--bark-light); font-size: 0.8rem; }
+
+.ir-list-empty { background: var(--surface-sunken); border: 1px solid var(--divider); border-radius: 9px; padding: 28px 20px; text-align: center; color: var(--bark-medium); }
+.ir-list-empty p { margin: 0; }
+.ir-list-empty__sub { margin-top: 4px !important; font-size: 0.82rem; color: var(--bark-light); }
+
+/* ---------- Match-type & account chips ---------- */
+.ir-mt-chip { font-size: 0.68rem; font-weight: 600; color: var(--accent-text); background: var(--honey-pale); border: 1px solid var(--divider); border-radius: 4px; padding: 1px 6px; white-space: nowrap; }
+.ir-action-chip { display: inline-flex; align-items: center; gap: 6px; font-size: 0.8rem; color: var(--bark-medium); white-space: nowrap; }
+.ir-action-chip__name { font-weight: 600; color: var(--bark); }
+.ir-action-chip__kind { font-size: 0.72rem; font-weight: 400; color: var(--bark-light); }
+.ir-action-chip__kind::before { content: '· '; }
+.ir-action-chip--exclude { color: var(--bark-light); font-weight: 600; }
+.ir-action-chip--none { color: var(--color-negative); font-style: italic; }
+
+/* ---------- Detail / editor ---------- */
+/* The column stretches to the (potentially long) list's height and the editor frame fills it,
+   so .ir-detail can stick within that tall box as you scroll a long rule list. */
+.ir-detail-col { align-self: stretch; min-width: 0; }
+.ir-detail-col > turbo-frame { display: block; height: 100%; }
+.ir-detail { position: sticky; top: 76px; max-height: calc(100vh - 92px); overflow-y: auto; background: var(--surface-sheet); border: 1px solid var(--divider); border-radius: 12px; box-shadow: var(--shadow-card); }
+.ir-detail__head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 13px 16px; border-bottom: 1px solid var(--divider); background: var(--honey-pale); }
+.ir-detail__title { font-size: 0.95rem; font-weight: 700; color: var(--bark); }
+.ir-detail__close { background: none; border: none; color: var(--bark-light); cursor: pointer; font-size: 1rem; line-height: 1; padding: 4px; border-radius: 5px; text-decoration: none; }
+.ir-detail__close:hover { background: rgba(0, 0, 0, 0.06); color: var(--bark); }
+.ir-detail__body { padding: 16px; }
+
+.ir-empty-detail { padding: 48px 24px; text-align: center; color: var(--bark-light); }
+.ir-empty-detail__icon { width: 40px; height: 40px; margin: 0 auto 12px; color: var(--honey); opacity: 0.6; }
+.ir-empty-detail h3 { margin: 0 0 6px; font-size: 1rem; color: var(--bark-medium); }
+.ir-empty-detail p { margin: 0 0 16px; font-size: 0.84rem; }
+
+.ir-form-errors { background: var(--bg-error); border: 1px solid var(--border-error); color: var(--text-error); border-radius: 8px; padding: 10px 12px; margin-bottom: 14px; font-size: 0.82rem; }
+.ir-form-errors ul { margin: 6px 0 0; padding-left: 18px; }
+
+/* ---------- Editor fields ---------- */
+.ir-field { margin-bottom: 14px; }
+.ir-field__label { display: flex; align-items: center; gap: 8px; font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--accent-text); margin-bottom: 6px; }
+.ir-field__hint { font-weight: 500; text-transform: none; letter-spacing: 0; color: var(--bark-light); font-size: 0.72rem; }
+.ir-pattern-input { width: 100%; padding: 9px 11px; background: var(--cream); color: var(--bark); border: 1px solid var(--divider); border-radius: 7px; font-size: 0.95rem; font-family: var(--font-mono); font-weight: 500; }
+.ir-pattern-input:focus { outline: none; border-color: var(--honey); box-shadow: 0 0 0 3px var(--honey-light); }
+
+/* Segmented match-type control (radios visually hidden, labels are the buttons) */
+.ir-mtseg { display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px; }
+.ir-mtseg__input { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.ir-mtseg__label { display: block; text-align: center; border: 1px solid var(--divider); background: var(--cream); padding: 7px 4px; border-radius: 6px; cursor: pointer; font-size: 0.74rem; font-weight: 600; color: var(--bark-medium); transition: all 0.1s; }
+.ir-mtseg__label:hover { border-color: var(--honey); }
+.ir-mtseg__input:checked + .ir-mtseg__label { border-color: var(--honey-dark); background: var(--honey-pale); color: var(--accent-text); }
+.ir-mtseg__input:focus-visible + .ir-mtseg__label { box-shadow: 0 0 0 3px var(--honey-light); }
+
+/* Assign / Exclude two-button toggle (radios visually hidden, labels are the buttons) */
+.ir-action-toggle { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; margin-bottom: 10px; }
+.ir-action-toggle__input { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.ir-action-toggle__btn { display: flex; align-items: center; justify-content: center; gap: 6px; border: 1px solid var(--divider); background: var(--cream); padding: 8px; border-radius: 6px; cursor: pointer; font-size: 0.8rem; font-weight: 600; color: var(--bark-medium); transition: all 0.1s; }
+.ir-action-toggle__btn:hover { border-color: var(--honey); }
+.ir-action-toggle__input:checked + .ir-action-toggle__btn { border-color: var(--honey-dark); background: var(--honey-pale); color: var(--accent-text); }
+.ir-action-toggle__input:focus-visible + .ir-action-toggle__btn { box-shadow: 0 0 0 3px var(--honey-light); }
+
+.ir-account-field .ir-field__label { margin-top: 2px; }
+.ir-select { width: 100%; padding: 9px 11px; background: var(--cream); color: var(--bark); border: 1px solid var(--divider); border-radius: 7px; font-size: 0.875rem; font-family: inherit; }
+.ir-select:focus { outline: none; border-color: var(--honey); box-shadow: 0 0 0 3px var(--honey-light); }
+.ir-exclude-note { background: var(--surface-sunken); border: 1px solid var(--divider); border-radius: 7px; padding: 10px 12px; font-size: 0.8rem; color: var(--bark-medium); line-height: 1.45; }
+
+.ir-section-label { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--bark-light); margin: 18px 0 8px; }
+
+.ir-editor-foot { display: flex; align-items: center; gap: 8px; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--divider); }
+.ir-spacer { flex: 1; }
+.ir-editor-foot form { margin: 0; }
+
+/* ---------- Live test panel ---------- */
+.ir-test-frame { display: block; position: relative; }
+/* Loading state (added by JS only when a fetch is slow): keep the old results in place but
+   dim them and spin, so quick queries don't flicker and nothing jumps. */
+.ir-test-frame--loading .ir-test { opacity: 0.55; }
+.ir-test-frame--loading::after {
+  content: '';
+  position: absolute; top: 10px; right: 12px;
+  width: 13px; height: 13px;
+  border: 2px solid var(--divider);
+  border-top-color: var(--honey-dark);
+  border-radius: 50%;
+  animation: ir-spin 0.6s linear infinite;
+}
+@keyframes ir-spin { to { transform: rotate(360deg); } }
+.ir-test { border: 1px solid var(--divider); border-radius: 9px; overflow: hidden; background: var(--cream); transition: opacity 0.15s ease; }
+.ir-test__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 9px 12px; background: var(--surface-sunken); border-bottom: 1px solid var(--divider); }
+.ir-test__title { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--bark-light); display: flex; align-items: center; gap: 7px; }
+.ir-test__count { font-size: 0.78rem; font-weight: 700; color: var(--accent-text); background: var(--honey-pale); border: 1px solid var(--divider); border-radius: 999px; padding: 1px 9px; font-variant-numeric: tabular-nums; }
+.ir-test__count--zero { color: var(--bark-light); background: var(--surface-sheet); }
+.ir-test__list { max-height: 240px; overflow-y: auto; }
+.ir-test__row { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; padding: 8px 12px; border-bottom: 1px solid var(--divider); }
+.ir-test__row:last-child { border-bottom: none; }
+/* Already-excluded matches: a clear badge + lightly muted text (so it reads as "excluded",
+   not just generically faded — which is ambiguous when every match is excluded). */
+.ir-test__row--excluded .ir-test__desc { color: var(--bark-light); }
+.ir-test__excluded { display: inline-flex; align-items: center; gap: 3px; font-size: 0.66rem; font-weight: 600; color: var(--bark-light); background: var(--surface-sunken); border: 1px solid var(--divider); border-radius: 4px; padding: 1px 6px; white-space: nowrap; }
+.ir-test__excluded .ir-x { font-size: 0.9em; }
+.ir-test__desc { font-family: var(--font-mono); font-size: 0.78rem; color: var(--bark-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ir-test__steal { font-size: 0.7rem; color: var(--honey-dark); margin-left: 6px; font-family: var(--font-sans, sans-serif); }
+.ir-test__meta { display: flex; align-items: center; gap: 10px; white-space: nowrap; }
+.ir-test__date { font-size: 0.72rem; color: var(--bark-light); }
+.ir-test__amt { font-size: 0.78rem; font-variant-numeric: tabular-nums; font-family: var(--font-mono); color: var(--bark-medium); }
+.ir-test__amt--neg { color: var(--color-negative); }
+.ir-test__amt--pos { color: var(--color-positive); }
+.ir-test__empty { padding: 22px 14px; text-align: center; color: var(--bark-light); font-size: 0.82rem; }
+.ir-test__foot { padding: 9px 12px; border-top: 1px solid var(--divider); background: var(--surface-sheet); font-size: 0.74rem; font-weight: 600; color: var(--honey-dark); }
+.ir-mark { background: var(--honey-light); color: var(--accent-text); border-radius: 2px; padding: 0 1px; font-weight: 700; }
+
+/* ---------- Modal (preview / preview & apply) ---------- */
+@keyframes ir-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes ir-rise { from { transform: translateY(12px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+/* Top-aligned 40px from the top (matches the prototype's flex-start backdrop), not centered. */
+/* overflow: visible overrides the dialog UA's overflow:auto, so the rise animation's
+   transient 12px translate doesn't flash a scrollbar (the modal body scrolls tall content). */
+.ir-modal-dialog { padding: 0; border: none; background: transparent; overflow: visible; max-width: 880px; width: calc(100% - 40px); margin: 40px auto auto; }
+.ir-modal-dialog::backdrop { background: rgba(28, 25, 23, 0.45); animation: ir-fade 0.15s ease; }
+.ir-modal-dialog turbo-frame { display: block; }
+.ir-modal { background: var(--surface-sheet); border: 1px solid var(--divider); border-radius: 14px; box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3); overflow: hidden; animation: ir-rise 0.18s ease; }
+.ir-modal__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 18px 22px; border-bottom: 1px solid var(--divider); }
+.ir-modal__head h2 { margin: 0; font-size: 1.2rem; font-weight: 700; color: var(--bark); }
+.ir-modal__head p { margin: 5px 0 0; font-size: 0.85rem; color: var(--bark-light); }
+.ir-modal__body { padding: 0; max-height: 56vh; overflow-y: auto; }
+.ir-modal__foot { display: flex; align-items: center; gap: 10px; padding: 16px 22px; border-top: 1px solid var(--divider); background: var(--honey-pale); }
+.ir-modal__empty { padding: 48px 24px; text-align: center; color: var(--bark-light); }
+.ir-modal__empty-mark { font-size: 1.6rem; margin-bottom: 8px; color: var(--color-positive); }
+
+.ir-change-group__head { display: flex; align-items: center; gap: 8px; padding: 11px 22px; background: var(--surface-sunken); border-bottom: 1px solid var(--divider); position: sticky; top: 0; z-index: 1; }
+.ir-change-group__title { font-size: 0.78rem; font-weight: 700; color: var(--bark); }
+.ir-change-group__count { font-size: 0.72rem; color: var(--bark-light); }
+.ir-change { display: grid; grid-template-columns: 1fr auto; gap: 14px; align-items: center; padding: 11px 22px; border-bottom: 1px solid var(--divider); }
+.ir-change:last-child { border-bottom: none; }
+.ir-change__main { min-width: 0; }
+.ir-change__desc { font-family: var(--font-mono); font-size: 0.8rem; color: var(--bark-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ir-change__sub { font-size: 0.72rem; color: var(--bark-light); margin-top: 3px; display: flex; align-items: center; gap: 8px; }
+.ir-change__amt { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }
+.ir-change__move { display: flex; align-items: center; gap: 9px; white-space: nowrap; }
+.ir-change__arrow { color: var(--honey-dark); }
+.ir-change__from { color: var(--bark-light); font-size: 0.78rem; text-decoration: line-through; text-decoration-color: var(--bark-light); }
+.ir-merge-flag { font-size: 0.68rem; font-weight: 600; color: var(--honey-deeper); background: var(--honey-pale); border: 1px solid var(--honey-dark); border-radius: 3px; padding: 0 5px; cursor: help; }
+
+/* scrollbar polish (matches the prototype) */
+.ir-test__list::-webkit-scrollbar, .ir-modal__body::-webkit-scrollbar { width: 9px; }
+.ir-test__list::-webkit-scrollbar-thumb, .ir-modal__body::-webkit-scrollbar-thumb { background: var(--divider); border-radius: 999px; border: 2px solid var(--surface-sheet); }
+
+@media (prefers-reduced-motion: reduce) {
+  .ir-modal-dialog::backdrop, .ir-modal, .ir-test-frame--loading::after { animation: none; }
+}
+
+/* ---------- Responsive: collapse the split pane ---------- */
+@media (max-width: 1000px) {
+  .ir-layout { grid-template-columns: 1fr; }
+  .ir-detail-col { align-self: start; }
+  .ir-detail { position: relative; top: 0; max-height: none; overflow: visible; }
+}
+
+@media (max-width: 560px) {
+  .ir-summary { flex-wrap: wrap; }
+  .ir-summary__cell { flex-basis: 50%; }
+  .ir-list-toolbar { flex-wrap: wrap; }
+  .ir-change { grid-template-columns: 1fr; }
+  .ir-change__move { justify-content: flex-start; }
+}

--- a/app/controllers/import_rules_controller.rb
+++ b/app/controllers/import_rules_controller.rb
@@ -1,9 +1,9 @@
 class ImportRulesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_import_rule, only: %i[ edit update destroy preview ]
+  before_action :set_import_rule, only: %i[ edit update destroy ]
 
   def index
-    @import_rules = current_user.import_rules.includes(:account).order(priority: :desc, match_pattern: :asc)
+    assign_rules
   end
 
   def new
@@ -11,14 +11,21 @@ class ImportRulesController < ApplicationController
   end
 
   def create
-    @import_rule = current_user.import_rules.build(import_rule_params)
+    attrs = import_rule_params
+    @import_rule = current_user.import_rules.build(attrs)
+    @import_rule.priority = next_priority if attrs[:priority].blank?
 
     respond_to do |format|
       if @import_rule.save
-        format.html { redirect_to import_rules_path, notice: "Rule was successfully created." }
+        notice = saved_notice("created", maybe_apply_retroactively)
+        @selected_id = @import_rule.id
+        assign_rules
+        format.html { redirect_to import_rules_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice; render :saved }
         format.json { render json: @import_rule, status: :created }
       else
         format.html { render :new, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: editor_stream(@import_rule), status: :unprocessable_entity }
         format.json { render json: @import_rule.errors, status: :unprocessable_entity }
       end
     end
@@ -30,10 +37,15 @@ class ImportRulesController < ApplicationController
   def update
     respond_to do |format|
       if @import_rule.update(import_rule_params)
-        format.html { redirect_to import_rules_path, notice: "Rule was successfully updated.", status: :see_other }
+        notice = saved_notice("updated", maybe_apply_retroactively)
+        @selected_id = @import_rule.id
+        assign_rules
+        format.html { redirect_to import_rules_path, notice: notice, status: :see_other }
+        format.turbo_stream { flash.now[:notice] = notice; render :saved }
         format.json { render json: @import_rule, status: :ok }
       else
         format.html { render :edit, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: editor_stream(@import_rule), status: :unprocessable_entity }
         format.json { render json: @import_rule.errors, status: :unprocessable_entity }
       end
     end
@@ -41,11 +53,40 @@ class ImportRulesController < ApplicationController
 
   def destroy
     @import_rule.destroy!
+    assign_rules
 
     respond_to do |format|
       format.html { redirect_to import_rules_path, notice: "Rule was successfully destroyed.", status: :see_other }
+      format.turbo_stream { flash.now[:notice] = "Rule was successfully destroyed."; render :workbench_update }
       format.json { head :no_content }
     end
+  end
+
+  # Reassign priority from a dragged ordering (first id = highest priority).
+  def reorder
+    ids = Array(params[:ids]).map(&:to_i)
+    rules = current_user.import_rules.where(id: ids).index_by(&:id)
+
+    ImportRule.transaction do
+      ids.each_with_index do |id, index|
+        rule = rules[id]
+        rule&.update_column(:priority, ids.size - index)
+      end
+    end
+
+    head :no_content
+  end
+
+  # Live "matches in your ledger" panel for the editor (driven by the draft form values).
+  def match_preview
+    @preview = ImportRule::MatchPreview.new(
+      user: current_user,
+      pattern: params[:pattern],
+      match_type: params[:match_type],
+      account_id: params[:account_id],
+      exclude: params[:exclude]
+    )
+    render partial: "match_preview", locals: { preview: @preview }
   end
 
   def preview_apply
@@ -58,18 +99,84 @@ class ImportRulesController < ApplicationController
     count = service.apply
 
     if service.errors.any?
-      redirect_to preview_apply_import_rules_path, alert: service.errors.first
+      @apply_error = service.errors.first
+      respond_to do |format|
+        format.html { redirect_to preview_apply_import_rules_path, alert: @apply_error }
+        format.turbo_stream { flash.now[:alert] = @apply_error; render :apply }
+      end
     else
-      redirect_to import_rules_path, notice: "#{count} #{"transaction".pluralize(count)} reassigned."
+      assign_rules
+      respond_to do |format|
+        format.html { redirect_to import_rules_path, notice: "#{count} #{"transaction".pluralize(count)} reassigned." }
+        format.turbo_stream { flash.now[:notice] = "#{count} #{"transaction".pluralize(count)} reassigned."; render :apply }
+      end
     end
   end
 
+  # Preview the impact of the draft rule in the editor (current form values), so Preview
+  # works for a brand-new rule and reflects unsaved edits — not just the saved rule.
   def preview
-    service = ImportRule::RetroactiveApply.new(user: current_user, rule: @import_rule)
-    @changes = service.preview
+    @import_rule = build_draft_rule
+    @dirty = draft_dirty?
+    @changes = ImportRule::RetroactiveApply.new(user: current_user, rule: @import_rule).preview
   end
 
   private
+
+    # When the per-rule Preview's "Apply" submitted the editor form, also re-run the saved
+    # rule over existing transactions. Returns the count reassigned, or nil if not applying.
+    def maybe_apply_retroactively
+      return nil if params[:apply_after_save].blank?
+
+      ImportRule::RetroactiveApply.new(user: current_user, rule: @import_rule).apply
+    end
+
+    def saved_notice(verb, applied)
+      return "Rule was successfully #{verb}." if applied.nil?
+      return "Rule saved." if applied.zero?
+
+      "Rule saved · #{applied} #{"transaction".pluralize(applied)} reassigned."
+    end
+
+    # True when the draft has unsaved edits (or is a brand-new rule) — so the Preview modal
+    # can tell the user that applying will also save the rule.
+    def draft_dirty?
+      saved = params[:id].present? ? current_user.import_rules.find_by(id: params[:id]) : nil
+      return true if saved.nil?
+
+      saved.match_pattern != @import_rule.match_pattern.to_s.strip ||
+        saved.match_type != @import_rule.match_type ||
+        saved.account_id != @import_rule.account_id ||
+        saved.exclude? != @import_rule.exclude?
+    end
+
+    def build_draft_rule
+      exclude = ActiveModel::Type::Boolean.new.cast(params[:exclude]) || false
+      match_type = ImportRule.match_types.key?(params[:match_type].to_s) ? params[:match_type] : "contains"
+      current_user.import_rules.build(
+        match_pattern: params[:pattern],
+        match_type: match_type,
+        account_id: (exclude ? nil : params[:account_id].presence),
+        exclude: exclude
+      )
+    end
+
+    def assign_rules
+      @import_rules = current_user.import_rules.includes(:account).order(priority: :desc, match_pattern: :asc).to_a
+      @total_count = @import_rules.size
+      @exclude_count = @import_rules.count(&:exclude?)
+      @assign_count = @total_count - @exclude_count
+    end
+
+    # Re-render the editor frame with the (invalid) draft so its errors show inline.
+    def editor_stream(rule)
+      turbo_stream.replace("rule_editor", partial: "import_rules/form", locals: { import_rule: rule })
+    end
+
+    # New rules go to the top of the priority order (highest wins) unless a priority is given.
+    def next_priority
+      (current_user.import_rules.maximum(:priority) || -1) + 1
+    end
 
     def set_import_rule
       @import_rule = current_user.import_rules.find(params.expect(:id))

--- a/app/controllers/import_rules_controller.rb
+++ b/app/controllers/import_rules_controller.rb
@@ -107,8 +107,8 @@ class ImportRulesController < ApplicationController
     else
       assign_rules
       respond_to do |format|
-        format.html { redirect_to import_rules_path, notice: "#{count} #{"transaction".pluralize(count)} reassigned." }
-        format.turbo_stream { flash.now[:notice] = "#{count} #{"transaction".pluralize(count)} reassigned."; render :apply }
+        format.html { redirect_to import_rules_path, notice: "#{count} #{"transaction".pluralize(count)} updated." }
+        format.turbo_stream { flash.now[:notice] = "#{count} #{"transaction".pluralize(count)} updated."; render :apply }
       end
     end
   end
@@ -124,18 +124,23 @@ class ImportRulesController < ApplicationController
   private
 
     # When the per-rule Preview's "Apply" submitted the editor form, also re-run the saved
-    # rule over existing transactions. Returns the count reassigned, or nil if not applying.
+    # rule over existing transactions. Returns the count updated, or nil if not applying;
+    # records any apply failure in @apply_error so the notice can surface it.
     def maybe_apply_retroactively
       return nil if params[:apply_after_save].blank?
 
-      ImportRule::RetroactiveApply.new(user: current_user, rule: @import_rule).apply
+      service = ImportRule::RetroactiveApply.new(user: current_user, rule: @import_rule)
+      applied = service.apply
+      @apply_error = service.errors.first
+      applied
     end
 
     def saved_notice(verb, applied)
       return "Rule was successfully #{verb}." if applied.nil?
+      return "Rule saved, but the changes couldn’t be applied: #{@apply_error}" if @apply_error
       return "Rule saved." if applied.zero?
 
-      "Rule saved · #{applied} #{"transaction".pluralize(applied)} reassigned."
+      "Rule saved · #{applied} #{"transaction".pluralize(applied)} updated."
     end
 
     # True when the draft has unsaved edits (or is a brand-new rule) — so the Preview modal
@@ -153,10 +158,13 @@ class ImportRulesController < ApplicationController
     def build_draft_rule
       exclude = ActiveModel::Type::Boolean.new.cast(params[:exclude]) || false
       match_type = ImportRule.match_types.key?(params[:match_type].to_s) ? params[:match_type] : "contains"
+      # Resolve the account through the current user so an enumerated foreign account_id can't
+      # be referenced in the (un-validated) draft preview/apply.
+      account = params[:account_id].present? ? current_user.accounts.find_by(id: params[:account_id]) : nil
       current_user.import_rules.build(
         match_pattern: params[:pattern],
         match_type: match_type,
-        account_id: (exclude ? nil : params[:account_id].presence),
+        account: (exclude ? nil : account),
         exclude: exclude
       )
     end

--- a/app/helpers/import_rules_helper.rb
+++ b/app/helpers/import_rules_helper.rb
@@ -1,0 +1,68 @@
+module ImportRulesHelper
+  MATCH_TYPE_SHORT = {
+    "contains" => "Contains",
+    "exact" => "Exact",
+    "starts_with" => "Starts",
+    "ends_with" => "Ends"
+  }.freeze
+
+  MATCH_TYPE_PHRASE = {
+    "contains" => "contains",
+    "exact" => "is exactly",
+    "starts_with" => "starts with",
+    "ends_with" => "ends with"
+  }.freeze
+
+  # Live preview for a rule's current attributes, so the editor can render its matches
+  # server-side (no "start typing" flash + round-trip when editing an existing rule).
+  def import_rule_live_preview(rule)
+    ImportRule::MatchPreview.new(
+      user: current_user,
+      pattern: rule.match_pattern,
+      match_type: rule.match_type,
+      account_id: rule.account_id,
+      exclude: rule.exclude
+    )
+  end
+
+  # Label for the editor's segmented match-type control.
+  def match_type_short_label(match_type)
+    MATCH_TYPE_SHORT[match_type.to_s] || match_type.to_s.humanize
+  end
+
+  # Phrase shown in the list chip ("contains", "is exactly", …).
+  def match_type_phrase(match_type)
+    MATCH_TYPE_PHRASE[match_type.to_s] || match_type.to_s.humanize
+  end
+
+  # Wrap the portion of a description that a (pattern, match_type) hits in <mark>,
+  # for the live preview. Mirrors ImportRule's case-insensitive matching.
+  def highlight_match(description, pattern, match_type)
+    pattern = pattern.to_s.strip
+    return description if pattern.blank?
+
+    lower = description.downcase
+    needle = pattern.downcase
+
+    start, finish =
+      case match_type.to_s
+      when "exact"
+        lower == needle ? [ 0, description.length ] : [ nil, nil ]
+      when "starts_with"
+        lower.start_with?(needle) ? [ 0, needle.length ] : [ nil, nil ]
+      when "ends_with"
+        lower.end_with?(needle) ? [ description.length - needle.length, description.length ] : [ nil, nil ]
+      else
+        index = lower.index(needle)
+        index ? [ index, index + needle.length ] : [ nil, nil ]
+      end
+
+    return description if start.nil?
+
+    safe_join([
+      description[0...start],
+      tag.mark(description[start...finish], class: "ir-mark"),
+      description[finish..]
+    ])
+  end
+end

--- a/app/javascript/controllers/import_rules/action_controller.js
+++ b/app/javascript/controllers/import_rules/action_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the editor's "Assign to account" / "Exclude" two-button toggle. When excluding,
+// hides the account select and clears its value (so the rule saves with no account);
+// when switching back to assigning, restores the previously chosen account. Backed by the
+// `exclude` radio pair so the choice submits as a real form value.
+export default class extends Controller {
+  static targets = ["radio", "accountField", "account", "note"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    const excluded = this.radioTargets.some(radio => radio.value === "true" && radio.checked)
+
+    if (this.hasAccountFieldTarget) this.accountFieldTarget.hidden = excluded
+    if (this.hasNoteTarget) this.noteTarget.hidden = !excluded
+
+    if (this.hasAccountTarget) {
+      if (excluded) {
+        // Remember the choice so it can be restored, then clear it (the select stays enabled
+        // but hidden, so the empty value submits and the saved rule ends up with no account).
+        if (this.accountTarget.value) this.savedAccount = this.accountTarget.value
+        this.accountTarget.value = ""
+      } else if (this.savedAccount) {
+        this.accountTarget.value = this.savedAccount
+      }
+    }
+  }
+}

--- a/app/javascript/controllers/import_rules/list_filter_controller.js
+++ b/app/javascript/controllers/import_rules/list_filter_controller.js
@@ -19,7 +19,11 @@ export default class extends Controller {
 
   selectSegment(event) {
     this.segment = event.currentTarget.dataset.segment
-    this.segmentTargets.forEach(button => button.classList.toggle("active", button === event.currentTarget))
+    this.segmentTargets.forEach(button => {
+      const selected = button === event.currentTarget
+      button.classList.toggle("active", selected)
+      button.setAttribute("aria-pressed", selected)
+    })
     this.apply()
   }
 

--- a/app/javascript/controllers/import_rules/list_filter_controller.js
+++ b/app/javascript/controllers/import_rules/list_filter_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Client-side search + segment (All / Assign / Exclude) filtering of the rule list.
+// Rule lists are small and fully rendered, so we just show/hide rows.
+export default class extends Controller {
+  static targets = ["search", "segment", "row", "count"]
+
+  initialize() {
+    this.segment = "all"
+  }
+
+  connect() {
+    this.apply()
+  }
+
+  filter() {
+    this.apply()
+  }
+
+  selectSegment(event) {
+    this.segment = event.currentTarget.dataset.segment
+    this.segmentTargets.forEach(button => button.classList.toggle("active", button === event.currentTarget))
+    this.apply()
+  }
+
+  // Highlight the row whose editor is open (the list isn't re-rendered on selection).
+  select(event) {
+    const row = event.currentTarget.closest(".ir-rule")
+    this.rowTargets.forEach(candidate => candidate.classList.toggle("ir-rule--selected", candidate === row))
+  }
+
+  // Re-apply whenever rows are swapped in by a Turbo Stream (create/update/destroy).
+  rowTargetConnected() {
+    this.apply()
+  }
+
+  apply() {
+    const query = (this.hasSearchTarget ? this.searchTarget.value : "").trim().toLowerCase()
+    let visible = 0
+
+    this.rowTargets.forEach(row => {
+      const matchesQuery = !query || (row.dataset.search || "").includes(query)
+      const isExclude = row.dataset.irExclude === "true"
+      const matchesSegment = this.segment === "all" || (this.segment === "exclude") === isExclude
+      const show = matchesQuery && matchesSegment
+
+      row.hidden = !show
+      if (show) visible += 1
+    })
+
+    if (this.hasCountTarget) this.countTarget.textContent = visible
+  }
+}

--- a/app/javascript/controllers/import_rules/live_test_controller.js
+++ b/app/javascript/controllers/import_rules/live_test_controller.js
@@ -1,0 +1,91 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the editor's live "matches in your ledger" panel and keeps the Preview button's
+// modal URL in sync with the draft. Debounces edits to the form, then points the
+// ir_match_preview Turbo Frame (and the Preview modal trigger) at the current pattern /
+// match type / account / exclude. A loading indicator is shown only if a fetch is slow,
+// so fast queries don't flash — the previous results stay put until the new ones arrive.
+export default class extends Controller {
+  static targets = ["frame", "previewButton"]
+  static values = { url: String, previewUrl: String, ruleId: String, delay: { type: Number, default: 250 } }
+
+  connect() {
+    this.stopLoading = this.stopLoading.bind(this)
+    if (this.hasFrameTarget) {
+      this.frameTarget.addEventListener("turbo:frame-load", this.stopLoading)
+      this.frameTarget.addEventListener("turbo:fetch-request-error", this.stopLoading)
+    }
+    this.syncPreviewButton()
+    // The live-match frame is preloaded server-side when the form renders, so don't refetch
+    // on connect — only when the draft actually changes (see update()).
+  }
+
+  disconnect() {
+    if (this.timer) clearTimeout(this.timer)
+    if (this.loadingTimer) clearTimeout(this.loadingTimer)
+    if (this.hasFrameTarget) {
+      this.frameTarget.removeEventListener("turbo:frame-load", this.stopLoading)
+      this.frameTarget.removeEventListener("turbo:fetch-request-error", this.stopLoading)
+    }
+  }
+
+  update() {
+    // The Preview button URL is just a string, so keep it current immediately; only the
+    // live-match Turbo Frame fetch is debounced.
+    this.syncPreviewButton()
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.run(), this.delayValue)
+  }
+
+  run() {
+    if (!this.hasFrameTarget) return
+
+    this.indicateLoadingSoon()
+    this.frameTarget.src = `${this.urlValue}?${this.draftParams().toString()}`
+  }
+
+  // Reveal the spinner/dim only if the fetch is actually slow, so fast loads don't flicker.
+  indicateLoadingSoon() {
+    if (this.loadingTimer) clearTimeout(this.loadingTimer)
+    this.loadingTimer = setTimeout(() => {
+      if (this.hasFrameTarget) this.frameTarget.classList.add("ir-test-frame--loading")
+    }, 150)
+  }
+
+  // Clear the loading indicator when the fetch finishes — whether it loaded or errored.
+  stopLoading() {
+    if (this.loadingTimer) clearTimeout(this.loadingTimer)
+    if (this.hasFrameTarget) this.frameTarget.classList.remove("ir-test-frame--loading")
+  }
+
+  syncPreviewButton() {
+    if (this.hasPreviewButtonTarget && this.hasPreviewUrlValue) {
+      this.previewButtonTarget.setAttribute("data-import-rules--modal-src-param", `${this.previewUrlValue}?${this.draftParams().toString()}`)
+    }
+  }
+
+  draftParams() {
+    const params = new URLSearchParams()
+    params.set("pattern", this.fieldValue("match_pattern"))
+    params.set("match_type", this.checkedValue("match_type") || "contains")
+
+    const account = this.fieldValue("account_id")
+    if (account) params.set("account_id", account)
+
+    params.set("exclude", this.checkedValue("exclude") === "true" ? "true" : "false")
+
+    // The saved rule id lets the preview tell whether the draft has unsaved edits.
+    if (this.hasRuleIdValue && this.ruleIdValue) params.set("id", this.ruleIdValue)
+    return params
+  }
+
+  fieldValue(attribute) {
+    const field = this.element.querySelector(`[name="import_rule[${attribute}]"]`)
+    return field ? field.value : ""
+  }
+
+  checkedValue(attribute) {
+    const field = this.element.querySelector(`[name="import_rule[${attribute}]"]:checked`)
+    return field ? field.value : ""
+  }
+}

--- a/app/javascript/controllers/import_rules/modal_controller.js
+++ b/app/javascript/controllers/import_rules/modal_controller.js
@@ -1,0 +1,65 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Opens a native <dialog> and lazily loads content into its Turbo Frame. Used for the
+// per-rule Preview and the Preview & apply-all modals. Sets the frame src imperatively
+// (don't rely on lazy loading inside a hidden dialog), clears it on close so re-opening
+// re-fetches fresh, and closes on Turbo cache / backdrop click / successful submit.
+export default class extends Controller {
+  static targets = ["dialog", "frame"]
+
+  connect() {
+    this.closeOnCache = this.closeOnCache.bind(this)
+    document.addEventListener("turbo:before-cache", this.closeOnCache)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-cache", this.closeOnCache)
+  }
+
+  open(event) {
+    event.preventDefault()
+    const src = event.params.src
+    if (src) this.frameTarget.src = src
+    if (!this.dialogTarget.open) this.dialogTarget.showModal()
+  }
+
+  close() {
+    if (this.dialogTarget.open) this.dialogTarget.close()
+    this.frameTarget.removeAttribute("src")
+    this.frameTarget.innerHTML = ""
+  }
+
+  // Close when the dialog itself (the backdrop) is clicked, not its content.
+  backdrop(event) {
+    if (event.target === this.dialogTarget) this.close()
+  }
+
+  // Close after the in-modal "Apply" submits successfully.
+  submitEnd(event) {
+    if (event.detail.success) this.close()
+  }
+
+  // "Apply" in the per-rule preview: persist the rule via the editor form (create/update),
+  // flagged to also apply retroactively — so the user's edits are saved, not discarded.
+  applyAndSave(event) {
+    event.preventDefault()
+    const form = document.querySelector("#rule_editor form")
+    if (!form) return
+
+    let flag = form.querySelector("input[name='apply_after_save']")
+    if (!flag) {
+      flag = document.createElement("input")
+      flag.type = "hidden"
+      flag.name = "apply_after_save"
+      form.appendChild(flag)
+    }
+    flag.value = "1"
+
+    this.close()
+    form.requestSubmit()
+  }
+
+  closeOnCache() {
+    if (this.dialogTarget.open) this.close()
+  }
+}

--- a/app/javascript/controllers/import_rules/reorder_controller.js
+++ b/app/javascript/controllers/import_rules/reorder_controller.js
@@ -1,0 +1,69 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Native HTML5 drag-and-drop to reorder rules (position = priority, first row wins).
+// Reorders the DOM optimistically, then POSTs the new id order; the server reassigns
+// priority and returns 204. No drag library needed.
+export default class extends Controller {
+  static targets = ["row"]
+  static values = { url: String }
+
+  dragStart(event) {
+    this.draggedId = event.currentTarget.dataset.ruleId
+    event.currentTarget.classList.add("ir-rule--dragging")
+    event.dataTransfer.effectAllowed = "move"
+    try { event.dataTransfer.setData("text/plain", this.draggedId) } catch (_) { /* some browsers */ }
+  }
+
+  dragOver(event) {
+    event.preventDefault()
+    const over = event.currentTarget
+    if (this.draggedId && over.dataset.ruleId !== this.draggedId) {
+      over.classList.add("ir-rule--dragover")
+    }
+  }
+
+  dragLeave(event) {
+    event.currentTarget.classList.remove("ir-rule--dragover")
+  }
+
+  drop(event) {
+    event.preventDefault()
+    const over = event.currentTarget
+    over.classList.remove("ir-rule--dragover")
+
+    const dragged = this.rowTargets.find(row => row.dataset.ruleId === this.draggedId)
+    if (!dragged || dragged === over) return
+
+    const draggedIndex = this.rowTargets.indexOf(dragged)
+    const overIndex = this.rowTargets.indexOf(over)
+    if (draggedIndex < overIndex) {
+      over.after(dragged)
+    } else {
+      over.before(dragged)
+    }
+
+    this.persist()
+  }
+
+  dragEnd() {
+    this.rowTargets.forEach(row => row.classList.remove("ir-rule--dragging", "ir-rule--dragover"))
+    this.draggedId = null
+  }
+
+  persist() {
+    const ids = this.rowTargets.map(row => row.dataset.ruleId)
+    const token = document.querySelector('meta[name="csrf-token"]')?.content
+
+    fetch(this.urlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "text/vnd.turbo-stream.html",
+        "X-CSRF-Token": token
+      },
+      body: JSON.stringify({ ids })
+    }).then(response => {
+      if (!response.ok) window.location.reload()
+    }).catch(() => window.location.reload())
+  }
+}

--- a/app/models/import_rule.rb
+++ b/app/models/import_rule.rb
@@ -30,6 +30,22 @@ class ImportRule < ApplicationRecord
     joins(:account).where(accounts: { kind: kind })
   }
 
+  # In-memory equivalent of for_description, for testing a single (possibly unsaved) rule
+  # against a description without a query — used to preview a draft rule.
+  def matches?(description)
+    needle = match_pattern.to_s.strip.downcase
+    return false if needle.blank?
+
+    text = description.to_s.strip.downcase
+    case match_type
+    when "contains" then text.include?(needle)
+    when "exact" then text == needle
+    when "starts_with" then text.start_with?(needle)
+    when "ends_with" then text.end_with?(needle)
+    else false
+    end
+  end
+
   private
 
     def account_must_not_be_virtual

--- a/app/services/import_rule/match_preview.rb
+++ b/app/services/import_rule/match_preview.rb
@@ -1,0 +1,140 @@
+# Live "matches in your ledger" preview for the rule editor. Given a draft pattern +
+# match type (and the draft's target account / exclude flag), finds the user's existing
+# transactions whose description matches — using the SAME escaped, case-insensitive LIKE
+# semantics as ImportRule#for_description, but transaction-side (the pattern is the bound
+# literal and `description` is the column). Whether each match "would move" is decided by
+# the SAME change_for logic the retroactive apply uses, so the editor preview and the
+# Preview modal agree. Unlike the apply, the list also includes already-excluded rows so
+# you can see everything the pattern matches.
+class ImportRule::MatchPreview
+  include ImportRule::TransactionScope
+
+  LIMIT = 50
+
+  Match = Struct.new(:transaction, :direction, :current_account, :would_move, :new_account, :excluded, keyword_init: true)
+
+  attr_reader :target_account, :pattern, :match_type
+
+  def initialize(user:, pattern:, match_type: "contains", account_id: nil, exclude: false)
+    @user = user
+    @pattern = pattern.to_s.strip
+    @match_type = ImportRule.match_types.key?(match_type.to_s) ? match_type.to_s : "contains"
+    @exclude = ActiveModel::Type::Boolean.new.cast(exclude) || false
+    @target_account = account_id.present? && !@exclude ? @user.accounts.find_by(id: account_id) : nil
+    @draft = @user.import_rules.build(match_pattern: @pattern, match_type: @match_type, exclude: @exclude, account: @target_account)
+    @matches = nil
+    @has_more = false
+  end
+
+  def matches
+    @matches ||= build_matches
+  end
+
+  def has_more?
+    matches # ensure populated
+    @has_more
+  end
+
+  def move_count
+    matches.count(&:would_move)
+  end
+
+  # "N" or "N+" — the + is only added when the result set is truncated AND the visible window
+  # is entirely movable rows (so there may be more movable rows beyond the cap). Because
+  # movable rows are ordered first, a count below the cap is exact.
+  def move_count_summary
+    return "#{move_count}+" if has_more? && move_count == LIMIT
+
+    move_count.to_s
+  end
+
+  # Header badge, e.g. "2 matches" / "1 match" / "50+ matches".
+  def count_summary
+    return "#{LIMIT}+ matches" if has_more?
+
+    "#{matches.size} #{"match".pluralize(matches.size)}"
+  end
+
+  def exclude? = @exclude
+
+  private
+
+    def build_matches
+      return [] if @pattern.blank?
+
+      rows = matched_transactions.limit(LIMIT + 1).to_a
+      @has_more = rows.size > LIMIT
+
+      rows.first(LIMIT).map { |transaction| build_match(transaction) }
+    end
+
+    def build_match(transaction)
+      # Already-excluded rows still show (so you can see what the pattern catches), but they
+      # wouldn't be touched by an apply.
+      if transaction.excluded_at.present?
+        return Match.new(transaction: transaction, direction: nil, current_account: nil,
+                         would_move: false, new_account: nil, excluded: true)
+      end
+
+      direction, counterpart = identify_counterpart(transaction)
+      change = change_for(transaction, @draft, direction: direction, counterpart: counterpart)
+
+      # With a destination (account or exclude), "would move" is exactly what the apply would
+      # do. Before an account is chosen, fall back to "any match with a known counterpart
+      # could be reassigned once you pick one".
+      would_move = if @exclude || @target_account
+        change.present?
+      else
+        direction.present?
+      end
+
+      Match.new(
+        transaction: transaction,
+        direction: direction,
+        current_account: would_move ? (change&.old_account || counterpart) : nil,
+        would_move: would_move,
+        new_account: change&.new_account,
+        excluded: false
+      )
+    end
+
+    def matched_transactions
+      preview_transactions
+        .where(like_clause, pattern: like_argument)
+        # Non-excluded (actionable) rows first, so already-excluded rows can't push movable
+        # rows out of the LIMIT window and undercount the footer; then most recent first.
+        # (NULLS FIRST keeps it a plain column ref, which SELECT DISTINCT allows in ORDER BY.)
+        .order(Arel.sql("transactions.excluded_at ASC NULLS FIRST"), transacted_at: :desc)
+    end
+
+    # Like candidate_transactions (RetroactiveApply's set) but keeps already-excluded rows,
+    # so the editor preview shows everything the pattern matches — not only what would change.
+    def preview_transactions
+      @user.transactions
+        .joins(:transaction_sources)
+        .where(merged_into_id: nil, split: false, opening_balance: false, parent_transaction_id: nil)
+        .includes(:currency, src_account: :account_sources, dest_account: :account_sources, transaction_sources: :sourceable)
+        .distinct
+    end
+
+    def like_clause
+      case @match_type
+      when "exact" then "LOWER(transactions.description) = :pattern"
+      else "LOWER(transactions.description) LIKE :pattern ESCAPE '\\'"
+      end
+    end
+
+    # The bound literal for the comparison: lowercased, with LIKE metacharacters escaped
+    # (except for the exact match, which is a plain equality).
+    def like_argument
+      lowered = @pattern.downcase
+      return lowered if @match_type == "exact"
+
+      escaped = lowered.gsub(/[\\%_]/) { |char| "\\#{char}" }
+      case @match_type
+      when "starts_with" then "#{escaped}%"
+      when "ends_with" then "%#{escaped}"
+      else "%#{escaped}%" # contains
+      end
+    end
+end

--- a/app/services/import_rule/match_preview.rb
+++ b/app/services/import_rule/match_preview.rb
@@ -39,11 +39,11 @@ class ImportRule::MatchPreview
     matches.count(&:would_move)
   end
 
-  # "N" or "N+" — the + is only added when the result set is truncated AND the visible window
-  # is entirely movable rows (so there may be more movable rows beyond the cap). Because
-  # movable rows are ordered first, a count below the cap is exact.
+  # "N" or "N+" — when the result set is truncated the move count is only a lower bound of the
+  # visible window (more movable rows may exist beyond the cap), so qualify it with "+". The
+  # Preview modal (RetroactiveApply, unbounded) is the authoritative count.
   def move_count_summary
-    return "#{move_count}+" if has_more? && move_count == LIMIT
+    return "#{move_count}+" if has_more?
 
     move_count.to_s
   end
@@ -117,10 +117,12 @@ class ImportRule::MatchPreview
         .distinct
     end
 
+    # TRIM the column so the preview matches ImportRule#for_description / #matches?, which
+    # strip the description before comparing (otherwise " FOO " disagrees on exact/ends_with).
     def like_clause
       case @match_type
-      when "exact" then "LOWER(transactions.description) = :pattern"
-      else "LOWER(transactions.description) LIKE :pattern ESCAPE '\\'"
+      when "exact" then "LOWER(TRIM(transactions.description)) = :pattern"
+      else "LOWER(TRIM(transactions.description)) LIKE :pattern ESCAPE '\\'"
       end
     end
 

--- a/app/services/import_rule/retroactive_apply.rb
+++ b/app/services/import_rule/retroactive_apply.rb
@@ -1,5 +1,5 @@
 class ImportRule::RetroactiveApply
-  Change = Struct.new(:transaction, :old_account, :new_account, :direction, :merge_candidate, :action, keyword_init: true)
+  include ImportRule::TransactionScope
 
   attr_reader :changes, :errors
 
@@ -51,128 +51,25 @@ class ImportRule::RetroactiveApply
         rule = find_matching_rule(transaction.description)
         next unless rule
 
-        if rule.exclude?
-          changes << Change.new(
-            transaction: transaction,
-            old_account: counterpart,
-            new_account: nil,
-            direction: direction,
-            merge_candidate: nil,
-            action: :exclude
-          )
-          next
-        end
-
-        next if rule.account_id == counterpart.id
-
-        merge_candidate = nil
-        if rule.account.balance_sheet?
-          candidates = merge_candidates(transaction, rule.account)
-          # Ambiguous balance-sheet match (2+ mergeable counterparts): Transaction::AutoMerge
-          # leaves it untouched (#182), so don't surface it as a reassignment that never resolves.
-          next if candidates.size > 1
-
-          merge_candidate = candidates.first
-        end
-
-        changes << Change.new(
-          transaction: transaction,
-          old_account: counterpart,
-          new_account: rule.account,
-          direction: direction,
-          merge_candidate: merge_candidate,
-          action: :reassign
-        )
+        change = change_for(transaction, rule, direction: direction, counterpart: counterpart)
+        changes << change if change
       end
 
       changes
     end
 
-    def candidate_transactions
-      @user.transactions
-        .joins(:transaction_sources)
-        .where(merged_into_id: nil, excluded_at: nil, split: false, opening_balance: false, parent_transaction_id: nil)
-        .includes(src_account: :account_sources, dest_account: :account_sources, transaction_sources: :sourceable)
-        .distinct
-    end
-
-    def identify_counterpart(transaction)
-      source_account_ids = import_side_account_ids(transaction)
-      src_linked = source_account_ids.include?(transaction.src_account_id)
-      dest_linked = source_account_ids.include?(transaction.dest_account_id)
-
-      if src_linked && !dest_linked
-        [ :expense, transaction.dest_account ]
-      elsif dest_linked && !src_linked
-        [ :revenue, transaction.src_account ]
-      end
-    end
-
-    # The ledger accounts that sit on the import side of a transaction. Aggregator
-    # accounts (SimpleFIN, Lunch Flow) carry an AccountSource, so the import side is
-    # whichever account is linked. CSV imports never create AccountSource records —
-    # their import side is the Csv::Import's chosen ledger account, reached through
-    # the transaction's Csv::Transaction source. Without this, CSV-sourced
-    # transactions have no recognized counterpart and rules never match them.
-    def import_side_account_ids(transaction)
-      ids = []
-      ids << transaction.src_account_id if transaction.src_account.account_sources.any?
-      ids << transaction.dest_account_id if transaction.dest_account.account_sources.any?
-      transaction.transaction_sources.each do |source|
-        sourceable = source.sourceable
-        # Read import_id off the already-preloaded Csv::Transaction and resolve the
-        # account through a cached map, rather than walking sourceable.account
-        # (import -> account) per row inside find_each.
-        ids << csv_import_account_ids[sourceable.import_id] if sourceable.is_a?(Csv::Transaction)
-      end
-      ids.compact.uniq
-    end
-
-    # import_id => ledger account_id for this user's CSV imports, loaded once.
-    def csv_import_account_ids
-      @csv_import_account_ids ||= Csv::Import.where(user_id: @user.id).pluck(:id, :account_id).to_h
-    end
-
+    # When scoped to a single rule, match it in memory so an unsaved draft rule can be
+    # previewed; otherwise resolve the winning rule across all of the user's rules.
     def find_matching_rule(description)
       @rule_cache ||= {}
       normalized = description.to_s.strip.downcase
       return @rule_cache[normalized] if @rule_cache.key?(normalized)
 
-      @rule_cache[normalized] = rule_scope.for_description(description).first
-    end
-
-    # Non-transfer transactions involving rule_account that this transaction could merge with.
-    # Only opposite-side rows are real counterparts (mirrors Transaction::Merge); same-direction
-    # rows can't form a transfer and so are not ambiguity.
-    def merge_candidates(transaction, rule_account)
-      @user.transactions
-        .unmerged
-        .unexcluded
-        .includes(:src_account, :dest_account)
-        .where.not(id: transaction.id)
-        .where(amount_minor: transaction.amount_minor, currency_id: transaction.currency_id)
-        .where(opening_balance: false, split: false, parent_transaction_id: nil)
-        .where(fx_amount_minor: nil)
-        .where("transactions.src_account_id = :id OR transactions.dest_account_id = :id", id: rule_account.id)
-        .where(transacted_at: (transaction.transacted_at - 7.days)..(transaction.transacted_at + 7.days))
-        .where.missing(:merged_sources)
-        .to_a
-        .select { |t| !t.src_account.balance_sheet? || !t.dest_account.balance_sheet? }
-        .select { |candidate| mergeable?(transaction, candidate) }
-    end
-
-    # Mirrors Transaction::Merge: a candidate can merge into a transfer only when one side has a
-    # balance-sheet account as source and the other as destination.
-    def mergeable?(transaction, candidate)
-      (transaction.src_account.balance_sheet? && candidate.dest_account.balance_sheet?) ||
-        (candidate.src_account.balance_sheet? && transaction.dest_account.balance_sheet?)
-    end
-
-    def rule_scope
-      @rule_scope ||= if @rule
-        @user.import_rules.where(id: @rule.id)
-      else
-        @user.import_rules
-      end
+      @rule_cache[normalized] =
+        if @rule
+          @rule.matches?(description) ? @rule : nil
+        else
+          @user.import_rules.for_description(description).first
+        end
     end
 end

--- a/app/services/import_rule/transaction_scope.rb
+++ b/app/services/import_rule/transaction_scope.rb
@@ -1,0 +1,114 @@
+# Shared transaction scoping, import-side detection, and per-transaction change
+# computation for the import-rule services (ImportRule::RetroactiveApply and
+# ImportRule::MatchPreview), so the live editor preview and the retroactive
+# apply agree on what a rule would actually do. Expects an @user instance
+# variable on the including object.
+module ImportRule::TransactionScope
+  Change = Struct.new(:transaction, :old_account, :new_account, :direction, :merge_candidate, :action, keyword_init: true)
+
+  private
+
+    # Imported, non-merged, non-split, non-excluded transactions that a rule could act on.
+    def candidate_transactions
+      @user.transactions
+        .joins(:transaction_sources)
+        .where(merged_into_id: nil, excluded_at: nil, split: false, opening_balance: false, parent_transaction_id: nil)
+        .includes(:currency, src_account: :account_sources, dest_account: :account_sources, transaction_sources: :sourceable)
+        .distinct
+    end
+
+    # The change a matching rule would make to a transaction, or nil if it would make none
+    # (no identifiable import side, already in the target account, or an ambiguous balance-sheet
+    # merge). `direction`/`counterpart` come from identify_counterpart.
+    def change_for(transaction, rule, direction:, counterpart:)
+      return nil unless direction && rule
+
+      if rule.exclude?
+        return Change.new(transaction: transaction, old_account: counterpart, new_account: nil,
+                          direction: direction, merge_candidate: nil, action: :exclude)
+      end
+
+      return nil if rule.account.nil? # assign rule without a chosen account: no destination yet
+      return nil if rule.account_id == counterpart.id
+
+      merge_candidate = nil
+      if rule.account.balance_sheet?
+        candidates = merge_candidates(transaction, rule.account)
+        # Ambiguous balance-sheet match (2+ mergeable counterparts): Transaction::AutoMerge
+        # leaves it untouched (#182), so don't surface it as a reassignment that never resolves.
+        return nil if candidates.size > 1
+
+        merge_candidate = candidates.first
+      end
+
+      Change.new(transaction: transaction, old_account: counterpart, new_account: rule.account,
+                 direction: direction, merge_candidate: merge_candidate, action: :reassign)
+    end
+
+    # Returns [direction, counterpart_account] where direction is :expense or :revenue and
+    # counterpart is the non-import side (the account a rule would reassign). nil when the
+    # import side can't be identified (e.g. both or neither side is linked).
+    def identify_counterpart(transaction)
+      source_account_ids = import_side_account_ids(transaction)
+      src_linked = source_account_ids.include?(transaction.src_account_id)
+      dest_linked = source_account_ids.include?(transaction.dest_account_id)
+
+      if src_linked && !dest_linked
+        [ :expense, transaction.dest_account ]
+      elsif dest_linked && !src_linked
+        [ :revenue, transaction.src_account ]
+      end
+    end
+
+    # The ledger accounts that sit on the import side of a transaction. Aggregator
+    # accounts (SimpleFIN, Lunch Flow) carry an AccountSource, so the import side is
+    # whichever account is linked. CSV imports never create AccountSource records —
+    # their import side is the Csv::Import's chosen ledger account, reached through
+    # the transaction's Csv::Transaction source. Without this, CSV-sourced
+    # transactions have no recognized counterpart and rules never match them.
+    def import_side_account_ids(transaction)
+      ids = []
+      ids << transaction.src_account_id if transaction.src_account.account_sources.any?
+      ids << transaction.dest_account_id if transaction.dest_account.account_sources.any?
+      transaction.transaction_sources.each do |source|
+        sourceable = source.sourceable
+        # Read import_id off the already-preloaded Csv::Transaction and resolve the
+        # account through a cached map, rather than walking sourceable.account
+        # (import -> account) per row inside find_each.
+        ids << csv_import_account_ids[sourceable.import_id] if sourceable.is_a?(Csv::Transaction)
+      end
+      ids.compact.uniq
+    end
+
+    # import_id => ledger account_id for this user's CSV imports, loaded once.
+    def csv_import_account_ids
+      @csv_import_account_ids ||= Csv::Import.where(user_id: @user.id).pluck(:id, :account_id).to_h
+    end
+
+    # Non-transfer transactions involving rule_account that this transaction could merge with.
+    # Only opposite-side rows are real counterparts (mirrors Transaction::Merge); same-direction
+    # rows can't form a transfer and so are not ambiguity.
+    def merge_candidates(transaction, rule_account)
+      @user.transactions
+        .unmerged
+        .unexcluded
+        .includes(:src_account, :dest_account)
+        .where.not(id: transaction.id)
+        .where(amount_minor: transaction.amount_minor, currency_id: transaction.currency_id)
+        .where(opening_balance: false, split: false, parent_transaction_id: nil)
+        .where(fx_amount_minor: nil)
+        .where("transactions.src_account_id = :id OR transactions.dest_account_id = :id", id: rule_account.id)
+        .where(transacted_at: (transaction.transacted_at - 7.days)..(transaction.transacted_at + 7.days))
+        .where.missing(:merged_sources)
+        .to_a
+        .select { |t| !t.src_account.balance_sheet? || !t.dest_account.balance_sheet? }
+        .select { |candidate| mergeable?(transaction, candidate) }
+    end
+
+    # Mirrors Transaction::Merge: a candidate can merge into a transfer only when one side has a
+    # balance-sheet account as source and the other as destination.
+    def mergeable?(transaction, candidate)
+      (transaction.src_account.balance_sheet? && candidate.dest_account.balance_sheet?) ||
+        (candidate.src_account.balance_sheet? && transaction.dest_account.balance_sheet?)
+    end
+end

--- a/app/views/import_rules/_account_chip.html.erb
+++ b/app/views/import_rules/_account_chip.html.erb
@@ -1,0 +1,11 @@
+<%# locals: account (Account or nil), exclude (boolean) %>
+<% if exclude %>
+  <span class="ir-action-chip ir-action-chip--exclude"><span class="ir-x" aria-hidden="true">⊘</span> Exclude</span>
+<% elsif account %>
+  <span class="ir-action-chip">
+    <span class="ir-action-chip__name"><%= account.name %></span>
+    <span class="ir-action-chip__kind"><%= account.kind.humanize %></span>
+  </span>
+<% else %>
+  <span class="ir-action-chip ir-action-chip--none">No account</span>
+<% end %>

--- a/app/views/import_rules/_change_row.html.erb
+++ b/app/views/import_rules/_change_row.html.erb
@@ -1,0 +1,22 @@
+<%# locals: change (ImportRule::TransactionScope::Change) %>
+<div class="ir-change">
+  <div class="ir-change__main">
+    <div class="ir-change__desc"><%= change.transaction.description %></div>
+    <div class="ir-change__sub">
+      <span><%= change.transaction.transacted_at&.strftime("%b %-d, %Y") %></span>
+      <span class="ir-change__amt"><%= transaction_amount_with_currency(change.transaction) %></span>
+      <% if change.merge_candidate %>
+        <span class="ir-merge-flag" title="Possible duplicate of &quot;<%= change.merge_candidate.description %>&quot; on <%= change.merge_candidate.transacted_at&.strftime("%b %-d, %Y") %>">likely duplicate</span>
+      <% end %>
+    </div>
+  </div>
+  <div class="ir-change__move">
+    <span class="ir-change__from"><%= change.old_account.name %></span>
+    <span class="ir-change__arrow" aria-hidden="true">→</span>
+    <% if change.action == :exclude %>
+      <%= render "account_chip", account: nil, exclude: true %>
+    <% else %>
+      <%= render "account_chip", account: change.new_account, exclude: false %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/import_rules/_editor_empty.html.erb
+++ b/app/views/import_rules/_editor_empty.html.erb
@@ -1,0 +1,10 @@
+<div class="ir-detail ir-detail--empty">
+  <div class="ir-empty-detail">
+    <svg class="ir-empty-detail__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+      <path d="M3 6h18M7 12h10M10 18h4" stroke-linecap="round" />
+    </svg>
+    <h3>Select a rule to edit</h3>
+    <p>Pick a rule from the list to tune its pattern and see live matches — or create a new one.</p>
+    <%= link_to "+ New rule", new_import_rule_path, class: "ir-btn", data: { turbo_frame: "rule_editor" } %>
+  </div>
+</div>

--- a/app/views/import_rules/_flash.html.erb
+++ b/app/views/import_rules/_flash.html.erb
@@ -1,0 +1,5 @@
+<%# locals: kind ("notice"/"alert"), message %>
+<div class="flash flash--<%= kind %>" data-controller="flash">
+  <span><%= message %></span>
+  <button class="flash__close" data-action="click->flash#dismiss" aria-label="Dismiss">✕</button>
+</div>

--- a/app/views/import_rules/_flash_stream.html.erb
+++ b/app/views/import_rules/_flash_stream.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update "ir_flash" do %>
+  <% if flash[:notice].present? %><%= render "flash", kind: "notice", message: flash[:notice] %><% end %>
+  <% if flash[:alert].present? %><%= render "flash", kind: "alert", message: flash[:alert] %><% end %>
+<% end %>

--- a/app/views/import_rules/_form.html.erb
+++ b/app/views/import_rules/_form.html.erb
@@ -1,50 +1,96 @@
-<%= form_with(model: import_rule) do |form| %>
-  <% if import_rule.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(import_rule.errors.count, "error") %> prohibited this rule from being saved:</h2>
-      <ul>
-        <% import_rule.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
+<%= turbo_frame_tag "rule_editor" do %>
+  <div class="ir-detail">
+    <div class="ir-detail__head">
+      <span class="ir-detail__title"><%= import_rule.persisted? ? "Edit rule" : "New rule" %></span>
+      <%= link_to "✕", import_rules_path, class: "ir-detail__close", aria: { label: "Close editor" }, data: { turbo_frame: "rule_editor" } %>
+    </div>
+
+    <div class="ir-detail__body">
+      <%= form_with model: import_rule,
+            data: {
+              controller: "import-rules--action import-rules--live-test",
+              action: "input->import-rules--live-test#update change->import-rules--live-test#update",
+              "import-rules--live-test-url-value": match_preview_import_rules_path,
+              "import-rules--live-test-preview-url-value": preview_import_rules_path,
+              "import-rules--live-test-rule-id-value": import_rule.id
+            } do |form| %>
+
+        <% if import_rule.errors.any? %>
+          <div class="ir-form-errors">
+            <strong><%= pluralize(import_rule.errors.count, "error") %> prohibited this rule from being saved:</strong>
+            <ul>
+              <% import_rule.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
         <% end %>
-      </ul>
+
+        <div class="ir-field">
+          <%= form.label :match_pattern, class: "ir-field__label" do %>
+            Pattern <span class="ir-field__hint">case-insensitive</span>
+          <% end %>
+          <%= form.text_field :match_pattern, required: true, class: "ir-pattern-input", placeholder: "e.g. WHOLEFDS" %>
+        </div>
+
+        <div class="ir-field">
+          <div class="ir-field__label">Match when description…</div>
+          <div class="ir-mtseg">
+            <% ImportRule.match_types.keys.each do |match_type| %>
+              <%= form.radio_button :match_type, match_type, class: "ir-mtseg__input" %>
+              <%= form.label :match_type, match_type_short_label(match_type), value: match_type, class: "ir-mtseg__label" %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="ir-field">
+          <div class="ir-field__label">Then</div>
+          <div class="ir-action-toggle">
+            <%= form.radio_button :exclude, false, class: "ir-action-toggle__input",
+                  data: { "import-rules--action-target": "radio", action: "change->import-rules--action#toggle" } %>
+            <%= form.label :exclude, "Assign to account", value: false, class: "ir-action-toggle__btn" %>
+            <%= form.radio_button :exclude, true, class: "ir-action-toggle__input",
+                  data: { "import-rules--action-target": "radio", action: "change->import-rules--action#toggle" } %>
+            <%= form.label :exclude, "⊘ Exclude", value: true, class: "ir-action-toggle__btn" %>
+          </div>
+
+          <div class="ir-account-field" data-import-rules--action-target="accountField">
+            <%= form.label :account_id, "Account", class: "ir-field__label" %>
+            <%= form.select :account_id,
+                  grouped_account_options_for_select(current_user.accounts.real.order(:kind, :name), Account.kinds.keys, selected_key: import_rule.account_id),
+                  { include_blank: "Select an account…" },
+                  class: "ir-select", data: { "import-rules--action-target": "account" } %>
+          </div>
+
+          <div class="ir-exclude-note" data-import-rules--action-target="note" hidden>
+            Matching transactions are kept out of balances and reports — useful for internal transfers, credit-card payments, and reimbursements.
+          </div>
+        </div>
+
+        <div class="ir-section-label">Live preview</div>
+        <%# Preloaded server-side so editing an existing rule shows its matches immediately. %>
+        <%= turbo_frame_tag "ir_match_preview", class: "ir-test-frame", data: { "import-rules--live-test-target": "frame" } do %>
+          <%= render "test_panel", preview: import_rule_live_preview(import_rule) %>
+        <% end %>
+
+        <div class="ir-editor-foot">
+          <%= form.submit (import_rule.persisted? ? "Save changes" : "Create rule"), class: "ir-btn" %>
+          <%# Previews the current draft (live-test keeps the modal URL in sync with edits). %>
+          <button type="button" class="ir-btn ir-btn--secondary"
+                  data-import-rules--live-test-target="previewButton"
+                  data-action="import-rules--modal#open"
+                  data-import-rules--modal-src-param="<%= preview_import_rules_path(pattern: import_rule.match_pattern, match_type: import_rule.match_type, account_id: import_rule.account_id, exclude: import_rule.exclude, id: import_rule.id) %>">Preview</button>
+          <span class="ir-spacer"></span>
+          <% if import_rule.persisted? %>
+            <%# A link (not button_to) so it stays valid markup inside the editor's own form. %>
+            <%= link_to "Delete", import_rule_path(import_rule),
+                  class: "ir-btn ir-btn--secondary ir-btn--danger",
+                  data: { turbo_method: :delete, turbo_confirm: "Delete this rule?" } %>
+          <% else %>
+            <%= link_to "Cancel", import_rules_path, class: "ir-btn ir-btn--secondary", data: { turbo_frame: "rule_editor" } %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
-
-  <div>
-    <%= form.label :match_pattern, "Pattern", style: "display: block" %>
-    <%= form.text_field :match_pattern, required: true %>
-    <br><small>Matching is case-insensitive.</small>
-  </div>
-
-  <div>
-    <%= form.label :match_type, "Match Type", style: "display: block" %>
-    <%= form.select :match_type, ImportRule.match_types.keys.map { |t| [ t.humanize, t ] } %>
-  </div>
-
-  <div data-controller="toggle-field">
-    <div style="margin-top: 0.5em">
-      <label for="<%= form.field_id(:exclude) %>">
-        <%= form.check_box :exclude, id: form.field_id(:exclude), data: { toggle_field_target: "checkbox", action: "change->toggle-field#toggle" } %>
-        Exclude matching transactions from calculations instead of assigning them to an account.
-      </label>
-    </div>
-
-    <div>
-      <%= form.label :account_id, "Account", style: "display: block" %>
-      <%= form.select :account_id,
-        grouped_account_options_for_select(current_user.accounts.real.order(:kind, :name), Account.kinds.keys, selected_key: import_rule.account_id),
-        { include_blank: "Select an account..." },
-        data: { toggle_field_target: "field" } %>
-    </div>
-  </div>
-
-  <div>
-    <%= form.label :priority, style: "display: block" %>
-    <%= form.number_field :priority, value: import_rule.priority || 0 %>
-    <br><small>Higher priority rules are checked first when multiple rules match.</small>
-  </div>
-
-  <div>
-    <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/import_rules/_list.html.erb
+++ b/app/views/import_rules/_list.html.erb
@@ -1,0 +1,10 @@
+<div id="ir_list" class="ir-list">
+  <% if @import_rules.empty? %>
+    <div class="ir-list-empty">
+      <p>No rules yet.</p>
+      <p class="ir-list-empty__sub">Create your first rule to start auto-sorting imported transactions.</p>
+    </div>
+  <% else %>
+    <%= render partial: "rule_row", collection: @import_rules, as: :rule, locals: { selected_id: @selected_id } %>
+  <% end %>
+</div>

--- a/app/views/import_rules/_match_preview.html.erb
+++ b/app/views/import_rules/_match_preview.html.erb
@@ -1,0 +1,4 @@
+<%# locals: preview (ImportRule::MatchPreview) %>
+<%= turbo_frame_tag "ir_match_preview" do %>
+  <%= render "test_panel", preview: preview %>
+<% end %>

--- a/app/views/import_rules/_preview_table.html.erb
+++ b/app/views/import_rules/_preview_table.html.erb
@@ -1,42 +1,30 @@
-<% has_reassigns = changes.any? { |c| c.action != :exclude } %>
-<table>
-  <thead>
-    <tr>
-      <th>Description</th>
-      <th>Date</th>
-      <th>Amount</th>
-      <% if has_reassigns %>
-        <th>Current Account</th>
-        <th></th>
-        <th>New Account</th>
-      <% else %>
-        <th>Action</th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <% changes.each do |change| %>
-      <tr>
-        <td><%= change.transaction.description %></td>
-        <td><%= change.transaction.transacted_at&.strftime("%Y-%m-%d") %></td>
-        <td class="numeric"><%= transaction_amount_with_currency(change.transaction) %></td>
-        <% if has_reassigns %>
-          <td><%= change.old_account.name %> (<%= change.old_account.kind %>)</td>
-          <td>&rarr;</td>
-          <td>
-            <% if change.action == :exclude %>
-              <em>Exclude</em>
-            <% else %>
-              <%= change.new_account.name %> (<%= change.new_account.kind %>)
-              <% if change.merge_candidate %>
-                <br><small>Will merge with: <%= change.merge_candidate.description %> (<%= change.merge_candidate.transacted_at&.strftime("%Y-%m-%d") %>, <%= transaction_amount_with_currency(change.merge_candidate) %>)</small>
-              <% end %>
-            <% end %>
-          </td>
-        <% else %>
-          <td><em>Exclude</em></td>
-        <% end %>
-      </tr>
+<%# locals: changes (array of ImportRule::TransactionScope::Change) %>
+<% reassigns = changes.reject { |change| change.action == :exclude } %>
+<% excludes = changes.select { |change| change.action == :exclude } %>
+<% duplicate_count = reassigns.count { |change| change.merge_candidate } %>
+
+<% if reassigns.any? %>
+  <div class="ir-change-group">
+    <div class="ir-change-group__head">
+      <span class="ir-change-group__title">Reassign to a different account</span>
+      <span class="ir-change-group__count">
+        <%= pluralize(reassigns.size, "transaction") %><%= " · #{pluralize(duplicate_count, "possible duplicate")}" if duplicate_count.positive? %>
+      </span>
+    </div>
+    <% reassigns.each do |change| %>
+      <%= render "change_row", change: change %>
     <% end %>
-  </tbody>
-</table>
+  </div>
+<% end %>
+
+<% if excludes.any? %>
+  <div class="ir-change-group">
+    <div class="ir-change-group__head">
+      <span class="ir-change-group__title">Exclude from balances</span>
+      <span class="ir-change-group__count"><%= pluralize(excludes.size, "transaction") %></span>
+    </div>
+    <% excludes.each do |change| %>
+      <%= render "change_row", change: change %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/import_rules/_rule_row.html.erb
+++ b/app/views/import_rules/_rule_row.html.erb
@@ -1,0 +1,29 @@
+<div id="<%= dom_id(rule) %>"
+     class="ir-rule<%= " ir-rule--selected" if rule.id == local_assigns[:selected_id] %>"
+     draggable="true"
+     data-rule-id="<%= rule.id %>"
+     data-ir-exclude="<%= rule.exclude? %>"
+     data-search="<%= [ rule.match_pattern, rule.account&.name ].compact.join(" ").downcase %>"
+     data-import-rules--list-filter-target="row"
+     data-import-rules--reorder-target="row"
+     data-action="dragstart->import-rules--reorder#dragStart dragover->import-rules--reorder#dragOver dragleave->import-rules--reorder#dragLeave drop->import-rules--reorder#drop dragend->import-rules--reorder#dragEnd">
+  <div class="ir-grip" title="Drag to reorder priority" aria-hidden="true">
+    <svg viewBox="0 0 12 18" fill="currentColor">
+      <circle cx="3" cy="3" r="1.4" /><circle cx="9" cy="3" r="1.4" />
+      <circle cx="3" cy="9" r="1.4" /><circle cx="9" cy="9" r="1.4" />
+      <circle cx="3" cy="15" r="1.4" /><circle cx="9" cy="15" r="1.4" />
+    </svg>
+  </div>
+
+  <%= link_to edit_import_rule_path(rule), class: "ir-rule__main",
+        data: { turbo_frame: "rule_editor", action: "click->import-rules--list-filter#select" } do %>
+    <div class="ir-rule__line1">
+      <span class="ir-rule__pattern"><%= rule.match_pattern %></span>
+      <span class="ir-mt-chip"><%= match_type_phrase(rule.match_type) %></span>
+    </div>
+    <div class="ir-rule__line2">
+      <span class="ir-rule__arrow" aria-hidden="true">→</span>
+      <%= render "account_chip", account: rule.account, exclude: rule.exclude? %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/import_rules/_test_head.html.erb
+++ b/app/views/import_rules/_test_head.html.erb
@@ -1,0 +1,10 @@
+<%# locals: count (String, e.g. "2 matches" or "—"), zero (Boolean) %>
+<div class="ir-test__head">
+  <span class="ir-test__title">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.5" y2="16.5" />
+    </svg>
+    Live matches in your ledger
+  </span>
+  <span class="ir-test__count<%= " ir-test__count--zero" if zero %>"><%= count %></span>
+</div>

--- a/app/views/import_rules/_test_panel.html.erb
+++ b/app/views/import_rules/_test_panel.html.erb
@@ -1,0 +1,43 @@
+<%# locals: preview (ImportRule::MatchPreview) %>
+<div class="ir-test">
+  <%= render "test_head", count: (preview.pattern.present? ? preview.count_summary : "—"), zero: preview.matches.empty? %>
+
+  <div class="ir-test__list">
+    <% if preview.pattern.blank? %>
+      <div class="ir-test__empty">Start typing a pattern to see what it matches.</div>
+    <% elsif preview.matches.empty? %>
+      <div class="ir-test__empty">No transactions match this pattern yet.<br>New imports matching it will be caught automatically.</div>
+    <% else %>
+      <% preview.matches.each do |match| %>
+        <% transaction = match.transaction %>
+        <div class="ir-test__row<%= " ir-test__row--excluded" if match.excluded %>">
+          <div class="ir-test__desc">
+            <%= highlight_match(transaction.description, preview.pattern, preview.match_type) %>
+            <% if !match.excluded && !preview.exclude? && match.would_move && match.current_account %>
+              <span class="ir-test__steal">· now in <%= match.current_account.name %></span>
+            <% end %>
+          </div>
+          <div class="ir-test__meta">
+            <% if match.excluded %>
+              <span class="ir-test__excluded"><span class="ir-x" aria-hidden="true">⊘</span> Excluded</span>
+            <% end %>
+            <span class="ir-test__date"><%= transaction.transacted_at&.strftime("%b %-d") %></span>
+            <span class="ir-test__amt<%= " ir-test__amt--neg" if match.direction == :expense %><%= " ir-test__amt--pos" if match.direction == :revenue %>">
+              <%= transaction_amount_with_currency(transaction) %>
+            </span>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if preview.pattern.present? && preview.move_count.positive? %>
+    <div class="ir-test__foot">
+      <% if preview.exclude? %>
+        <%= preview.move_count_summary %> would be excluded
+      <% else %>
+        <%= preview.move_count_summary %> would move into <%= preview.target_account&.name || "this account" %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/import_rules/apply.turbo_stream.erb
+++ b/app/views/import_rules/apply.turbo_stream.erb
@@ -1,0 +1,15 @@
+<% if @apply_error %>
+  <%= render "flash_stream" %>
+<% else %>
+  <%= turbo_stream.replace "ir_list" do %>
+    <%= render "list" %>
+  <% end %>
+
+  <%= turbo_stream.replace "rule_editor" do %>
+    <%= turbo_frame_tag "rule_editor" do %>
+      <%= render "editor_empty" %>
+    <% end %>
+  <% end %>
+
+  <%= render "flash_stream" %>
+<% end %>

--- a/app/views/import_rules/edit.html.erb
+++ b/app/views/import_rules/edit.html.erb
@@ -1,7 +1,2 @@
 <% content_for :title, "Edit Import Rule" %>
-
-<h1>Edit Import Rule</h1>
-
 <%= render "form", import_rule: @import_rule %>
-
-<%= link_to "Back to rules", import_rules_path %>

--- a/app/views/import_rules/index.html.erb
+++ b/app/views/import_rules/index.html.erb
@@ -58,7 +58,7 @@
         </div>
         <div class="ir-seg" role="group" aria-label="Filter rules">
           <% [ [ "all", "All" ], [ "assign", "Assign" ], [ "exclude", "Exclude" ] ].each_with_index do |(value, label), index| %>
-            <button type="button" class="<%= "active" if index.zero? %>"
+            <button type="button" class="<%= "active" if index.zero? %>" aria-pressed="<%= index.zero? %>"
                     data-segment="<%= value %>"
                     data-import-rules--list-filter-target="segment"
                     data-action="import-rules--list-filter#selectSegment"><%= label %></button>

--- a/app/views/import_rules/index.html.erb
+++ b/app/views/import_rules/index.html.erb
@@ -1,35 +1,88 @@
 <% content_for :title, "Import Rules" %>
 
-<h1>Import Rules</h1>
+<div class="ir-wrap" data-controller="import-rules--modal">
+  <div id="ir_flash"></div>
 
-<p>Rules control how imported transactions are matched to accounts. Matching is case-insensitive.</p>
+  <div class="ir-page-head">
+    <div class="ir-page-head__titles">
+      <h1>Import Rules</h1>
+      <p class="ir-page-head__sub">Rules sort imported transactions into accounts automatically. When several rules match, the topmost wins; matching is case-insensitive.</p>
+    </div>
+    <div class="ir-page-head__actions">
+      <button type="button" class="ir-btn ir-btn--secondary ir-btn-icon"
+              data-action="import-rules--modal#open"
+              data-import-rules--modal-src-param="<%= preview_apply_import_rules_path %>">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M4 4v6h6M20 20v-6h-6" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M20 10a8 8 0 0 0-14.3-3.7L4 8M4 14a8 8 0 0 0 14.3 3.7L20 16" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        Preview &amp; apply all
+      </button>
+      <%= link_to new_import_rule_path, class: "ir-btn ir-btn-icon", data: { turbo_frame: "rule_editor" } do %>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+          <line x1="12" y1="5" x2="12" y2="19" stroke-linecap="round" />
+          <line x1="5" y1="12" x2="19" y2="12" stroke-linecap="round" />
+        </svg>
+        New rule
+      <% end %>
+    </div>
+  </div>
 
-<table>
-  <thead>
-    <tr>
-      <th>Pattern</th>
-      <th>Match Type</th>
-      <th>Action</th>
-      <th>Priority</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @import_rules.each do |rule| %>
-      <tr>
-        <td><%= rule.match_pattern %></td>
-        <td><%= rule.match_type.humanize %></td>
-        <td><%= rule.exclude? ? "Exclude" : "Assign to #{rule.account.name} (#{rule.account.kind})" %></td>
-        <td><%= rule.priority %></td>
-        <td>
-          <%= link_to "Preview", preview_import_rule_path(rule) %>
-          <%= link_to "Edit", edit_import_rule_path(rule) %>
-          <%= link_to "Delete", import_rule_path(rule), data: { turbo_method: :delete, turbo_confirm: "Delete this rule?" } %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+  <div class="ir-summary">
+    <div class="ir-summary__cell">
+      <div class="ir-summary__label">Rules</div>
+      <div class="ir-summary__value"><%= @total_count %></div>
+    </div>
+    <div class="ir-summary__cell">
+      <div class="ir-summary__label">Assign to account</div>
+      <div class="ir-summary__value"><%= @assign_count %></div>
+    </div>
+    <div class="ir-summary__cell">
+      <div class="ir-summary__label">Exclude</div>
+      <div class="ir-summary__value"><%= @exclude_count %></div>
+    </div>
+  </div>
 
-<%= link_to "New Rule", new_import_rule_path %>
-<%= link_to "Preview & Apply Rules", preview_apply_import_rules_path %>
+  <div class="ir-layout">
+    <div class="ir-list-col"
+         data-controller="import-rules--list-filter import-rules--reorder"
+         data-import-rules--reorder-url-value="<%= reorder_import_rules_path %>">
+      <div class="ir-list-toolbar">
+        <div class="ir-search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.5" y2="16.5" />
+          </svg>
+          <%= search_field_tag :ir_search, nil, placeholder: "Search patterns or accounts…",
+                autocomplete: "off",
+                data: { "import-rules--list-filter-target": "search", action: "input->import-rules--list-filter#filter" } %>
+        </div>
+        <div class="ir-seg" role="group" aria-label="Filter rules">
+          <% [ [ "all", "All" ], [ "assign", "Assign" ], [ "exclude", "Exclude" ] ].each_with_index do |(value, label), index| %>
+            <button type="button" class="<%= "active" if index.zero? %>"
+                    data-segment="<%= value %>"
+                    data-import-rules--list-filter-target="segment"
+                    data-action="import-rules--list-filter#selectSegment"><%= label %></button>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="ir-list-meta">
+        <span class="ir-list-meta__count"><span data-import-rules--list-filter-target="count"><%= @total_count %></span> <%= "rule".pluralize(@total_count) %></span>
+        <span class="ir-list-meta__sort">top rule wins · drag to reorder</span>
+      </div>
+
+      <%= render "list" %>
+    </div>
+
+    <div class="ir-detail-col">
+      <%= turbo_frame_tag "rule_editor" do %>
+        <%= render "editor_empty" %>
+      <% end %>
+    </div>
+  </div>
+
+  <dialog class="ir-modal-dialog" data-import-rules--modal-target="dialog"
+          data-action="click->import-rules--modal#backdrop turbo:submit-end->import-rules--modal#submitEnd">
+    <%= turbo_frame_tag "preview_modal_frame", data: { "import-rules--modal-target": "frame" } %>
+  </dialog>
+</div>

--- a/app/views/import_rules/new.html.erb
+++ b/app/views/import_rules/new.html.erb
@@ -1,7 +1,2 @@
 <% content_for :title, "New Import Rule" %>
-
-<h1>New Import Rule</h1>
-
 <%= render "form", import_rule: @import_rule %>
-
-<%= link_to "Back to rules", import_rules_path %>

--- a/app/views/import_rules/preview.html.erb
+++ b/app/views/import_rules/preview.html.erb
@@ -1,13 +1,58 @@
 <% content_for :title, "Preview Rule: #{@import_rule.match_pattern}" %>
 
-<h1>Preview Rule: <%= @import_rule.match_pattern %></h1>
+<%= turbo_frame_tag "preview_modal_frame" do %>
+  <div class="ir-modal">
+    <div class="ir-modal__head">
+      <div>
+        <h2>Preview rule</h2>
+        <p>
+          <% if @changes.empty? %>
+            Re-running this rule over your history wouldn’t change anything.
+          <% else %>
+            <% exclude_count = @changes.count { |change| change.action == :exclude } %>
+            <% reassign_count = @changes.size - exclude_count %>
+            <% parts = [] %>
+            <% parts << "#{reassign_count} reassigned" if reassign_count.positive? %>
+            <% parts << "#{exclude_count} excluded" if exclude_count.positive? %>
+            Re-running this rule over your history would update <strong><%= @changes.size %></strong>
+            <%= "transaction".pluralize(@changes.size) %> (<%= parts.join(", ") %>).
+          <% end %>
+        </p>
+      </div>
+      <button type="button" class="ir-detail__close" data-action="import-rules--modal#close" aria-label="Close">✕</button>
+    </div>
 
-<% if @changes.any? %>
-  <p><%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be <%= @import_rule.exclude? ? "excluded" : "reassigned" %> by this rule.</p>
+    <div class="ir-modal__body">
+      <% if @changes.empty? %>
+        <div class="ir-modal__empty">
+          <div class="ir-modal__empty-mark">✓</div>
+          <% if @dirty %>
+            No transactions need to move — but your rule edits aren’t saved yet.
+          <% else %>
+            No changes needed.
+          <% end %>
+        </div>
+      <% else %>
+        <%= render "preview_table", changes: @changes %>
+      <% end %>
+    </div>
 
-  <%= render "preview_table", changes: @changes %>
-<% else %>
-  <p>No existing transactions would be changed by this rule.</p>
+    <div class="ir-modal__foot">
+      <span class="ir-change-group__count">
+        <% if @dirty %>
+          Applying also saves your edits to this rule.
+        <% elsif @changes.any? %>
+          Review the changes above before applying.
+        <% end %>
+      </span>
+      <span class="ir-spacer"></span>
+      <button type="button" class="ir-btn ir-btn--secondary" data-action="import-rules--modal#close">Cancel</button>
+      <%# Each "apply" action saves the rule via the editor form (flagged to apply retroactively). %>
+      <% if @changes.empty? && @dirty %>
+        <button type="button" class="ir-btn" data-action="import-rules--modal#applyAndSave">Save rule</button>
+      <% elsif @changes.any? %>
+        <button type="button" class="ir-btn" data-action="import-rules--modal#applyAndSave"><%= @dirty ? "Save & apply" : "Apply" %> <%= pluralize(@changes.size, "change") %></button>
+      <% end %>
+    </div>
+  </div>
 <% end %>
-
-<p><%= link_to "Back to Import Rules", import_rules_path %></p>

--- a/app/views/import_rules/preview_apply.html.erb
+++ b/app/views/import_rules/preview_apply.html.erb
@@ -1,22 +1,49 @@
-<% content_for :title, "Preview Rule Application" %>
+<% content_for :title, "Preview & Apply Rules" %>
 
-<h1>Preview Rule Application</h1>
+<%= turbo_frame_tag "preview_modal_frame" do %>
+  <div class="ir-modal">
+    <div class="ir-modal__head">
+      <div>
+        <h2>Preview &amp; apply all rules</h2>
+        <p>
+          <% if @changes.empty? %>
+            Everything already matches your current rules — nothing to change.
+          <% else %>
+            <% exclude_count = @changes.count { |change| change.action == :exclude } %>
+            <% reassign_count = @changes.size - exclude_count %>
+            <% parts = [] %>
+            <% parts << "#{reassign_count} reassigned" if reassign_count.positive? %>
+            <% parts << "#{exclude_count} excluded" if exclude_count.positive? %>
+            Re-running every rule over your history would update <strong><%= @changes.size %></strong>
+            <%= "transaction".pluralize(@changes.size) %> (<%= parts.join(", ") %>).
+          <% end %>
+        </p>
+      </div>
+      <button type="button" class="ir-detail__close" data-action="import-rules--modal#close" aria-label="Close">✕</button>
+    </div>
 
-<% if @changes.any? %>
-  <% exclude_count = @changes.count { |c| c.action == :exclude } %>
-  <% reassign_count = @changes.size - exclude_count %>
-  <p>
-    <% parts = [] %>
-    <% parts << "#{reassign_count} reassigned" if reassign_count > 0 %>
-    <% parts << "#{exclude_count} excluded" if exclude_count > 0 %>
-    <%= @changes.size %> <%= "transaction".pluralize(@changes.size) %> would be updated (<%= parts.join(", ") %>).
-  </p>
+    <div class="ir-modal__body">
+      <% if @changes.empty? %>
+        <div class="ir-modal__empty">
+          <div class="ir-modal__empty-mark">✓</div>
+          No changes needed.
+        </div>
+      <% else %>
+        <%= render "preview_table", changes: @changes %>
+      <% end %>
+    </div>
 
-  <%= render "preview_table", changes: @changes %>
-
-  <%= button_to "Apply Changes", apply_import_rules_path, data: { turbo_confirm: "Reassign #{@changes.size} #{"transaction".pluralize(@changes.size)}?" } %>
-<% else %>
-  <p>All transactions already match current rules. No changes needed.</p>
+    <div class="ir-modal__foot">
+      <% if @changes.any? %>
+        <span class="ir-change-group__count">Review the changes above before applying.</span>
+      <% end %>
+      <span class="ir-spacer"></span>
+      <button type="button" class="ir-btn ir-btn--secondary" data-action="import-rules--modal#close">Cancel</button>
+      <% if @changes.any? %>
+        <%= button_to "Apply #{pluralize(@changes.size, "change")}", apply_import_rules_path,
+              class: "ir-btn",
+              form: { data: { turbo_confirm: "Reassign #{pluralize(@changes.size, "transaction")}?" } } %>
+      <% end %>
+    </div>
+  </div>
 <% end %>
-
-<p><%= link_to "Back to Import Rules", import_rules_path %></p>

--- a/app/views/import_rules/saved.turbo_stream.erb
+++ b/app/views/import_rules/saved.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.replace "ir_list" do %>
+  <%= render "list" %>
+<% end %>
+
+<%# Keep the just-saved rule open in the editor (now in "Edit rule" mode). %>
+<%= turbo_stream.replace "rule_editor" do %>
+  <%= render "form", import_rule: @import_rule %>
+<% end %>
+
+<%= render "flash_stream" %>

--- a/app/views/import_rules/workbench_update.turbo_stream.erb
+++ b/app/views/import_rules/workbench_update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "ir_list" do %>
+  <%= render "list" %>
+<% end %>
+
+<%= turbo_stream.replace "rule_editor" do %>
+  <%= turbo_frame_tag "rule_editor" do %>
+    <%= render "editor_empty" %>
+  <% end %>
+<% end %>
+
+<%= render "flash_stream" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
     collection do
       get :preview_apply
       post :apply
-    end
-    member do
+      post :reorder
+      get :match_preview
       get :preview
     end
   end

--- a/test/controllers/import_rules_controller_test.rb
+++ b/test/controllers/import_rules_controller_test.rb
@@ -199,9 +199,23 @@ class ImportRulesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to import_rules_path
   end
 
-  test "should get preview for a single rule" do
-    get preview_import_rule_url(@import_rule)
+  test "preview of an edited draft rule offers to save it" do
+    get preview_import_rules_url, params: {
+      pattern: "NOMATCH_PATTERN_XYZ", match_type: "contains", account_id: accounts(:expense_account).id
+    }
     assert_response :success
+    assert_match "saved yet", @response.body
+    assert_match "Save rule", @response.body
+  end
+
+  test "preview of an unchanged saved rule does not offer to save it" do
+    rule = import_rules(:fixture_rule_one)
+    get preview_import_rules_url, params: {
+      id: rule.id, pattern: rule.match_pattern, match_type: rule.match_type, account_id: rule.account_id, exclude: false
+    }
+    assert_response :success
+    assert_match "No changes needed", @response.body
+    assert_no_match "Save rule", @response.body
   end
 
   test "should create rule with asset account" do
@@ -216,4 +230,196 @@ class ImportRulesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to import_rules_path
   end
+
+  test "should place a new rule at the top priority when none is given" do
+    top = current_user_top_priority
+    post import_rules_url, params: { import_rule: {
+      match_pattern: "TopOfStack",
+      match_type: "contains",
+      account_id: accounts(:expense_account).id
+    } }
+    assert_redirected_to import_rules_path
+    assert_equal top + 1, ImportRule.find_by(match_pattern: "TopOfStack").priority
+  end
+
+  test "should create import_rule via turbo_stream" do
+    assert_difference("ImportRule.count") do
+      post import_rules_url, params: { import_rule: {
+        match_pattern: "TurboNew", match_type: "contains", account_id: accounts(:expense_account).id
+      } }, as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_match "ir_list", @response.body
+    assert_match "rule_editor", @response.body
+  end
+
+  test "should re-render the editor on invalid turbo_stream create" do
+    assert_no_difference("ImportRule.count") do
+      post import_rules_url, params: { import_rule: { match_pattern: "" } }, as: :turbo_stream
+    end
+
+    assert_response :unprocessable_entity
+    assert_match "rule_editor", @response.body
+  end
+
+  test "should update import_rule via turbo_stream" do
+    patch import_rule_url(@import_rule), params: { import_rule: { match_pattern: "TurboUpdated" } }, as: :turbo_stream
+    assert_response :success
+    assert_match "ir_list", @response.body
+    assert_equal "TurboUpdated", @import_rule.reload.match_pattern
+  end
+
+  test "should destroy import_rule via turbo_stream" do
+    assert_difference("ImportRule.count", -1) do
+      delete import_rule_url(@import_rule), as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_match "ir_list", @response.body
+  end
+
+  test "should apply via turbo_stream" do
+    post apply_import_rules_url, as: :turbo_stream
+    assert_response :success
+  end
+
+  test "should reorder rules and reassign priority" do
+    first = import_rules(:fixture_rule_one)
+    second = import_rules(:fixture_rule_two)
+
+    post reorder_import_rules_url, params: { ids: [ second.id, first.id ] }
+
+    assert_response :no_content
+    assert_operator second.reload.priority, :>, first.reload.priority
+  end
+
+  test "should ignore another user's rules when reordering" do
+    other_user = users(:two)
+    other_account = Account.create!(user: other_user, currency: currencies(:usd), name: "Other Reorder", kind: :expense)
+    other_rule = ImportRule.create!(user: other_user, account: other_account, match_pattern: "OtherReorder")
+    original_priority = other_rule.priority
+
+    post reorder_import_rules_url, params: { ids: [ other_rule.id ] }
+
+    assert_response :no_content
+    assert_equal original_priority, other_rule.reload.priority
+  end
+
+  test "should return live matches from match_preview" do
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, currency: currencies(:usd), name: "MP Expense", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_mp_1",
+      amount: "-12.00", description: "MATCHPREVIEW COFFEE", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: bank, dest_account: expense, amount_minor: 1200,
+      currency: currencies(:usd), description: "MATCHPREVIEW COFFEE", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    get match_preview_import_rules_url, params: { pattern: "MATCHPREVIEW", match_type: "contains" }
+
+    assert_response :success
+    # The matched substring is wrapped in <mark>, so assert on the highlight + plain remainder.
+    assert_match %r{<mark class="ir-mark">MATCHPREVIEW</mark> COFFEE}, @response.body
+  end
+
+  test "match_preview with a blank pattern prompts for input" do
+    get match_preview_import_rules_url, params: { pattern: "" }
+
+    assert_response :success
+    assert_match "Start typing", @response.body
+  end
+
+  test "match_preview lists already-excluded transactions" do
+    bank = accounts(:linked_asset)
+    expense = Account.create!(user: @user, currency: currencies(:usd), name: "Excl Cat", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_excl",
+      amount: "-3.00", description: "EXCLUDEDITEM SHOP", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    transaction = create_sourced_transaction(
+      user: @user, src_account: bank, dest_account: expense, amount_minor: 300,
+      currency: currencies(:usd), description: "EXCLUDEDITEM SHOP", transacted_at: 1.day.ago, sourceable: source
+    )
+    transaction.update_columns(excluded_at: Time.current)
+
+    get match_preview_import_rules_url, params: { pattern: "EXCLUDEDITEM", match_type: "contains", exclude: "true" }
+
+    assert_response :success
+    assert_match %r{<mark class="ir-mark">EXCLUDEDITEM</mark> SHOP}, @response.body
+    assert_match "ir-test__row--excluded", @response.body
+    assert_match "ir-test__excluded", @response.body
+  end
+
+  test "edit preloads the live preview with the rule's matches" do
+    rule = ImportRule.create!(user: @user, account: accounts(:expense_account), match_pattern: "PRELOADME", match_type: :contains)
+    expense = Account.create!(user: @user, currency: currencies(:usd), name: "Preload Cat", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_preload",
+      amount: "-5.00", description: "PRELOADME CAFE", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: expense, amount_minor: 500,
+      currency: currencies(:usd), description: "PRELOADME CAFE", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    get edit_import_rule_url(rule)
+
+    assert_response :success
+    assert_match %r{<mark class="ir-mark">PRELOADME</mark> CAFE}, @response.body
+  end
+
+  test "should create a rule and apply it retroactively when flagged" do
+    bank = accounts(:linked_asset)
+    old_category = Account.create!(user: @user, currency: currencies(:usd), name: "Old Cat", kind: :expense)
+    new_category = Account.create!(user: @user, currency: currencies(:usd), name: "New Cat", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_apply_save",
+      amount: "-7.00", description: "SAVEAPPLY ITEM", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    transaction = create_sourced_transaction(
+      user: @user, src_account: bank, dest_account: old_category, amount_minor: 700,
+      currency: currencies(:usd), description: "SAVEAPPLY ITEM", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    assert_difference("ImportRule.count") do
+      post import_rules_url, params: {
+        apply_after_save: "1",
+        import_rule: { match_pattern: "SAVEAPPLY", match_type: "contains", account_id: new_category.id }
+      }
+    end
+
+    assert_redirected_to import_rules_path
+    assert_match(/reassigned/, flash[:notice])
+    assert_equal new_category, transaction.reload.dest_account
+  end
+
+  test "should apply retroactively after updating a rule when flagged" do
+    bank = accounts(:linked_asset)
+    old_category = Account.create!(user: @user, currency: currencies(:usd), name: "Old Cat 2", kind: :expense)
+    target = @import_rule.account
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_update_apply",
+      amount: "-3.00", description: "UPDATEAPPLY ITEM", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    transaction = create_sourced_transaction(
+      user: @user, src_account: bank, dest_account: old_category, amount_minor: 300,
+      currency: currencies(:usd), description: "UPDATEAPPLY ITEM", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    patch import_rule_url(@import_rule), params: {
+      apply_after_save: "1", import_rule: { match_pattern: "UPDATEAPPLY" }
+    }
+
+    assert_match(/reassigned/, flash[:notice])
+    assert_equal target, transaction.reload.dest_account
+  end
+
+  private
+
+    def current_user_top_priority
+      @user.import_rules.maximum(:priority) || -1
+    end
 end

--- a/test/controllers/import_rules_controller_test.rb
+++ b/test/controllers/import_rules_controller_test.rb
@@ -178,7 +178,7 @@ class ImportRulesControllerTest < ActionDispatch::IntegrationTest
 
     post apply_import_rules_url
     assert_redirected_to import_rules_path
-    assert_match(/reassigned/, flash[:notice])
+    assert_match(/updated/, flash[:notice])
   end
 
   test "should redirect with alert on apply error" do
@@ -392,7 +392,7 @@ class ImportRulesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to import_rules_path
-    assert_match(/reassigned/, flash[:notice])
+    assert_match(/updated/, flash[:notice])
     assert_equal new_category, transaction.reload.dest_account
   end
 
@@ -413,8 +413,46 @@ class ImportRulesControllerTest < ActionDispatch::IntegrationTest
       apply_after_save: "1", import_rule: { match_pattern: "UPDATEAPPLY" }
     }
 
-    assert_match(/reassigned/, flash[:notice])
+    assert_match(/updated/, flash[:notice])
     assert_equal target, transaction.reload.dest_account
+  end
+
+  test "draft preview ignores another user's account_id" do
+    foreign = Account.create!(user: users(:two), currency: currencies(:eur), name: "Foreign Acct", kind: :expense)
+    bank = accounts(:linked_asset)
+    mine = Account.create!(user: @user, currency: currencies(:usd), name: "Mine Cat", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "ctrl_leak",
+      amount: "-2.00", description: "LEAKTEST ITEM", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: bank, dest_account: mine, amount_minor: 200,
+      currency: currencies(:usd), description: "LEAKTEST ITEM", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    get preview_import_rules_url, params: { pattern: "LEAKTEST", match_type: "contains", account_id: foreign.id }
+
+    assert_response :success
+    assert_no_match "Foreign Acct", @response.body
+  end
+
+  test "surfaces a failure from save-and-apply but keeps the rule saved" do
+    service_mock = Minitest::Mock.new
+    service_mock.expect(:apply, 0)
+    service_mock.expect(:errors, [ "boom" ])
+
+    assert_difference("ImportRule.count") do
+      ImportRule::RetroactiveApply.stub(:new, service_mock) do
+        post import_rules_url, params: {
+          apply_after_save: "1",
+          import_rule: { match_pattern: "ApplyErr", match_type: "contains", account_id: accounts(:expense_account).id }
+        }
+      end
+    end
+
+    assert ImportRule.exists?(user: @user, match_pattern: "ApplyErr")
+    assert_match(/couldn.t be applied: boom/, flash[:notice])
+    assert_mock service_mock
   end
 
   private

--- a/test/fixtures/import_rules.yml
+++ b/test/fixtures/import_rules.yml
@@ -11,3 +11,10 @@ fixture_rule_two:
   match_pattern: FIXTURE_PATTERN_TWO
   match_type: exact
   priority: 5
+
+fixture_rule_exclude:
+  user: one
+  match_pattern: FIXTURE_EXCLUDE_PATTERN
+  match_type: contains
+  exclude: true
+  priority: 8

--- a/test/helpers/import_rules_helper_test.rb
+++ b/test/helpers/import_rules_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ImportRulesHelperTest < ActionView::TestCase
+  test "highlight_match wraps the matched span for each match type" do
+    assert_equal %(BLUE <mark class="ir-mark">COFF</mark>EE), highlight_match("BLUE COFFEE", "coff", "contains")
+    assert_equal %(<mark class="ir-mark">BLUE</mark> COFFEE), highlight_match("BLUE COFFEE", "blue", "starts_with")
+    assert_equal %(BLUE <mark class="ir-mark">COFFEE</mark>), highlight_match("BLUE COFFEE", "coffee", "ends_with")
+    assert_equal %(<mark class="ir-mark">BLUE COFFEE</mark>), highlight_match("BLUE COFFEE", "blue coffee", "exact")
+  end
+
+  test "highlight_match returns the description unchanged when nothing matches" do
+    assert_equal "BLUE COFFEE", highlight_match("BLUE COFFEE", "xyz", "contains")
+    assert_equal "BLUE COFFEE", highlight_match("BLUE COFFEE", "blue", "exact")
+    assert_equal "BLUE COFFEE", highlight_match("BLUE COFFEE", "", "contains")
+  end
+
+  test "match-type labels" do
+    assert_equal "Starts", match_type_short_label("starts_with")
+    assert_equal "starts with", match_type_phrase("starts_with")
+  end
+end

--- a/test/models/import_rule_test.rb
+++ b/test/models/import_rule_test.rb
@@ -187,5 +187,6 @@ class ImportRuleTest < ActiveSupport::TestCase
 
     assert_not ImportRule.new(match_pattern: "coffee", match_type: :exact).matches?("BLUE COFFEE BAR")
     assert_not ImportRule.new(match_pattern: "", match_type: :contains).matches?("anything")
+    assert_not ImportRule.new(match_pattern: "x", match_type: nil).matches?("x")
   end
 end

--- a/test/models/import_rule_test.rb
+++ b/test/models/import_rule_test.rb
@@ -176,4 +176,16 @@ class ImportRuleTest < ActiveSupport::TestCase
     assert_includes revenue_results, revenue_rule
     assert_not_includes revenue_results, expense_rule
   end
+
+  # matches? (in-memory, for previewing an unsaved draft)
+
+  test "matches? mirrors each match type, case-insensitively" do
+    assert ImportRule.new(match_pattern: "coffee", match_type: :contains).matches?("BLUE COFFEE BAR")
+    assert ImportRule.new(match_pattern: "BLUE COFFEE BAR", match_type: :exact).matches?("blue coffee bar")
+    assert ImportRule.new(match_pattern: "blue", match_type: :starts_with).matches?("BLUE COFFEE BAR")
+    assert ImportRule.new(match_pattern: "bar", match_type: :ends_with).matches?("BLUE COFFEE BAR")
+
+    assert_not ImportRule.new(match_pattern: "coffee", match_type: :exact).matches?("BLUE COFFEE BAR")
+    assert_not ImportRule.new(match_pattern: "", match_type: :contains).matches?("anything")
+  end
 end

--- a/test/services/import_rule/match_preview_test.rb
+++ b/test/services/import_rule/match_preview_test.rb
@@ -1,0 +1,169 @@
+require "test_helper"
+
+class ImportRule::MatchPreviewTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @currency = currencies(:usd)
+    @bank_account = accounts(:linked_asset) # linked via fixture account_sources
+    @expense = Account.create!(user: @user, name: "Old Groceries", kind: :expense, currency: @currency)
+    @target = Account.create!(user: @user, name: "Groceries", kind: :expense, currency: @currency)
+
+    @transaction = seed_transaction(description: "GROCERY STORE #123", remote_id: "mp_setup_1")
+  end
+
+  test "matches a transaction by contains and reports its counterpart" do
+    preview = build(pattern: "grocery")
+
+    match = preview.matches.find { |candidate| candidate.transaction.id == @transaction.id }
+    assert_not_nil match
+    assert_equal :expense, match.direction
+    assert_equal @expense, match.current_account
+  end
+
+  test "would_move is true when assigning to a different account" do
+    preview = build(pattern: "GROCERY", account_id: @target.id)
+    match = preview.matches.first
+    assert match.would_move
+  end
+
+  test "would_move is false when the transaction already sits in the target account" do
+    preview = build(pattern: "GROCERY", account_id: @expense.id)
+    match = preview.matches.first
+    assert_not match.would_move
+  end
+
+  test "exclude rules always mark a match as moving" do
+    preview = build(pattern: "GROCERY", exclude: true)
+    match = preview.matches.first
+    assert match.would_move
+    assert preview.exclude?
+  end
+
+  test "matching is case-insensitive" do
+    assert build(pattern: "grocery store").matches.any?
+    assert build(pattern: "GROCERY STORE").matches.any?
+  end
+
+  test "supports every match type" do
+    assert build(pattern: "STORE", match_type: "contains").matches.any?
+    assert build(pattern: "GROCERY STORE #123", match_type: "exact").matches.any?
+    assert build(pattern: "GROCERY", match_type: "starts_with").matches.any?
+    assert build(pattern: "#123", match_type: "ends_with").matches.any?
+
+    assert_empty build(pattern: "STORE", match_type: "starts_with").matches
+    assert_empty build(pattern: "GROCERY", match_type: "exact").matches
+  end
+
+  test "treats LIKE metacharacters in the pattern literally" do
+    literal = seed_transaction(description: "50% CASHBACK BONUS", remote_id: "mp_pct")
+
+    assert_includes build(pattern: "50%").matches.map { |m| m.transaction.id }, literal.id
+    assert_empty build(pattern: "50X", match_type: "starts_with").matches
+  end
+
+  test "blank pattern returns no matches" do
+    assert_empty build(pattern: "").matches
+    assert_empty build(pattern: "   ").matches
+  end
+
+  test "does not match another user's transactions" do
+    other = users(:two)
+    other_currency = currencies(:eur)
+    other_expense = Account.create!(user: other, name: "Other Expense", kind: :expense, currency: other_currency)
+    Transaction.create!(
+      user: other, src_account: accounts(:two), dest_account: other_expense,
+      amount_minor: 100, currency: other_currency, description: "GROCERY ELSEWHERE", transacted_at: 1.day.ago
+    )
+
+    descriptions = build(pattern: "GROCERY").matches.map { |m| m.transaction.description }
+    assert_not_includes descriptions, "GROCERY ELSEWHERE"
+  end
+
+  test "lists already-excluded transactions, marked and not moving" do
+    @transaction.update_columns(excluded_at: Time.current)
+
+    match = build(pattern: "GROCERY").matches.find { |candidate| candidate.transaction.id == @transaction.id }
+    assert_not_nil match
+    assert match.excluded
+    assert_not match.would_move
+    assert_equal 0, build(pattern: "GROCERY").move_count
+  end
+
+  test "skips merged, split, and opening-balance transactions" do
+    @transaction.update_columns(merged_into_id: @transaction.id)
+    assert_empty build(pattern: "GROCERY").matches
+
+    @transaction.update_columns(merged_into_id: nil, split: true)
+    assert_empty build(pattern: "GROCERY").matches
+
+    @transaction.update_columns(split: false, opening_balance: true)
+    assert_empty build(pattern: "GROCERY").matches
+  end
+
+  test "caps results at the limit and flags truncation" do
+    52.times { |index| seed_transaction(description: "BULK GROCERY #{index}", remote_id: "mp_bulk_#{index}") }
+
+    preview = build(pattern: "BULK GROCERY")
+    assert_equal ImportRule::MatchPreview::LIMIT, preview.matches.size
+    assert preview.has_more?
+    assert_equal "#{ImportRule::MatchPreview::LIMIT}+ matches", preview.count_summary
+    # All visible rows are movable and the set is truncated, so the move count is "N+".
+    assert_equal "#{ImportRule::MatchPreview::LIMIT}+", preview.move_count_summary
+  end
+
+  test "orders actionable matches ahead of already-excluded ones" do
+    movable = seed_transaction(description: "ORDER GROCERY old", remote_id: "ord_mov")
+    movable.update_columns(transacted_at: 10.days.ago)
+    excluded = seed_transaction(description: "ORDER GROCERY recent", remote_id: "ord_excl")
+    excluded.update_columns(transacted_at: 1.hour.ago, excluded_at: Time.current)
+
+    matches = build(pattern: "ORDER GROCERY", account_id: @target.id).matches
+
+    # The movable row sorts first despite being older; the excluded row sorts last.
+    assert_equal movable.id, matches.first.transaction.id
+    assert_not matches.first.excluded
+    assert matches.last.excluded
+    assert_equal 1, build(pattern: "ORDER GROCERY", account_id: @target.id).move_count
+  end
+
+  test "lists a match but does not count it as moving when it already sits in the target" do
+    preview = build(pattern: "GROCERY", account_id: @expense.id)
+
+    assert preview.matches.any?
+    assert_equal 0, preview.move_count
+    assert_not preview.matches.first.would_move
+  end
+
+  test "count_summary pluralizes" do
+    assert_equal "1 match", build(pattern: "GROCERY STORE #123", match_type: "exact").count_summary
+  end
+
+  private
+
+    def build(pattern:, match_type: "contains", account_id: nil, exclude: false)
+      ImportRule::MatchPreview.new(
+        user: @user, pattern: pattern, match_type: match_type, account_id: account_id, exclude: exclude
+      )
+    end
+
+    def seed_transaction(description:, remote_id:)
+      source = Simplefin::Transaction.create!(
+        account: simplefin_accounts(:linked_one),
+        remote_id: remote_id,
+        amount: "-50.00",
+        description: description,
+        transacted_at: 1.day.ago,
+        posted: 1.day.ago
+      )
+      create_sourced_transaction(
+        user: @user,
+        src_account: @bank_account,
+        dest_account: @expense,
+        amount_minor: 5000,
+        currency: @currency,
+        description: description,
+        transacted_at: 1.day.ago,
+        sourceable: source
+      )
+    end
+end

--- a/test/services/import_rule/match_preview_test.rb
+++ b/test/services/import_rule/match_preview_test.rb
@@ -138,6 +138,13 @@ class ImportRule::MatchPreviewTest < ActiveSupport::TestCase
     assert_equal "1 match", build(pattern: "GROCERY STORE #123", match_type: "exact").count_summary
   end
 
+  test "trims surrounding whitespace so it matches the apply path" do
+    padded = seed_transaction(description: "  WHITESPACE STORE  ", remote_id: "mp_ws")
+
+    assert_includes build(pattern: "WHITESPACE STORE", match_type: "exact").matches.map { |m| m.transaction.id }, padded.id
+    assert_includes build(pattern: "STORE", match_type: "ends_with").matches.map { |m| m.transaction.id }, padded.id
+  end
+
   private
 
     def build(pattern:, match_type: "contains", account_id: nil, exclude: false)

--- a/test/system/import_rules_test.rb
+++ b/test/system/import_rules_test.rb
@@ -243,7 +243,7 @@ class ImportRulesTest < ApplicationSystemTestCase
 
     # The rule is persisted (shows in the list) and the flash confirms the reassignment.
     within("#ir_list") { assert_text "APPLYSAVE" }
-    assert_text "reassigned"
+    assert_text "updated"
     assert ImportRule.exists?(user: @user, match_pattern: "APPLYSAVE")
   end
 

--- a/test/system/import_rules_test.rb
+++ b/test/system/import_rules_test.rb
@@ -1,74 +1,265 @@
 require "application_system_test_case"
 
 class ImportRulesTest < ApplicationSystemTestCase
+  include ActionView::RecordIdentifier
+
   setup do
     @user = users(:one)
     @user.update!(password: "password123")
     sign_in_as(@user)
   end
 
-  test "create import rule with contains match type" do
-    create_rule(pattern: "grocery", match_type: "Contains", account: "Expense Account")
-
-    assert_text "grocery"
-    assert_text "Contains"
-    assert_text "Expense Account"
-  end
-
-  test "create import rule with exact match type" do
-    create_rule(pattern: "AMAZON PRIME", match_type: "Exact", account: "Expense Account")
-
-    assert_text "AMAZON PRIME"
-    assert_text "Exact"
-  end
-
-  test "create import rule with starts_with match type" do
-    create_rule(pattern: "PAYPAL", match_type: "Starts with", account: "Revenue Account")
-
-    assert_text "PAYPAL"
-    assert_text "Starts with"
-    assert_text "Revenue Account"
-  end
-
-  test "create import rule with ends_with match type" do
-    create_rule(pattern: "SUBSCRIPTION", match_type: "Ends with", account: "Expense Account")
-
-    assert_text "SUBSCRIPTION"
-    assert_text "Ends with"
-  end
-
-  test "edit an import rule" do
+  test "create a rule inline in the workbench" do
     visit import_rules_path
-    within("tr", text: "FIXTURE_PATTERN_ONE") do
-      click_link "Edit"
+    click_on "New rule"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "grocery"
+      choose "Starts", allow_label_click: true
+      select "Expense Account", from: "Account"
+      click_button "Create rule"
     end
 
-    fill_in "Pattern", with: "UPDATED_PATTERN"
-    select "Exact", from: "Match Type"
-    click_button "Update Import rule"
-
-    assert_text "UPDATED_PATTERN"
-    assert_text "Exact"
+    within "#ir_list" do
+      assert_text "grocery"
+      assert_text "Expense Account"
+    end
+    # The just-created rule stays open in the editor.
+    within("#rule_editor") { assert_field "Pattern", with: "grocery" }
   end
 
-  test "delete an import rule" do
+  test "create an exclude rule without an account" do
+    visit import_rules_path
+    click_on "New rule"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "internal transfer"
+      choose "Exclude", allow_label_click: true
+      click_button "Create rule"
+    end
+
+    within "#ir_list" do
+      assert_text "internal transfer"
+      assert_text "Exclude"
+    end
+  end
+
+  test "toggling to exclude and back restores the chosen account" do
+    visit import_rules_path
+    click_on "New rule"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "restore me"
+      select "Expense Account", from: "Account"
+
+      choose "Exclude", allow_label_click: true
+      choose "Assign to account", allow_label_click: true
+
+      assert page.has_select?("Account", selected: "Expense Account")
+    end
+  end
+
+  test "edit a rule inline and highlight the selected row" do
+    visit import_rules_path
+    rule_row = "##{dom_id(import_rules(:fixture_rule_one))}"
+
+    within(rule_row) { click_on "FIXTURE_PATTERN_ONE" }
+    assert_selector "#{rule_row}.ir-rule--selected"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "UPDATED_PATTERN"
+      click_button "Save changes"
+    end
+
+    within "#ir_list" do
+      assert_text "UPDATED_PATTERN"
+      assert_no_text "FIXTURE_PATTERN_ONE"
+    end
+    # The editor stays open on the saved rule, with its row still highlighted.
+    within("#rule_editor") { assert_field "Pattern", with: "UPDATED_PATTERN" }
+    assert_selector "#{rule_row}.ir-rule--selected"
+  end
+
+  test "delete a rule from the editor" do
     visit import_rules_path
     assert_text "FIXTURE_PATTERN_ONE"
 
-    within("tr", text: "FIXTURE_PATTERN_ONE") do
-      accept_confirm("Delete this rule?") do
-        click_link "Delete"
-      end
+    within("##{dom_id(import_rules(:fixture_rule_one))}") { click_on "FIXTURE_PATTERN_ONE" }
+    within "#rule_editor" do
+      accept_confirm("Delete this rule?") { click_on "Delete" }
     end
 
     assert_no_text "FIXTURE_PATTERN_ONE"
+  end
+
+  test "live preview shows matching ledger transactions as you type" do
+    expense = Account.create!(user: @user, currency: currencies(:usd), name: "Coffee", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "sys_live_1",
+      amount: "-5.00", description: "BLUEBOTTLE COFFEE", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: expense, amount_minor: 500,
+      currency: currencies(:usd), description: "BLUEBOTTLE COFFEE", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    visit import_rules_path
+    click_on "New rule"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "BLUEBOTTLE"
+    end
+
+    within "#ir_match_preview" do
+      assert_text "BLUEBOTTLE COFFEE"
+      assert_text "1 match"
+    end
+  end
+
+  test "editing a rule preloads its live matches" do
+    misc = Account.create!(user: @user, currency: currencies(:usd), name: "Misc Preload", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "sys_preload",
+      amount: "-6.00", description: "PRELOADSYS CAFE", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: misc, amount_minor: 600,
+      currency: currencies(:usd), description: "PRELOADSYS CAFE", transacted_at: 1.day.ago, sourceable: source
+    )
+    rule = ImportRule.create!(user: @user, account: accounts(:expense_account), match_pattern: "PRELOADSYS", match_type: :contains)
+
+    visit import_rules_path
+    within("##{dom_id(rule)}") { click_on "PRELOADSYS" }
+
+    # The match shows immediately, without typing (the frame is rendered server-side).
+    within("#ir_match_preview") { assert_text "PRELOADSYS CAFE" }
+  end
+
+  test "filter the list with search" do
+    visit import_rules_path
+    assert_text "FIXTURE_PATTERN_ONE"
+    assert_text "FIXTURE_PATTERN_TWO"
+
+    fill_in "ir_search", with: "PATTERN_ONE"
+
+    assert_text "FIXTURE_PATTERN_ONE"
+    assert_no_text "FIXTURE_PATTERN_TWO"
+  end
+
+  test "filter the list by exclude action" do
+    visit import_rules_path
+
+    within(".ir-seg") { click_on "Exclude" }
+
+    assert_text "FIXTURE_EXCLUDE_PATTERN"
+    assert_no_text "FIXTURE_PATTERN_ONE"
+  end
+
+  test "open the per-rule preview modal from the editor" do
+    visit import_rules_path
+
+    within("##{dom_id(import_rules(:fixture_rule_one))}") { click_on "FIXTURE_PATTERN_ONE" }
+    within("#rule_editor") { click_on "Preview" }
+
+    within "#preview_modal_frame" do
+      assert_text "Preview rule"
+      # Unedited rule that matches nothing: a clean "no changes" state, no save prompt.
+      assert_text "No changes needed"
+    end
+  end
+
+  test "preview a brand-new rule before saving it" do
+    misc = Account.create!(user: @user, currency: currencies(:usd), name: "Misc", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "sys_draft_1",
+      amount: "-9.99", description: "DRAFTPREVIEW SHOP", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: misc, amount_minor: 999,
+      currency: currencies(:usd), description: "DRAFTPREVIEW SHOP", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    visit import_rules_path
+    click_on "New rule"
+
+    within "#rule_editor" do
+      fill_in "Pattern", with: "DRAFTPREVIEW"
+      select "Expense Account", from: "Account"
+      click_on "Preview"
+    end
+
+    within "#preview_modal_frame" do
+      assert_text "Preview rule"
+      assert_text "DRAFTPREVIEW SHOP"
+      # A brand-new rule has unsaved edits, so the modal offers to save while applying.
+      assert_text "Save & apply 1 change"
+    end
+  end
+
+  test "previewing an unedited saved rule offers a plain Apply" do
+    misc = Account.create!(user: @user, currency: currencies(:usd), name: "Misc Clean", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "sys_clean",
+      amount: "-4.00", description: "CLEANRULE SHOP", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: misc, amount_minor: 400,
+      currency: currencies(:usd), description: "CLEANRULE SHOP", transacted_at: 1.day.ago, sourceable: source
+    )
+    rule = ImportRule.create!(user: @user, account: accounts(:expense_account), match_pattern: "CLEANRULE", match_type: :contains)
+
+    visit import_rules_path
+    within("##{dom_id(rule)}") { click_on "CLEANRULE" }
+    within("#rule_editor") { click_on "Preview" }
+
+    within "#preview_modal_frame" do
+      assert_text "Apply 1 change"
+      assert_no_text "Save & apply"
+      assert_text "Review the changes above"
+    end
+  end
+
+  test "applying from the preview modal saves the rule and reassigns transactions" do
+    misc = Account.create!(user: @user, currency: currencies(:usd), name: "Misc", kind: :expense)
+    source = Simplefin::Transaction.create!(
+      account: simplefin_accounts(:linked_one), remote_id: "sys_apply_save",
+      amount: "-9.99", description: "APPLYSAVE SHOP", transacted_at: 1.day.ago, posted: 1.day.ago
+    )
+    create_sourced_transaction(
+      user: @user, src_account: accounts(:linked_asset), dest_account: misc, amount_minor: 999,
+      currency: currencies(:usd), description: "APPLYSAVE SHOP", transacted_at: 1.day.ago, sourceable: source
+    )
+
+    visit import_rules_path
+    click_on "New rule"
+    within "#rule_editor" do
+      fill_in "Pattern", with: "APPLYSAVE"
+      select "Expense Account", from: "Account"
+      click_on "Preview"
+    end
+
+    # A new rule is dirty, so the modal's primary action saves and applies.
+    within("#preview_modal_frame") { click_on "Save & apply 1 change" }
+
+    # The rule is persisted (shows in the list) and the flash confirms the reassignment.
+    within("#ir_list") { assert_text "APPLYSAVE" }
+    assert_text "reassigned"
+    assert ImportRule.exists?(user: @user, match_pattern: "APPLYSAVE")
+  end
+
+  test "open the preview and apply all modal" do
+    visit import_rules_path
+    click_on "Preview & apply all"
+
+    within "#preview_modal_frame" do
+      assert_text "Preview & apply all rules"
+    end
   end
 
   test "user cannot see another user's import rules" do
     visit import_rules_path
     assert_text "FIXTURE_PATTERN_ONE"
 
-    # Sign in as a different user via a fresh browser session
     Capybara.reset_sessions!
     user_two = users(:two)
     user_two.update!(password: "password123")
@@ -87,15 +278,5 @@ class ImportRulesTest < ApplicationSystemTestCase
     fill_in "Password", with: "password123"
     click_button "Log in"
     assert_link "Logout"
-  end
-
-  def create_rule(pattern:, match_type:, account:)
-    visit import_rules_path
-    click_link "New Rule"
-
-    fill_in "Pattern", with: pattern
-    select match_type, from: "Match Type"
-    select account, from: "Account"
-    click_button "Create Import rule"
   end
 end


### PR DESCRIPTION
## What & why

Replaces the plain Import Rules `<table>` + separate full-page form/preview screens with a single split-pane **rules workbench**, recreating a Claude Design prototype in idiomatic server-rendered Hotwire (Turbo + Stimulus). **No schema changes** — the existing `match_type` / `exclude` / `priority` / `account` model is untouched.

## Highlights

- **Split-pane workbench** — a searchable + filterable (All / Assign / Exclude) rule list on the left, an inline editor on the right loaded into a `rule_editor` Turbo Frame. Create/edit/delete happen inline via Turbo Streams (no page jumps); after a save the editor stays open on the rule and its row stays highlighted. The editor sticks below the header and scrolls internally so it stays usable with a long rule list.
- **Live pattern testing** — typing a pattern shows the matching ledger transactions with the matched text highlighted and "now in {account}" notes. It's **preloaded server-side** when the editor opens (no "start typing" flash + round-trip), debounced on edit with a delayed loading indicator, and lists **already-excluded** matches with a clear badge. Powered by a new `ImportRule::MatchPreview` service that mirrors the rule-matching SQL transaction-side.
- **Drag-to-reorder priority** — priority is now positional (the numeric field is gone): native HTML5 drag-and-drop posts to a new `reorder` endpoint.
- **Preview modals** — per-rule **Preview** and **Preview & apply all** as native `<dialog>` modals with the prototype's fade/rise transitions. Per-rule Preview reflects unsaved edits; its **Save & apply** persists the rule and applies it retroactively in one step (the modal copy adapts to whether the rule is dirty/new vs. clean).
- **Shared change-detection** — `ImportRule::RetroactiveApply` (the apply path) and the live preview now share an `ImportRule::TransactionScope` module, so the editor preview and the modal always agree on what would change (already-excluded rows are shown in the preview but never touched by an apply).

Account chips are quiet "Name · Kind" text (no colored dots), and all styles live in a namespaced `app/assets/stylesheets/import_rules.css` (loaded via the `:app` glob).

## Test plan

All items have coverage:

- **Model** (`test/models/import_rule_test.rb`) — `matches?` in-memory matcher across every match type, case-insensitivity.
- **Service** (`test/services/import_rule/match_preview_test.rb`) — match types / escaping / scoping, would-move vs. target/exclude, already-excluded rows listed-but-not-moving, movable-first ordering, `LIMIT`/`+` truncation. `retroactive_apply_test.rb` still passes against the extracted shared module.
- **Controller** (`test/controllers/import_rules_controller_test.rb`) — CRUD (html + json + turbo_stream), `reorder`, `match_preview` (matches, blank, excluded), draft `preview` (dirty vs. clean), create/update **+ apply-after-save**, and the editor preloading its matches.
- **System** (`test/system/import_rules_test.rb`) — inline create/edit/delete, selected-row highlight + editor-stays-open, live preview (preloaded, no typing), search + segment filter, toggle-restore of the account, the three preview-modal states (Save & apply / Apply / no changes), apply-from-modal persists + reassigns. (Native HTML5 drag-reorder is covered by the request test, per the unreliable-Selenium-DnD note.)

CI green locally: `bin/rails test` (917) + `bin/rails test:system` (77), `bin/rubocop`, `bin/brakeman` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)