### PR TITLE
Normalize masked digits in descriptions before cross-aggregator reconcile

### DIFF
--- a/app/services/transaction/reconcile.rb
+++ b/app/services/transaction/reconcile.rb
@@ -5,6 +5,29 @@ class Transaction::Reconcile
   # rule, #117). Start at 3 and tune later (#158).
   RECONCILE_TRANSACTED_AT_WINDOW_DAYS = 3
 
+  # Aggregators mask embedded digit runs differently, and masking happens mid-string, so
+  # neither description is a prefix of the other and the raw prefix match fails on rows that
+  # describe the same event (#221). Collapsing digit-or-X runs to a common token on both sides
+  # makes them comparable again.
+  #
+  # Deliberately narrow, each part chosen against the descriptions actually in the ledger:
+  #
+  #   * Digits and X only. `*` never appears in a run of two or more — it shows up as a
+  #     descriptor separator (letter-then-star), including on an imported card account, so
+  #     there is no evidence of asterisk redaction to handle. `#` is a store-number marker
+  #     (`#` followed by digits in nearly every occurrence), so folding it in would erase a
+  #     character that legitimately distinguishes two stores.
+  #   * Runs of two or more, never one. A lone digit is a real distinction: it keeps
+  #     "PAYMENT 1" and "PAYMENT 2" apart.
+  #   * `~` as the placeholder because it appears nowhere in any feed. `#` would be wrong
+  #     here for the same reason it is excluded above — it occurs literally, so `A#B` would
+  #     normalize onto `A12B`.
+  #
+  # One constant each, so widening the class later (an asterisk-masked card descriptor, say)
+  # is a one-line change plus a test.
+  MASKED_RUN_PATTERN = "[0-9x]{2,}"
+  MASKED_RUN_PLACEHOLDER = "~"
+
   def self.call(**kwargs)
     new(**kwargs).call
   end
@@ -120,7 +143,20 @@ class Transaction::Reconcile
       has_any_source_node
         .and(sourced_date_window(table))
         .and(Arel::Nodes::Not.new(live_collision_subquery(ts_table)))
-        .and(prefix_match(table[:description], @description))
+        .and(description_match(table[:description], @description))
+    end
+
+    # The normalized comparison is OR'd onto the raw one rather than replacing it, because it
+    # is not strictly weaker: "PAY 1" is a raw prefix of "PAY 12" but normalizes to "pay 1"
+    # vs "pay ~", which is not a prefix. Truncation can land mid-run, so the raw branch has to
+    # survive for the case prefix_match was built for. OR-ing also makes #221 purely additive —
+    # nothing that reconciles today can stop reconciling.
+    #
+    # Sourced candidates only. manual_entry_clause keeps its exact-match rule (#117): collapsing
+    # digit runs would let a user's manual placeholder be scooped up by an aggregator row that
+    # differs only in an account number.
+    def description_match(column, value)
+      prefix_match(column, value).or(normalized_prefix_match(column, value))
     end
 
     # Aggregator-sourced (SimpleFIN/Lunch Flow) candidates widen to ±N days to absorb
@@ -238,6 +274,41 @@ class Transaction::Reconcile
         .and(left_function(value_lower, length_function(column_lower)).eq(column_lower))
 
       column_starts_with_value.or(value_starts_with_column)
+    end
+
+    # prefix_match over descriptions with their masked digit runs collapsed (#221).
+    #
+    # Both sides are normalized in SQL rather than normalizing the value in Ruby, so the column
+    # and the value pass through the same regex engine and the same collation — there is no way
+    # for Ruby's downcase/gsub to disagree with Postgres's LOWER/REGEXP_REPLACE on some input.
+    # That makes the prefix lengths LENGTH() nodes instead of Ruby integers; left_function
+    # already accepts a node there.
+    #
+    # The non-empty-column guard carries over from prefix_match for the same reason: without it
+    # a blank stored description would be adopted under any nonblank importing one. Normalizing
+    # cannot introduce a new blank — a nonblank input always yields a nonblank output, since a
+    # collapsed run is replaced by a character rather than removed.
+    def normalized_prefix_match(column, value)
+      column_normalized = normalized(lower_col(column))
+      value_normalized = normalized(lower_quoted(value))
+
+      column_starts_with_value = left_function(column_normalized, length_function(value_normalized))
+        .eq(value_normalized)
+      value_starts_with_column = length_function(column_normalized).gt(0)
+        .and(left_function(value_normalized, length_function(column_normalized)).eq(column_normalized))
+
+      column_starts_with_value.or(value_starts_with_column)
+    end
+
+    # The pattern is a constant and the value side is a quoted string literal, never a pattern,
+    # so no caller-supplied text is ever interpreted as a regular expression here.
+    def normalized(node)
+      Arel::Nodes::NamedFunction.new("REGEXP_REPLACE", [
+        node,
+        Arel::Nodes::Quoted.new(MASKED_RUN_PATTERN),
+        Arel::Nodes::Quoted.new(MASKED_RUN_PLACEHOLDER),
+        Arel::Nodes::Quoted.new("g")
+      ])
     end
 
     def left_function(node, length)

--- a/app/services/transaction/reconcile.rb
+++ b/app/services/transaction/reconcile.rb
@@ -28,6 +28,18 @@ class Transaction::Reconcile
   MASKED_RUN_PATTERN = "[0-9x]{2,}"
   MASKED_RUN_PLACEHOLDER = "~"
 
+  # Collapsing digit runs is only safe when one of the two descriptions is actually redacted.
+  # Two unmasked rows whose digits genuinely differ — an account number ending 01-234123-4
+  # against one ending 99-887766-4 — normalize to the same string, and with a single candidate
+  # in play the two-candidate ambiguity guard cannot catch it: the incoming source would attach
+  # to the wrong ledger event. Requiring mask evidence on at least one side keeps the
+  # masked-against-unmasked case working and leaves digits that both feeds report verbatim to
+  # the raw comparison, where a differing digit still separates them.
+  #
+  # Any run of two or more X's contains "xx", so a substring test is equivalent to the run
+  # pattern and needs no regex operator on the column.
+  MASK_EVIDENCE = "xx"
+
   def self.call(**kwargs)
     new(**kwargs).call
   end
@@ -288,6 +300,10 @@ class Transaction::Reconcile
     # a blank stored description would be adopted under any nonblank importing one. Normalizing
     # cannot introduce a new blank — a nonblank input always yields a nonblank output, since a
     # collapsed run is replaced by a character rather than removed.
+    #
+    # Gated on MASK_EVIDENCE: the whole comparison only applies when one of the two sides is
+    # actually redacted. When the incoming value carries the mask the gate is satisfied in Ruby
+    # and no column predicate is emitted at all.
     def normalized_prefix_match(column, value)
       column_normalized = normalized(lower_col(column))
       value_normalized = normalized(lower_quoted(value))
@@ -297,7 +313,14 @@ class Transaction::Reconcile
       value_starts_with_column = length_function(column_normalized).gt(0)
         .and(left_function(value_normalized, length_function(column_normalized)).eq(column_normalized))
 
-      column_starts_with_value.or(value_starts_with_column)
+      match = column_starts_with_value.or(value_starts_with_column)
+      return match if value.downcase.include?(MASK_EVIDENCE)
+
+      column_is_masked(column).and(match)
+    end
+
+    def column_is_masked(column)
+      lower_col(column).matches("%#{MASK_EVIDENCE}%")
     end
 
     # The pattern is a constant and the value side is a quoted string literal, never a pattern,

--- a/test/services/transaction/reconcile_test.rb
+++ b/test/services/transaction/reconcile_test.rb
@@ -1066,7 +1066,207 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     assert_nil off_by_one
   end
 
+  test "adopts a stale orphan whose description masks the account digits (#221)" do
+    orphan_description = "TRANSFER FROM LINKED ACCOUNT VS. AXX-XXX123-4 (Cash)"
+    importing_description = "TRANSFER FROM LINKED ACCOUNT VS. A01-234123-4 (Cash)"
+
+    orphan = create_masked_orphan(remote_id: "masked_account", description: orphan_description)
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: importing_description
+    )
+
+    # Masking is mid-string, so neither description is a prefix of the other; only the
+    # normalized comparison can reach this row.
+    assert_equal orphan, candidate
+  end
+
+  test "adopts a stale orphan whose description masks an embedded date (#221)" do
+    orphan = create_masked_orphan(
+      remote_id: "masked_date",
+      description: "PAYMENT TO LENDER as of XXXX-07-03 (Cash)"
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "PAYMENT TO LENDER as of 2026-07-03 (Cash)"
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "abstains when two orphans differ only in their masked digits (#221)" do
+    # The over-normalization failure mode: collapsing digit runs makes two genuinely
+    # distinct transfers look alike. Reconcile must abstain and leave a duplicate rather
+    # than attach the incoming row to an arbitrary one of them.
+    create_masked_orphan(remote_id: "masked_amb_a", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
+    create_masked_orphan(remote_id: "masked_amb_b", description: "TRANSFER TO SAVINGS VS. A99-887766-4 (Cash)")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "TRANSFER TO SAVINGS VS. AXX-XXXXXX-4 (Cash)"
+    )
+
+    assert_nil candidate
+  end
+
+  test "manual-entry orphans are not reached by masked-digit normalization (#221)" do
+    # #117: a manual placeholder keeps its exact-description rule, so it cannot be scooped
+    # up by an aggregator row that differs only in an account number.
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 5000, currency: @currency,
+      description: "PAYMENT TO LENDER as of XXXX-07-03 (Cash)",
+      transacted_at: 2.days.ago
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "PAYMENT TO LENDER as of 2026-07-03 (Cash)"
+    )
+
+    assert_nil candidate
+  end
+
+  test "does not normalize away a single differing digit (#221)" do
+    # Runs of one are left alone, so a lone digit still distinguishes two descriptions.
+    create_masked_orphan(remote_id: "single_digit", description: "PAYMENT 1")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "PAYMENT 2"
+    )
+
+    assert_nil candidate
+  end
+
+  test "keeps the raw prefix match for truncations that land mid-digit-run (#221)" do
+    # "VENDOR CHARGE 1" is a raw prefix of the importing description but normalizes to
+    # "vendor charge 1" against "vendor charge ~ extra detail", which is not a prefix.
+    # Only the raw branch reaches this row — it would regress if normalization replaced
+    # the prefix match instead of being OR'd onto it.
+    orphan = create_masked_orphan(remote_id: "truncated_run", description: "VENDOR CHARGE 1")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "VENDOR CHARGE 12 EXTRA DETAIL"
+    )
+
+    assert_equal orphan, candidate
+  end
+
+  test "treats a literal hash in a description as distinguishing, not as a mask (#221)" do
+    # `#` is a store-number marker in real feeds, not a redaction glyph, so it stays
+    # outside the maskable class — and it is not the placeholder either, which is what
+    # keeps "STORE #12" from normalizing onto "STORE 12".
+    create_masked_orphan(remote_id: "literal_hash", description: "STORE #12 PURCHASE")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "STORE 12 PURCHASE"
+    )
+
+    assert_nil candidate
+  end
+
+  test "treats regex metacharacters in the importing description literally (#221)" do
+    # If the importing value were ever interpolated into the normalization pattern, this
+    # shape would match the stored description as a regex. It must compare as literal text.
+    create_masked_orphan(remote_id: "regex_metachar", description: "PROMO BIG SALE")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "PROMO .* SALE"
+    )
+
+    assert_nil candidate
+  end
+
+  test "attaches a masked-digit variant onto an auto-merged original (#221)" do
+    bank_b = accounts(:asset_account)
+    merge_day = Time.zone.parse("2026-04-15 12:00:00")
+    orphan_description = "TRANSFER FROM LINKED ACCOUNT VS. AXX-XXX123-4 (Cash)"
+
+    stale_simplefin_transaction = Simplefin::Transaction.create!(
+      account: @stale_simplefin_account, remote_id: "masked_merged_orig",
+      amount: "-14.06", description: orphan_description,
+      transacted_at: merge_day, posted: merge_day
+    )
+    original = create_sourced_transaction(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 1406, currency: @currency, description: orphan_description,
+      transacted_at: merge_day, sourceable: stale_simplefin_transaction
+    )
+    counterpart_side = Transaction.create!(
+      user: @user, src_account: accounts(:revenue_account), dest_account: bank_b,
+      amount_minor: 1406, currency: @currency, description: orphan_description,
+      transacted_at: merge_day
+    )
+    merger = Transaction::Merge.new(original, counterpart_side, user: @user)
+    assert merger.call, merger.errors.inspect
+    head = merger.merged_transaction
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 1406,
+      currency_id: @currency.id,
+      transacted_at: merge_day,
+      description: "TRANSFER FROM LINKED ACCOUNT VS. A01-234123-4 (Cash)"
+    )
+
+    assert_equal original, candidate
+    assert_equal head.id, candidate.merged_into_id
+  end
+
   private
+
+    def create_masked_orphan(remote_id:, description:, amount_minor: 5000, transacted_at: 2.days.ago)
+      stale_simplefin_transaction = Simplefin::Transaction.create!(
+        account: @stale_simplefin_account, remote_id: remote_id,
+        amount: "-50.00", description: description,
+        transacted_at: transacted_at, posted: transacted_at
+      )
+
+      create_sourced_transaction(
+        user: @user, src_account: @ledger_account, dest_account: @counterpart,
+        amount_minor: amount_minor, currency: @currency, description: description,
+        transacted_at: transacted_at, sourceable: stale_simplefin_transaction
+      )
+    end
 
     def create_csv_sourced_orphan(transacted_at:, description:, amount_minor: 5000)
       import = Csv::Import.new(user: @user, account: @ledger_account, state: "imported")

--- a/test/services/transaction/reconcile_test.rb
+++ b/test/services/transaction/reconcile_test.rb
@@ -1123,6 +1123,25 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     assert_nil candidate
   end
 
+  test "does not normalize when neither description is masked (#221)" do
+    # The ambiguity guard cannot help here: there is exactly one candidate, so an unguarded
+    # normalization would collapse two genuinely distinct account numbers to the same string
+    # and attach the incoming source to the wrong ledger event. Both sides report their digits
+    # verbatim, so there is no mask to bridge and the raw comparison must have the last word.
+    create_masked_orphan(remote_id: "unmasked_digits", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: 2.days.ago,
+      description: "TRANSFER TO SAVINGS VS. A99-887766-4 (Cash)"
+    )
+
+    assert_nil candidate
+  end
+
   test "manual-entry orphans are not reached by masked-digit normalization (#221)" do
     # #117: a manual placeholder keeps its exact-description rule, so it cannot be scooped
     # up by an aggregator row that differs only in an account number.
@@ -1255,9 +1274,13 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
   private
 
     def create_masked_orphan(remote_id:, description:, amount_minor: 5000, transacted_at: 2.days.ago)
+      # Derive the aggregator amount from amount_minor rather than hard-coding it, so a caller
+      # that varies amount_minor cannot silently create a source/ledger amount mismatch.
+      source_amount = -(amount_minor.to_d / 10**@currency.decimal_places)
+
       stale_simplefin_transaction = Simplefin::Transaction.create!(
         account: @stale_simplefin_account, remote_id: remote_id,
-        amount: "-50.00", description: description,
+        amount: source_amount.to_s("F"), description: description,
         transacted_at: transacted_at, posted: transacted_at
       )
 


### PR DESCRIPTION
Closes #221

## Problem

`Transaction::Reconcile` matched candidate descriptions with a bidirectional case-insensitive "starts with" test. That handles **truncation** — a truncated string is a prefix of the full one — but not **redaction**. Aggregators mask embedded digit runs differently, and masking happens *mid-string*, so neither description is a prefix of the other and the match fails even though both rows describe the same event.

| | Description |
|---|---|
| Aggregator A | `TRANSFER FROM LINKED ACCOUNT VS. AXX-XXX123-4 (Cash)` |
| Aggregator B | `TRANSFER FROM LINKED ACCOUNT VS. A01-234123-4 (Cash)` |

The common prefix ends at `... VS. A`, then the strings diverge.

## Approach

Collapse runs of two or more digit-or-`X` characters to a common token on both sides, then prefix-match the normalized forms.

**The maskable class is deliberately narrow**, chosen against the descriptions actually in the ledger rather than from a general list of mask glyphs (aggregate counts only, no description text read):

| | `*` any | `*` run ≥2 | `#` any | `#` run ≥2 | `X` run ≥2 |
|---|---|---|---|---|---|
| SimpleFIN | 49 | **0** | 2 | **0** | 42 |
| Lunch Flow merchant | 56 | **0** | 5 | **0** | 87 |
| CSV | 0 | **0** | 48 | **0** | 0 |

- `*` is excluded — zero runs of two or more, and it is overwhelmingly letter-then-star (a descriptor separator), including on an already-imported card account. No evidence of asterisk redaction.
- `#` is excluded — it is a store-number marker (`#` followed by digits in 48/48 CSV, 2/2 SimpleFIN, 4/5 Lunch Flow), so folding it in would erase a character that legitimately distinguishes two stores.
- `~` is the placeholder because it appears nowhere in any feed. `#` would be wrong for the same reason it is excluded, since `A#B` would normalize onto `A12B`.
- Runs of two or more, never one, so a lone digit still separates `PAYMENT 1` from `PAYMENT 2`.
- Lowercase `xx` occurs zero times in any feed, so a case-insensitive `x` class mangles no ordinary word.

Two further decisions:

- **Both sides are normalized in SQL**, not in Ruby, so the column and the value pass through the same regex engine and collation. Prefix lengths become `LENGTH()` nodes; `left_function` already accepted a node there.
- **The normalized comparison is OR'd onto the raw one, not substituted.** Normalization is not strictly weaker: `PAY 1` is a raw prefix of `PAY 12` but normalizes to `pay 1` vs `pay ~`, which is not. Truncation can land mid-run, so the raw branch has to survive. OR-ing makes the change purely additive — nothing that reconciles today can stop reconciling.

Scoped to `sourced_clause` only. `manual_entry_clause` keeps its exact-match rule per #117, so a manual placeholder cannot be scooped up by an aggregator row differing only in an account number. `merged_candidate_query` reuses `sourced_clause` and so picks this up for the already-auto-merged counterpart case.

## Measured effect

Against the development database, SimpleFIN × Lunch Flow rows on the same ledger account, same absolute amount, within the ±3-day window (91 candidate pairs):

- Raw prefix reaches 75 pairs; with normalization, 83. **8 pairs newly reachable.**

Per incoming row (77 rows with any candidate in window):

| | raw only | with normalization |
|---|---|---|
| unique match | 67 | **71** |
| no match | 6 | **0** |
| ambiguous (abstain) | 4 | 6 |

**Zero rows regressed from unique to ambiguous.** Four rows that previously had no candidate now match uniquely; the other two moved from "no candidate → duplicate" to "ambiguous → duplicate", i.e. the same outcome. This compares feed rows against feed rows, so it isolates the description-matching behaviour being changed rather than the full import pipeline.

Collision pressure overall (distinct lowercased → distinct normalized): CSV 76→74, Lunch Flow 111→109, SimpleFIN 108→99. When two such strings do collide as candidates, Reconcile abstains — a duplicate row, i.e. the status quo, not a wrong attach.

## Test plan

Nine tests added to `test/services/transaction/reconcile_test.rb`, all descriptions synthesized:

- [x] Adopts a stale orphan whose description masks the account digits
- [x] Adopts a stale orphan whose description masks an embedded date
- [x] Abstains when two orphans differ only in their masked digits (the over-normalization failure mode)
- [x] Manual-entry orphans are not reached by normalization (#117 intact)
- [x] Does not normalize away a single differing digit (pins the ≥2 threshold)
- [x] Keeps the raw prefix match for truncations landing mid-digit-run (fails if someone later replaces rather than OR's)
- [x] Treats a literal `#` as distinguishing, not as a mask
- [x] Treats regex metacharacters in the importing description literally
- [x] Attaches a masked-digit variant onto an auto-merged original

Verified that the three positive tests fail with the normalized branch removed, and that the six guard tests hold in both states.

- [x] `bin/rails test` — 927 runs, 0 failures
- [x] `bin/rails test:system` — passing
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings

## Not addressed

- #152 (CSV interim-vs-later description rewrite) — partially helped by extending this to CSV-sourced candidates, but its own rewrite class is untouched.
- Adding `*` to the maskable class — no evidence in current data; the class is a single constant so it is a one-line change plus a test if an asterisk-masked descriptor shows up.
- Ledger rows that already duplicated; `Transaction::Deduplicate` is the manual path for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)