### PR TITLE
Stop importing Lunch Flow pending transactions

### DIFF
--- a/app/jobs/lunchflow/refresh_job.rb
+++ b/app/jobs/lunchflow/refresh_job.rb
@@ -56,7 +56,7 @@ class Lunchflow::RefreshJob < ApplicationJob
 
       api_transactions = client.transactions(api_account["id"])
       api_transactions.each do |api_txn|
-        # Skip pending transactions with no ID (can't upsert without identifier)
+        # Skip transactions with no ID (can't upsert without identifier)
         next if api_txn["id"].nil?
 
         lf_transaction = Lunchflow::Transaction.find_or_initialize_by(

--- a/app/jobs/lunchflow/refresh_job.rb
+++ b/app/jobs/lunchflow/refresh_job.rb
@@ -54,7 +54,7 @@ class Lunchflow::RefreshJob < ApplicationJob
 
       lf_account.save!
 
-      api_transactions = client.transactions(api_account["id"], include_pending: true)
+      api_transactions = client.transactions(api_account["id"])
       api_transactions.each do |api_txn|
         # Skip pending transactions with no ID (can't upsert without identifier)
         next if api_txn["id"].nil?

--- a/test/jobs/lunchflow/refresh_job_test.rb
+++ b/test/jobs/lunchflow/refresh_job_test.rb
@@ -336,4 +336,31 @@ class Lunchflow::RefreshJobTest < ActiveJob::TestCase
     assert_nil @lunchflow_connection.error
     assert_not_nil @lunchflow_connection.refreshed_at
   end
+
+  test "does not request pending transactions from the API" do
+    mock_client = Minitest::Mock.new
+
+    def mock_client.accounts
+      [ { "id" => 501, "name" => "Checking", "currency" => "USD", "status" => "ACTIVE" } ]
+    end
+
+    def mock_client.balance(account_id)
+      { "amount" => 100.0, "currency" => "USD" }
+    end
+
+    def mock_client.include_pending_calls = @include_pending_calls ||= []
+
+    def mock_client.transactions(account_id, include_pending: false)
+      (@include_pending_calls ||= []) << include_pending
+      []
+    end
+
+    LunchflowClient.stub :new, mock_client do
+      Lunchflow::RefreshJob.perform_now(@lunchflow_connection.id)
+    end
+
+    # Pending transactions are excluded from the ledger for now; the refresh must
+    # not opt into them via include_pending.
+    assert_equal [ false ], mock_client.include_pending_calls
+  end
 end

--- a/test/jobs/lunchflow/refresh_job_test.rb
+++ b/test/jobs/lunchflow/refresh_job_test.rb
@@ -351,7 +351,7 @@ class Lunchflow::RefreshJobTest < ActiveJob::TestCase
     def mock_client.include_pending_calls = @include_pending_calls ||= []
 
     def mock_client.transactions(account_id, include_pending: false)
-      (@include_pending_calls ||= []) << include_pending
+      include_pending_calls << include_pending
       []
     end
 

--- a/test/lib/lunchflow_client_test.rb
+++ b/test/lib/lunchflow_client_test.rb
@@ -36,6 +36,23 @@ class LunchflowClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "transactions defaults include_pending to false" do
+    client = LunchflowClient.new(api_key: "test_key")
+
+    called_with = nil
+    response = { "transactions" => [] }
+    stub_get = ->(*args) { called_with = args; response }
+
+    response.define_singleton_method(:code) { 200 }
+
+    LunchflowClient.stub :get, stub_get do
+      client.transactions(42)
+      # The Lunch Flow API value-checks the flag, so include_pending=false
+      # correctly excludes pending transactions (verified against the live API).
+      assert_equal false, called_with[1][:query][:include_pending]
+    end
+  end
+
   test "balance fetches for specific account" do
     client = LunchflowClient.new(api_key: "test_key")
 


### PR DESCRIPTION
## What

`Lunchflow::RefreshJob` requested `include_pending: true`, so pending authorization holds were imported into the ledger as uncleared transactions (`cleared_at: lft.pending ? nil : lft.date`). Pending holds can vanish before they post, leaving phantom uncleared ledger entries. This drops the opt-in and relies on the client's `include_pending: false` default.

The Lunch Flow API **value-checks** the flag (unlike the SimpleFIN bridge, which presence-checks — see #215). A live read-only probe against an account with a pending charge:

```
include_pending=true     n=33  pending=2
include_pending=false    n=31  pending=0
omitted                  n=31  pending=0
```

`false` and omitted are identical; only `true` returns the pending rows. So no client change is needed — just stop passing `true`.

## Why

This aligns Lunch Flow with SimpleFIN (#215), so neither aggregator auto-posts pending transactions to the ledger. It's a deliberate interim stance: proper pending support (a review queue for manual import, plus automatic matching when a hold clears) is tracked as a follow-up enhancement.

There are currently zero pending Lunch Flow rows in the ledger, so this is purely forward-looking — no cleanup. Lunch Flow reuses `remote_id` across the pending→posted transition, so a hold that does post will clear in place; only vanishing holds were ever a problem, and those no longer enter the ledger.

## Changes

- `app/jobs/lunchflow/refresh_job.rb` — `client.transactions(id)` instead of `client.transactions(id, include_pending: true)`. Client unchanged.

## Test plan

- [x] `transactions defaults include_pending to false` — client sends `false` on a default call.
- [x] `does not request pending transactions from the API` — refresh-job test records every `include_pending` value passed and asserts all are `false`.
- [x] Existing `transactions fetches for specific account` still asserts `include_pending: true` is passed through when requested.
- [x] Full suite green (`bin/rails test`: 890 runs, 0 failures), `bin/rubocop` clean.

Counterpart to #215 (SimpleFIN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
