### PR TITLE
Correct inbound-transfer direction when a feed signs both legs of a transfer negative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Both SimpleFIN and Lunch Flow follow the same namespaced pattern: `Connection` �
 
 Each aggregator namespace has its own `ImportTransactionsJob` (`Simplefin::ImportTransactionsJob`, `Lunchflow::ImportTransactionsJob`) that converts aggregator transactions to app `Transaction` records with double-entry bookkeeping. Negative amount = expense (auto-creates expense account), positive = revenue. Lunch Flow imports prefer `merchant` over `description`. Each job requires a specific account ID. RefreshJobs automatically enqueue import jobs for linked accounts after a successful per-account refresh.
 
+Direction is not derived from the sign alone. `Transaction::InferLedgerSide` (`app/services/transaction/infer_ledger_side.rb`) applies one override on top of it: a feed that signs *both* legs of an internal transfer negative has its inbound leg (`TRANSFER…FROM` wording plus a negative amount) flipped to `:dest` (#222). Only the direction is overridden — the aggregator row stays a verbatim mirror and the ledger amount is stored as `.abs` either way. The override is gated on `negative?` so it is inert for correctly-signed feeds and self-heals if the provider fixes their signing. When it fires, `transaction_sources.direction_overridden` records it on the source attachment; that flag is written on create only and is never re-derived on resync.
+
 ### Production Database Setup
 
 Production uses four separate PostgreSQL databases (Rails multi-DB):

--- a/app/jobs/lunchflow/import_transactions_job.rb
+++ b/app/jobs/lunchflow/import_transactions_job.rb
@@ -18,12 +18,19 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
 
         description = lft.merchant.presence || lft.description
 
-        # Sign decides direction once per row: a negative amount is a charge
-        # (ledger account on src), non-negative is a refund/credit (ledger on
-        # dest). amount_minor carries the same sign as the source amount (and we
-        # already compute it for storage), so we reuse it — no BigDecimal parse —
-        # for reconciliation, kind, and src/dest assignment below.
-        ledger_side = lft.amount_minor.negative? ? :src : :dest
+        # Direction is decided once per row and drives reconciliation, kind, and
+        # src/dest assignment below. Normally the sign decides it: a negative amount
+        # is a charge (ledger account on src), non-negative is a refund/credit
+        # (ledger on dest). A feed that signs both legs of an internal transfer
+        # negative has its inbound leg flipped by description (#222) — only the
+        # direction is overridden, the amount is stored as .abs either way and
+        # Lunchflow::Transaction stays a verbatim mirror. This feed signs those rows
+        # correctly today, so the negative? gate leaves it inert.
+        direction = Transaction::InferLedgerSide.call(
+          description: description,
+          amount_minor: lft.amount_minor
+        )
+        ledger_side = direction.ledger_side
 
         existing_source = TransactionSource.find_by(sourceable: lft)
 
@@ -66,7 +73,10 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
           # insert, the AR transaction rolls back and we move on.
           begin
             Transaction.transaction do
-              TransactionSource::Attach.call(transaction: match, sourceable: lft)
+              TransactionSource::Attach.call(
+                transaction: match, sourceable: lft,
+                direction_overridden: direction.direction_overridden?
+              )
               match.update!(synced_at: Time.current)
             end
           rescue TransactionSource::Attach::MismatchedTransaction
@@ -111,7 +121,10 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
         begin
           Transaction.transaction do
             transaction.save!
-            TransactionSource::Attach.call(transaction: transaction, sourceable: lft)
+            TransactionSource::Attach.call(
+              transaction: transaction, sourceable: lft,
+              direction_overridden: direction.direction_overridden?
+            )
           end
         rescue TransactionSource::Attach::MismatchedTransaction
           next

--- a/app/jobs/simplefin/import_transactions_job.rb
+++ b/app/jobs/simplefin/import_transactions_job.rb
@@ -16,12 +16,18 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
         ledger_account = sft.account.ledger_accounts.first
         next if ledger_account.nil?
 
-        # Sign decides direction once per row: a negative amount is a charge
-        # (ledger account on src), non-negative is a refund/credit (ledger on
-        # dest). amount_minor carries the same sign as the source amount (and we
-        # already compute it for storage), so we reuse it — no BigDecimal parse —
-        # for reconciliation, kind, and src/dest assignment below.
-        ledger_side = sft.amount_minor.negative? ? :src : :dest
+        # Direction is decided once per row and drives reconciliation, kind, and
+        # src/dest assignment below. Normally the sign decides it: a negative amount
+        # is a charge (ledger account on src), non-negative is a refund/credit
+        # (ledger on dest). One feed signs both legs of an internal transfer
+        # negative, so an inbound transfer is flipped by description (#222) — only
+        # the direction is overridden, the amount is stored as .abs either way and
+        # Simplefin::Transaction stays a verbatim mirror.
+        direction = Transaction::InferLedgerSide.call(
+          description: sft.description,
+          amount_minor: sft.amount_minor
+        )
+        ledger_side = direction.ledger_side
 
         existing_source = TransactionSource.find_by(sourceable: sft)
 
@@ -64,7 +70,10 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
           # insert, the AR transaction rolls back and we move on.
           begin
             Transaction.transaction do
-              TransactionSource::Attach.call(transaction: match, sourceable: sft)
+              TransactionSource::Attach.call(
+                transaction: match, sourceable: sft,
+                direction_overridden: direction.direction_overridden?
+              )
               match.update!(synced_at: Time.current)
             end
           rescue TransactionSource::Attach::MismatchedTransaction
@@ -109,7 +118,10 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
         begin
           Transaction.transaction do
             transaction.save!
-            TransactionSource::Attach.call(transaction: transaction, sourceable: sft)
+            TransactionSource::Attach.call(
+              transaction: transaction, sourceable: sft,
+              direction_overridden: direction.direction_overridden?
+            )
           end
         rescue TransactionSource::Attach::MismatchedTransaction
           next

--- a/app/services/transaction/infer_ledger_side.rb
+++ b/app/services/transaction/infer_ledger_side.rb
@@ -1,0 +1,60 @@
+# Decides which side of the ledger transaction the linked bank account lands on for
+# one incoming aggregator row.
+#
+# The default is the sign rule the importers have always used: a negative amount is
+# money leaving the account (ledger on src), non-negative is money arriving (ledger
+# on dest).
+#
+# One override sits on top of it. A SimpleFIN institution signs *both* legs of an
+# internal transfer negative — the receiving account reports "TRANSFERRED FROM …" at
+# a negative amount, which money cannot do (#222). The description is the only
+# direction signal that feed provides (`extra` is null on every affected row), so we
+# key on TRANSFER…FROM adjacency and flip the direction only.
+#
+# Two deliberate properties:
+#
+#   * Only the direction is overridden, never the amount. Simplefin::Transaction and
+#     Lunchflow::Transaction stay verbatim mirrors of what the provider sent, and the
+#     importers already store the ledger amount as `.abs`.
+#   * The override is gated on `negative?`, so it is inert for feeds that are already
+#     signed correctly and self-heals the moment the provider fixes their signing —
+#     nothing to revert, and no window where the correction double-applies.
+class Transaction::InferLedgerSide
+  # Adjacency, not a fixed string: one observed row puts the counterparty token
+  # directly after FROM with no intervening phrase, and the same feed also emits the
+  # un-suffixed "TRANSFER FROM" form.
+  INBOUND_TRANSFER_PATTERN = /\bTRANSFER(?:RED)?\s+FROM\b/i
+
+  Result = Struct.new(:ledger_side, :direction_overridden, keyword_init: true) do
+    def direction_overridden? = direction_overridden
+  end
+
+  def self.call(**kwargs)
+    new(**kwargs).call
+  end
+
+  # description:  the resolved description the importer will store — Lunch Flow
+  #               prefers `merchant` over `description`, so the caller passes the
+  #               resolved string rather than the source record.
+  # amount_minor: the source row's signed minor amount.
+  def initialize(description:, amount_minor:)
+    @description = description
+    @amount_minor = amount_minor
+  end
+
+  # Returns a Result carrying both the side and whether the override fired, so a
+  # caller cannot derive the two inconsistently from separate regex evaluations.
+  def call
+    return Result.new(ledger_side: :dest, direction_overridden: true) if inbound_transfer?
+
+    Result.new(ledger_side: @amount_minor.negative? ? :src : :dest, direction_overridden: false)
+  end
+
+  private
+
+    # Regexp#match? is false for a nil description, so no separate blank guard is
+    # needed. A nil amount_minor still raises, exactly as the sign rule did before.
+    def inbound_transfer?
+      @amount_minor.negative? && INBOUND_TRANSFER_PATTERN.match?(@description)
+    end
+end

--- a/app/services/transaction_source/attach.rb
+++ b/app/services/transaction_source/attach.rb
@@ -1,13 +1,14 @@
 class TransactionSource::Attach
   class MismatchedTransaction < StandardError; end
 
-  def self.call(transaction:, sourceable:)
-    new(transaction: transaction, sourceable: sourceable).call
+  def self.call(transaction:, sourceable:, direction_overridden: false)
+    new(transaction: transaction, sourceable: sourceable, direction_overridden: direction_overridden).call
   end
 
-  def initialize(transaction:, sourceable:)
+  def initialize(transaction:, sourceable:, direction_overridden: false)
     @transaction = transaction
     @sourceable = sourceable
+    @direction_overridden = direction_overridden
   end
 
   # Idempotent on (sourceable_type, sourceable_id): returns the existing
@@ -16,12 +17,19 @@ class TransactionSource::Attach
   # ledger transaction — fail loudly rather than silently leave the legacy
   # sourceable_* columns and the join row pointing at different ledger
   # transactions, since transactions.sourceable still has no unique index.
+  #
+  # direction_overridden records how the importer interpreted this source row at
+  # attach time (#222) and is written on create only — on the idempotent find path
+  # the row already carries the value its first writer computed. It is a historical
+  # fact about the import decision, not a re-derivation, so a later resync (which
+  # never re-derives src/dest anyway) must not rewrite it.
   def call
     row = TransactionSource.create_or_find_by!(
       sourceable_type: @sourceable.class.name,
       sourceable_id: @sourceable.id
     ) do |new_row|
       new_row.ledger_transaction = @transaction
+      new_row.direction_overridden = @direction_overridden
     end
 
     if row.transaction_id != @transaction.id

--- a/db/migrate/20260726185643_add_direction_overridden_to_transaction_sources.rb
+++ b/db/migrate/20260726185643_add_direction_overridden_to_transaction_sources.rb
@@ -1,0 +1,8 @@
+class AddDirectionOverriddenToTransactionSources < ActiveRecord::Migration[8.1]
+  def change
+    add_column :transaction_sources, :direction_overridden, :boolean, default: false, null: false
+    add_index :transaction_sources, :direction_overridden,
+              where: "direction_overridden",
+              name: "index_transaction_sources_on_direction_overridden"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_160556) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_26_185643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -226,10 +226,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_160556) do
 
   create_table "transaction_sources", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.boolean "direction_overridden", default: false, null: false
     t.bigint "sourceable_id", null: false
     t.string "sourceable_type", null: false
     t.bigint "transaction_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["direction_overridden"], name: "index_transaction_sources_on_direction_overridden", where: "direction_overridden"
     t.index ["sourceable_type", "sourceable_id"], name: "index_transaction_sources_on_sourceable", unique: true
     t.index ["transaction_id", "sourceable_type", "sourceable_id"], name: "index_transaction_sources_on_transaction_and_sourceable", unique: true
     t.index ["transaction_id"], name: "index_transaction_sources_on_transaction_id"

--- a/test/jobs/lunchflow/import_transactions_job_test.rb
+++ b/test/jobs/lunchflow/import_transactions_job_test.rb
@@ -756,6 +756,60 @@ class Lunchflow::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_empty refund_orphan.reload.transaction_sources
   end
 
+  test "leaves a correctly-signed inbound transfer alone (#222 is inert for this feed)" do
+    lf_account, lf_bank_account = create_linked_lunchflow_account(remote_id: 951, name: "Inbound OK Checking")
+
+    lunchflow_transaction = Lunchflow::Transaction.create!(
+      account: lf_account, remote_id: "lf_inbound_positive", amount: "38.26",
+      currency: "USD", description: "TRANSFERRED FROM ACCT ****0001",
+      pending: false, date: Date.current - 1
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+
+    transaction = lunchflow_transaction.ledger_transactions.sole
+    assert_equal lf_bank_account, transaction.dest_account
+    assert_equal "revenue", transaction.src_account.kind
+    assert_not lunchflow_transaction.transaction_sources.sole.direction_overridden?
+  end
+
+  test "flips a negative TRANSFERRED FROM row on Lunch Flow too (#222)" do
+    lf_account, lf_bank_account = create_linked_lunchflow_account(remote_id: 952, name: "Inbound Flip Checking")
+
+    lunchflow_transaction = Lunchflow::Transaction.create!(
+      account: lf_account, remote_id: "lf_inbound_negative", amount: "-38.26",
+      currency: "USD", description: "TRANSFERRED FROM ACCT ****0001",
+      pending: false, date: Date.current - 1
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+
+    transaction = lunchflow_transaction.ledger_transactions.sole
+    assert_equal lf_bank_account, transaction.dest_account
+    assert_equal "revenue", transaction.src_account.kind
+    assert lunchflow_transaction.transaction_sources.sole.direction_overridden?
+  end
+
+  test "decides direction from the merchant string when one is present (#222)" do
+    lf_account, lf_bank_account = create_linked_lunchflow_account(remote_id: 953, name: "Merchant Precedence Checking")
+
+    # The job stores merchant in preference to description, so the override must be
+    # evaluated against the same resolved string the ledger transaction ends up with.
+    lunchflow_transaction = Lunchflow::Transaction.create!(
+      account: lf_account, remote_id: "lf_merchant_precedence", amount: "-38.26",
+      currency: "USD", merchant: "Coffee Shop",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      pending: false, date: Date.current - 1
+    )
+
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+
+    transaction = lunchflow_transaction.ledger_transactions.sole
+    assert_equal lf_bank_account, transaction.src_account
+    assert_equal "Coffee Shop", transaction.description
+    assert_not lunchflow_transaction.transaction_sources.sole.direction_overridden?
+  end
+
   private
 
     def create_linked_lunchflow_account(remote_id: 901, name: "LF Test Checking")

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -1088,6 +1088,200 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
       "the off-by-two-day SimpleFIN copy should attach to the existing Lunch Flow row"
   end
 
+  test "flips an inbound transfer that the feed signed negative onto the destination side (#222)" do
+    sf_account, bank_account = create_linked_simplefin_account(remote_id: "acc_inbound", name: "Inbound Checking")
+
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_inbound_negative", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = simplefin_transaction.ledger_transactions.sole
+    assert_equal bank_account, transaction.dest_account,
+      "money arriving cannot leave the receiving account"
+    assert_equal "TRANSFERRED FROM ACCT ****0001", transaction.src_account.name
+    assert_equal "revenue", transaction.src_account.kind
+    assert_equal 3826, transaction.amount_minor
+    assert_equal 3826, bank_account.reload.balance_minor
+  end
+
+  test "leaves a positive TRANSFERRED FROM row unchanged and unflagged (#222)" do
+    sf_account, bank_account = create_linked_simplefin_account(remote_id: "acc_inbound_ok", name: "Correct Checking")
+
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_inbound_positive", amount: "38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = simplefin_transaction.ledger_transactions.sole
+    assert_equal bank_account, transaction.dest_account
+    assert_equal "revenue", transaction.src_account.kind
+    assert_not simplefin_transaction.transaction_sources.sole.direction_overridden?,
+      "a correctly-signed row needs no override, so the rule must stay quiet"
+  end
+
+  test "leaves a negative TRANSFERRED TO row on the source side (#222)" do
+    sf_account, bank_account = create_linked_simplefin_account(remote_id: "acc_outbound", name: "Outbound Checking")
+
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_outbound", amount: "-38.26",
+      description: "TRANSFERRED TO ACCT ****0002",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = simplefin_transaction.ledger_transactions.sole
+    assert_equal bank_account, transaction.src_account
+    assert_equal "expense", transaction.dest_account.kind
+    assert_not simplefin_transaction.transaction_sources.sole.direction_overridden?
+  end
+
+  test "records direction_overridden on the source row only when the override fires (#222)" do
+    sf_account, _bank_account = create_linked_simplefin_account(remote_id: "acc_audit", name: "Audit Checking")
+
+    inbound_transfer = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_audit_inbound", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+    ordinary_charge = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_audit_charge", amount: "-50.00",
+      description: "Coffee Shop",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    assert inbound_transfer.transaction_sources.sole.direction_overridden?
+    assert_not ordinary_charge.transaction_sources.sole.direction_overridden?
+  end
+
+  test "adopts the correctly-signed Lunch Flow leg instead of duplicating an inbound transfer (#222)" do
+    sf_account, bank_account = create_linked_simplefin_account(remote_id: "acc_dual_inbound", name: "Dual Inbound Checking")
+
+    # The same ledger account is also linked to a live Lunch Flow account, which
+    # signs the receiving leg of the transfer correctly.
+    lf_account = Lunchflow::Account.create!(
+      connection: lunchflow_connections(:one), remote_id: 4343,
+      name: "Dual Inbound Checking", institution_name: "Test Bank",
+      provider: "finicity", currency: "USD", status: "ACTIVE", balance: "1000.00"
+    )
+    bank_account.account_sources.create!(sourceable: lf_account)
+
+    lunchflow_transaction = Lunchflow::Transaction.create!(
+      account: lf_account, remote_id: "lf_dual_inbound", amount: "38.26",
+      currency: "USD", description: "TRANSFERRED FROM ACCT ****0001",
+      pending: false, date: "2026-04-21"
+    )
+    Lunchflow::ImportTransactionsJob.perform_now(lunchflow_account_id: lf_account.id)
+    original = lunchflow_transaction.ledger_transactions.sole
+
+    # SimpleFIN reports the same event with the receiving leg wrongly signed negative.
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_dual_inbound", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: Time.zone.parse("2026-04-21 12:00:00"),
+      transacted_at: Time.zone.parse("2026-04-21 12:00:00"), pending: false
+    )
+
+    assert_no_difference -> { Transaction.count } do
+      Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+    end
+
+    original.reload
+    assert_includes original.transaction_sources.map(&:sourceable), simplefin_transaction,
+      "the wrongly-signed SimpleFIN copy should reconcile onto the Lunch Flow row"
+    assert_equal bank_account, original.dest_account
+    assert_equal 3826, bank_account.reload.balance_minor,
+      "without the override the duplicate points the other way and cancels the balance out"
+
+    assert original.transaction_sources.find_by(sourceable: simplefin_transaction).direction_overridden?
+    assert_not original.transaction_sources.find_by(sourceable: lunchflow_transaction).direction_overridden?
+  end
+
+  test "known limitation: a legitimately negative returned transfer is still flipped (#222 residual risk)" do
+    sf_account, bank_account = create_linked_simplefin_account(remote_id: "acc_returned", name: "Returned Checking")
+
+    # A reversed or returned transfer would legitimately debit the receiving account
+    # while still being worded "TRANSFERRED FROM". No such wording appears in the
+    # observed corpus, so the heuristic flips it — this test pins the accepted false
+    # positive, and direction_overridden is what makes such rows findable. If a
+    # reversal-wording exclusion is ever added, these assertions flip visibly.
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_returned", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001 RETURNED",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    transaction = simplefin_transaction.ledger_transactions.sole
+    assert_equal bank_account, transaction.dest_account
+    assert simplefin_transaction.transaction_sources.sole.direction_overridden?
+  end
+
+  test "an overridden inbound leg and its outbound leg become mergeable into a transfer (#222)" do
+    sf_account_a, bank_a = create_linked_simplefin_account(remote_id: "acc_leg_a", name: "Leg A Checking")
+    sf_account_b, bank_b = create_linked_simplefin_account(remote_id: "acc_leg_b", name: "Leg B Checking")
+
+    outbound = Simplefin::Transaction.create!(
+      account: sf_account_a, remote_id: "sf_leg_a", amount: "-38.26",
+      description: "TRANSFERRED TO ACCT ****0002",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+    inbound = Simplefin::Transaction.create!(
+      account: sf_account_b, remote_id: "sf_leg_b", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account_a.id)
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account_b.id)
+
+    leg_a = outbound.ledger_transactions.sole
+    leg_b = inbound.ledger_transactions.sole
+
+    # AutoMerge only absorbs balance-sheet-to-balance-sheet transfers, so neither
+    # leg merges on its own — but with the direction corrected the pair is now one
+    # balance-sheet src and one balance-sheet dest, which Merge requires. Before the
+    # fix both legs sat on src and merging them was impossible.
+    assert_nil leg_a.merged_into_id
+    assert_nil leg_b.merged_into_id
+    assert_equal bank_a, leg_a.src_account
+    assert_equal bank_b, leg_b.dest_account
+
+    assert Transaction::Merge.new(leg_a, leg_b, user: @user).call
+    merged = leg_a.reload.merged_into || leg_b.reload.merged_into
+    assert_equal bank_a, merged.src_account
+    assert_equal bank_b, merged.dest_account
+  end
+
+  test "applies a balance sheet import rule on the correct side of an overridden inbound transfer (#222)" do
+    _sf_account_a, bank_a = create_linked_simplefin_account(remote_id: "acc_rule_a", name: "Rule A Checking")
+    sf_account_b, bank_b = create_linked_simplefin_account(remote_id: "acc_rule_b", name: "Rule B Checking")
+
+    ImportRule.create!(user: @user, account: bank_a, match_pattern: "TRANSFERRED FROM", match_type: :contains)
+
+    simplefin_transaction = Simplefin::Transaction.create!(
+      account: sf_account_b, remote_id: "sf_rule_inbound", amount: "-38.26",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account_b.id)
+
+    transaction = simplefin_transaction.ledger_transactions.sole
+    assert_equal bank_a, transaction.src_account
+    assert_equal bank_b, transaction.dest_account
+  end
+
   private
 
     def create_linked_simplefin_account(remote_id: "acc_test", name: "SF Test Checking")

--- a/test/services/transaction/infer_ledger_side_test.rb
+++ b/test/services/transaction/infer_ledger_side_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class Transaction::InferLedgerSideTest < ActiveSupport::TestCase
+  test "puts the ledger account on src for a negative amount" do
+    result = infer("Coffee Shop", -5000)
+
+    assert_equal :src, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "puts the ledger account on dest for a positive amount" do
+    result = infer("Salary Payment", 250_000)
+
+    assert_equal :dest, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "treats a zero amount as an inflow" do
+    result = infer("Fee Waiver", 0)
+
+    assert_equal :dest, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "overrides a negative TRANSFERRED FROM row onto dest (#222)" do
+    result = infer("TRANSFERRED FROM ACCT ****0001", -3826)
+
+    assert_equal :dest, result.ledger_side
+    assert result.direction_overridden?
+  end
+
+  test "leaves a positive TRANSFERRED FROM row alone so the fix self-heals (#222)" do
+    result = infer("TRANSFERRED FROM ACCT ****0001", 3826)
+
+    assert_equal :dest, result.ledger_side
+    assert_not result.direction_overridden?,
+      "a correctly-signed inflow needs no override, so the rule must go quiet on its own"
+  end
+
+  test "leaves a negative TRANSFERRED TO row on src" do
+    result = infer("TRANSFERRED TO ACCT ****0002", -3826)
+
+    assert_equal :src, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "matches the un-suffixed TRANSFER FROM form" do
+    assert infer("TRANSFER FROM ACCT ****0001", -3826).direction_overridden?
+  end
+
+  test "matches when the counterparty token follows FROM directly" do
+    assert infer("TRANSFERRED FROM ****0001", -3826).direction_overridden?
+  end
+
+  test "matches case-insensitively" do
+    assert infer("transferred from acct ****0001", -3826).direction_overridden?
+  end
+
+  test "matches across extra whitespace" do
+    assert infer("TRANSFERRED   FROM ACCT ****0001", -3826).direction_overridden?
+  end
+
+  test "matches an inbound wire worded WIRE TRANSFER FROM" do
+    assert infer("WIRE TRANSFER FROM ACCT ****0001", -3826).direction_overridden?
+  end
+
+  test "does not match FROM inside a longer word" do
+    result = infer("TRANSFERRED FROMAGE CO", -3826)
+
+    assert_equal :src, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "requires TRANSFER and FROM to be adjacent" do
+    result = infer("TRANSFER TO ACCT ****0002 FROM ACCT ****0001", -3826)
+
+    assert_equal :src, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  test "does not match a nil description" do
+    result = infer(nil, -3826)
+
+    assert_equal :src, result.ledger_side
+    assert_not result.direction_overridden?
+  end
+
+  private
+
+    def infer(description, amount_minor)
+      Transaction::InferLedgerSide.call(description: description, amount_minor: amount_minor)
+    end
+end

--- a/test/services/transaction_source/attach_test.rb
+++ b/test/services/transaction_source/attach_test.rb
@@ -49,4 +49,34 @@ class TransactionSource::AttachTest < ActiveSupport::TestCase
       TransactionSource::Attach.call(transaction: other_ledger, sourceable: @simplefin_transaction)
     end
   end
+
+  test "defaults direction_overridden to false" do
+    row = TransactionSource::Attach.call(transaction: @ledger_transaction, sourceable: @simplefin_transaction)
+
+    assert_not row.direction_overridden?
+  end
+
+  test "records direction_overridden when the importer overrode the direction (#222)" do
+    row = TransactionSource::Attach.call(
+      transaction: @ledger_transaction, sourceable: @simplefin_transaction,
+      direction_overridden: true
+    )
+
+    assert row.direction_overridden?
+  end
+
+  test "does not rewrite direction_overridden on the idempotent find path (#222)" do
+    TransactionSource::Attach.call(transaction: @ledger_transaction, sourceable: @simplefin_transaction)
+
+    row = nil
+    assert_no_difference("TransactionSource.count") do
+      row = TransactionSource::Attach.call(
+        transaction: @ledger_transaction, sourceable: @simplefin_transaction,
+        direction_overridden: true
+      )
+    end
+
+    assert_not row.reload.direction_overridden?,
+      "the flag is a historical fact about the first writer's import decision, not a re-derivation"
+  end
 end


### PR DESCRIPTION
## Problem

One SimpleFIN institution signs **both legs** of an internal transfer negative — the sending account reports `TRANSFERRED TO …` at a negative amount (correct) and the receiving account reports `TRANSFERRED FROM …` at the *same* negative amount. Money cannot leave both sides of an internal transfer. The same events arrive correctly signed through Lunch Flow, and `extra` is null on every affected row, so the description string is the only direction signal the feed provides.

Both import jobs derived direction purely from the sign, so a negatively-signed inbound transfer put the ledger account on `src`. `Transaction::Reconcile` — direction-aware since #159 — then queried `src_account_id` while the correctly-signed row from the other aggregator sat on `dest_account_id`. No candidate, duplicate created, and because the duplicate points the wrong way the account balance moves by **2×**.

## Approach

`Transaction::InferLedgerSide` applies one override on top of the sign rule: `TRANSFER…FROM` wording plus a negative amount flips the side to `:dest`.

- **Direction only, never the amount.** The aggregator rows stay verbatim provider mirrors, and the importers already store `amount_minor.abs`, so the ledger amount never carries the sign. The entire bug is one boolean.
- **Gated on `negative?`.** Inert for feeds that are already signed correctly, and self-healing — when the provider fixes their signing the condition stops firing on its own. Nothing to revert, and no window where the correction double-applies.
- **Adjacency regex**, not a fixed string: `/\bTRANSFER(?:RED)?\s+FROM\b/i` covers the un-suffixed `TRANSFER FROM` form and rows where the counterparty token follows `FROM` directly.
- **Applied to both aggregators.** Lunch Flow signs these correctly today so the gate leaves it inert, but neither feed can now regress the same way unnoticed.

`transaction_sources.direction_overridden` records when the rule fires. It lives on the join row rather than on `transactions` because in the reconcile-match branch the heuristic only changed *which side we searched* — the matched transaction's own direction came from the other aggregator. It is written on create only: the flag is a historical fact about the first writer's import decision, not a re-derivation, and resync never re-derives `src`/`dest` either.

Note for whoever picks up #168: the flag is per-source, and a reconciled transaction legitimately carries one `true` and one `false` source. Any per-transaction question has to be `transaction_sources.exists?(direction_overridden: true)`, not a single boolean — so it cannot be a naive per-transaction badge.

## Test plan

| Coverage | Where |
| --- | --- |
| Sign rule unchanged for ordinary negative / positive / zero amounts | `test/services/transaction/infer_ledger_side_test.rb` |
| Negative `TRANSFERRED FROM` overrides to `:dest`; positive does not; negative `TRANSFERRED TO` stays on `:src` | same |
| Regex variants: un-suffixed `TRANSFER FROM`, token directly after `FROM`, lower case, extra whitespace, `WIRE TRANSFER FROM` | same |
| Non-matches: `FROM` inside a longer word, `TRANSFER`/`FROM` non-adjacent, nil description | same |
| Import puts the ledger account on `dest` with a revenue counterpart and a single-counted balance | `test/jobs/simplefin/import_transactions_job_test.rb` |
| `direction_overridden` true only when the rule fires, in both attach branches | same |
| **The duplicate is not created**: a negative SimpleFIN `TRANSFERRED FROM` reconciles onto the correctly-signed Lunch Flow leg instead of duplicating, and the balance stays at 1× | same |
| The two legs become mergeable into a transfer (pre-fix both sat on `src`, so `Merge` refused) | same |
| A balance-sheet import rule now lands on the correct side | same |
| Residual risk pinned: a legitimately-negative returned transfer is still flipped | same |
| Lunch Flow inert case, override case, and merchant-over-description precedence | `test/jobs/lunchflow/import_transactions_job_test.rb` |
| `Attach` defaults the flag to false, records true, and does not rewrite it on the idempotent find path | `test/services/transaction_source/attach_test.rb` |

Verified the new tests are load-bearing: with `INBOUND_TRANSFER_PATTERN` temporarily neutered, exactly the six override-dependent SimpleFIN tests fail — including the reconcile test, where the balance assertion drops to `0` because the duplicate points the other way — while the two inert-case tests still pass.

Local run: 918 tests / 0 failures, 69 system tests / 0 failures, RuboCop clean, Brakeman 0 warnings, bundler-audit and importmap audit clean.

## Out of scope

- **No backfill.** Rows imported before this change keep their wrong direction; the resync branch deliberately never re-derives `src`/`dest` (that is what produced #137). Cleanup of the observed duplicates is tracked by #221 and #223. Users with existing bad rows will see a same-named expense/revenue account pair, since the corrected direction creates the revenue counterpart the row should always have had.
- **CSV.** `Csv::ImportTransactionsJob` computes the identical `ledger_side` and would have the same bug on an export from the same institution, but its descriptions are user-authored with no provider signing convention behind them. With the shared service in place it is a two-line addition later.
- **The outbound leg.** `TRANSFERRED TO` at a negative amount is already correct, so the pair is now *consistent* but still two separate rows unless merged or ruled. This closes the duplicate / 2× balance bug, not transfer handling generally.
- **UI.** Surfacing the flag belongs to #168/#223.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
