### PR TITLE
Omit pending and balances-only from SimpleFIN request when false

### DIFF
--- a/lib/simplefin_client.rb
+++ b/lib/simplefin_client.rb
@@ -29,9 +29,9 @@ class SimplefinClient
     self.class.get("/accounts", basic_auth: @auth, query: {
       'start-date': start_date,
       'end-date': end_date,
-      pending: pending ? 1 : 0,
+      pending: (1 if pending),
       account: account,
-      'balances-only': balances_only ? 1 : 0,
+      'balances-only': (1 if balances_only),
       version: 2
     }.compact)
   end

--- a/test/lib/simplefin_client_test.rb
+++ b/test/lib/simplefin_client_test.rb
@@ -78,4 +78,34 @@ class SimplefinClientTest < ActiveSupport::TestCase
       assert_equal 2, opts[:query][:version]
     end
   end
+
+  test "accounts omits pending when not requested" do
+    client = SimplefinClient.new(username: "user", password: "pass")
+
+    called_with = nil
+    stub_get = ->(*args) { called_with = args; { "accounts" => [] } }
+
+    SimplefinClient.stub :get, stub_get do
+      client.accounts(start_date: 1000)
+      # The SimpleFIN bridge presence-checks `pending`, so sending pending=0 opts
+      # us into pending transactions. Omitting the key is what yields the default.
+      assert_not called_with[1][:query].key?(:pending)
+    end
+  end
+
+  test "accounts omits balances-only when not requested" do
+    client = SimplefinClient.new(username: "user", password: "pass")
+
+    called_with = nil
+    stub_get = ->(*args) { called_with = args; { "accounts" => [] } }
+
+    SimplefinClient.stub :get, stub_get do
+      client.accounts(start_date: 1000)
+      query = called_with[1][:query]
+      assert_not query.key?(:"balances-only")
+      # Guard against an over-eager compact dropping legitimate params.
+      assert_equal 1000, query[:"start-date"]
+      assert_equal 2, query[:version]
+    end
+  end
 end


### PR DESCRIPTION
## What

`SimplefinClient#accounts` built its query with `pending: pending ? 1 : 0` and `'balances-only': balances_only ? 1 : 0`. The trailing `.compact` only strips `nil`, so **every request this app has ever made carried `?pending=0&balances-only=0`** — `Simplefin::RefreshJob` has only ever called `accounts(start_date:)`, relying on the `pending: false` default.

The SimpleFIN bridge **presence-checks** the `pending` parameter. A live read-only probe against a connection with a pending charge in authorization:

```
pending=0   txns=37   unposted=3
omitted     txns=34   unposted=0   (strict subset — the 3 pending rows, nothing else)
```

Sending `pending=0` opts us *into* pending transactions exactly as `pending=1` would; omitting the key is what yields the documented default of excluding them. So the app has been silently ingesting pending transactions it never requested — the root cause of the duplicate-ledger-transaction bug in #211.

This emits both boolean flags only when true and lets `.compact` drop them otherwise.

## Why it matters

A pending row imports as an uncleared ledger `Transaction`. When the charge later posts under a **new** `remote_id` (some institutions do this), a second mirror row is created and `Transaction::Reconcile` declines to adopt the original, producing a duplicate ledger transaction and a double-counted balance. Stopping pending rows at the source makes that unreachable.

## Changes

- `lib/simplefin_client.rb` — `pending: (1 if pending)`, `'balances-only': (1 if balances_only)`; signature and defaults unchanged. `Simplefin::RefreshJob` (the only production caller) needs no edit.
- `test/lib/simplefin_client_test.rb` — two new cases.

## Test plan

- [x] `accounts omits pending when not requested` — asserts `query.key?(:pending)` is false on a default call.
- [x] `accounts omits balances-only when not requested` — asserts `query.key?(:"balances-only")` is false, and that `start-date` / `version` survive `.compact`.
- [x] Existing `accounts fetches with auth and query params` still asserts both flags serialize to `1` when passed `true`.
- [x] Full suite green (`bin/rails test`: 888 runs, 0 failures), `bin/rubocop` clean.
- [x] End-to-end: `conn.client.accounts(start_date:)` through the patched client returns `unposted=0` (was 3).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
