### PR TITLE
Break ambiguous reconcile ties by nearest date

### DIFF
--- a/app/services/transaction/reconcile.rb
+++ b/app/services/transaction/reconcile.rb
@@ -5,6 +5,12 @@ class Transaction::Reconcile
   # rule, #117). Start at 3 and tune later (#158).
   RECONCILE_TRANSACTED_AT_WINDOW_DAYS = 3
 
+  # How many candidates each query fetches before the tie-break (#197). The old limit(2) only had to
+  # answer "is there more than one?"; picking the nearest means seeing the whole set. Hitting the cap
+  # abstains: at that much ambiguity we cannot be sure the true nearest was even fetched, and
+  # abstaining is the conservative answer either way.
+  RECONCILE_TIE_BREAK_CANDIDATE_LIMIT = 10
+
   # Aggregators mask embedded digit runs differently, and masking happens mid-string, so
   # neither description is a prefix of the other and the raw prefix match fails on rows that
   # describe the same event (#221). Collapsing digit-or-X runs to a common token on both sides
@@ -60,20 +66,60 @@ class Transaction::Reconcile
   def call
     return nil if @description.blank?
 
-    # Abstain immediately if the live orphans alone are already ambiguous.
-    live_candidates = candidate_query.limit(2).to_a
-    return nil if live_candidates.size >= 2
+    live_candidates = fetch_candidates(candidate_query)
+    merged_candidates = fetch_candidates(merged_candidate_query)
+    return nil if live_candidates.size >= RECONCILE_TIE_BREAK_CANDIDATE_LIMIT ||
+      merged_candidates.size >= RECONCILE_TIE_BREAK_CANDIDATE_LIMIT
 
     # The first aggregator's side may have been auto-merged into a transfer (zeroed,
     # merged_into set), which the live query can't see because it matches on
-    # amount_minor. Consider live and merged candidates together so that a live +
-    # merged collision within the widened window is treated as ambiguous rather than
-    # silently attaching to the live row and hiding the merged event (#158).
-    candidates = live_candidates + merged_candidate_query.limit(2).to_a
-    candidates.size == 1 ? candidates.first : nil
+    # amount_minor. A live + merged collision within the widened window stays ambiguous
+    # rather than silently attaching to the live row and hiding the merged event (#158).
+    #
+    # Deliberately carved out of the #197 tie-break rather than overlooked by it. Date
+    # proximity could rank these two against each other, but #158 abstained on the shape
+    # itself, not merely on the count, and hiding a merged event is a different kind of
+    # damage from attaching to the wrong one of two equals. Revisit as its own decision.
+    return nil if live_candidates.any? && merged_candidates.any?
+
+    candidates = live_candidates.presence || merged_candidates
+    return nil if candidates.empty?
+    return candidates.first if candidates.size == 1
+
+    nearest_candidate(candidates)
   end
 
   private
+
+    # transaction_sources is preloaded because nearest_candidate inspects it per candidate; the set
+    # is capped either way, but this keeps it to one extra query instead of one per row.
+    def fetch_candidates(query)
+      query.includes(:transaction_sources).limit(RECONCILE_TIE_BREAK_CANDIDATE_LIMIT).to_a
+    end
+
+    # Several candidates matched amount, currency, direction, description and the window, so the
+    # only signal left is date proximity. Take the candidate that is *strictly* nearest; anything
+    # equidistant keeps abstaining, which is the pre-#197 behaviour for the whole set (#197).
+    def nearest_candidate(candidates)
+      # A manual entry is same-day by construction (manual_entry_clause), so it would win every
+      # tie-break it took part in. Adopting a hand-entered row on date proximity alone is a call
+      # for a human to confirm, not for the importer to make silently — those pairs belong in the
+      # suggestion surface (#223), so any manual candidate in the running abstains the whole set.
+      # A lone manual candidate never reaches here and is still adopted as before (#117).
+      return nil if candidates.any? { |candidate| candidate.transaction_sources.empty? }
+
+      nearest = candidates.group_by { |candidate| day_distance(candidate) }.min_by(&:first).last
+      nearest.size == 1 ? nearest.first : nil
+    end
+
+    # Calendar days, not raw timestamps. Aggregators disagree on time-of-day precision — Lunch Flow
+    # stores a DATE (so its ledger rows sit at midnight) while SimpleFIN carries a real posted time —
+    # so an incoming afternoon row measures *closer* to the next midnight than to its own day's, and
+    # timestamp distance would systematically pick the wrong day. Day distance also keeps a same-day
+    # cluster equidistant, which is the ambiguity the count-based rule already declined to resolve.
+    def day_distance(candidate)
+      (candidate.transacted_at.to_date - @transacted_at.to_date).to_i.abs
+    end
 
     def candidate_query
       # Direction-aware: an incoming charge (ledger on src) must only match a

--- a/test/services/transaction/reconcile_test.rb
+++ b/test/services/transaction/reconcile_test.rb
@@ -1070,7 +1070,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     orphan_description = "TRANSFER FROM LINKED ACCOUNT VS. AXX-XXX123-4 (Cash)"
     importing_description = "TRANSFER FROM LINKED ACCOUNT VS. A01-234123-4 (Cash)"
 
-    orphan = create_masked_orphan(remote_id: "masked_account", description: orphan_description)
+    orphan = create_aggregator_orphan(remote_id: "masked_account", description: orphan_description)
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1087,7 +1087,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
   end
 
   test "adopts a stale orphan whose description masks an embedded date (#221)" do
-    orphan = create_masked_orphan(
+    orphan = create_aggregator_orphan(
       remote_id: "masked_date",
       description: "PAYMENT TO LENDER as of XXXX-07-03 (Cash)"
     )
@@ -1108,8 +1108,8 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     # The over-normalization failure mode: collapsing digit runs makes two genuinely
     # distinct transfers look alike. Reconcile must abstain and leave a duplicate rather
     # than attach the incoming row to an arbitrary one of them.
-    create_masked_orphan(remote_id: "masked_amb_a", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
-    create_masked_orphan(remote_id: "masked_amb_b", description: "TRANSFER TO SAVINGS VS. A99-887766-4 (Cash)")
+    create_aggregator_orphan(remote_id: "masked_amb_a", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
+    create_aggregator_orphan(remote_id: "masked_amb_b", description: "TRANSFER TO SAVINGS VS. A99-887766-4 (Cash)")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1128,7 +1128,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     # normalization would collapse two genuinely distinct account numbers to the same string
     # and attach the incoming source to the wrong ledger event. Both sides report their digits
     # verbatim, so there is no mask to bridge and the raw comparison must have the last word.
-    create_masked_orphan(remote_id: "unmasked_digits", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
+    create_aggregator_orphan(remote_id: "unmasked_digits", description: "TRANSFER TO SAVINGS VS. A01-234123-4 (Cash)")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1166,7 +1166,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
 
   test "does not normalize away a single differing digit (#221)" do
     # Runs of one are left alone, so a lone digit still distinguishes two descriptions.
-    create_masked_orphan(remote_id: "single_digit", description: "PAYMENT 1")
+    create_aggregator_orphan(remote_id: "single_digit", description: "PAYMENT 1")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1185,7 +1185,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     # "vendor charge 1" against "vendor charge ~ extra detail", which is not a prefix.
     # Only the raw branch reaches this row — it would regress if normalization replaced
     # the prefix match instead of being OR'd onto it.
-    orphan = create_masked_orphan(remote_id: "truncated_run", description: "VENDOR CHARGE 1")
+    orphan = create_aggregator_orphan(remote_id: "truncated_run", description: "VENDOR CHARGE 1")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1203,7 +1203,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     # `#` is a store-number marker in real feeds, not a redaction glyph, so it stays
     # outside the maskable class — and it is not the placeholder either, which is what
     # keeps "STORE #12" from normalizing onto "STORE 12".
-    create_masked_orphan(remote_id: "literal_hash", description: "STORE #12 PURCHASE")
+    create_aggregator_orphan(remote_id: "literal_hash", description: "STORE #12 PURCHASE")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1220,7 +1220,7 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
   test "treats regex metacharacters in the importing description literally (#221)" do
     # If the importing value were ever interpolated into the normalization pattern, this
     # shape would match the stored description as a regex. It must compare as literal text.
-    create_masked_orphan(remote_id: "regex_metachar", description: "PROMO BIG SALE")
+    create_aggregator_orphan(remote_id: "regex_metachar", description: "PROMO BIG SALE")
 
     candidate = Transaction::Reconcile.call(
       ledger_account: @ledger_account,
@@ -1271,9 +1271,228 @@ class Transaction::ReconcileTest < ActiveSupport::TestCase
     assert_equal head.id, candidate.merged_into_id
   end
 
+  test "adopts the strictly nearest candidate when several match (#197)" do
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+    description = "RECURRING VENDOR CHARGE"
+
+    nearest = create_aggregator_orphan(
+      remote_id: "tiebreak_near", description: description, transacted_at: incoming_day - 1.day
+    )
+    create_aggregator_orphan(
+      remote_id: "tiebreak_far", description: description, transacted_at: incoming_day - 3.days
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: description
+    )
+
+    assert_equal nearest, candidate
+  end
+
+  test "abstains when two candidates are equidistant (#197)" do
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+    description = "RECURRING VENDOR CHARGE"
+
+    create_aggregator_orphan(
+      remote_id: "equi_before", description: description, transacted_at: incoming_day - 1.day
+    )
+    create_aggregator_orphan(
+      remote_id: "equi_after", description: description, transacted_at: incoming_day + 1.day
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: description
+    )
+
+    assert_nil candidate
+  end
+
+  test "measures distance in calendar days rather than raw timestamps (#197)" do
+    # Lunch Flow stores a DATE, so its ledger rows sit at midnight, while an incoming SimpleFIN
+    # row carries a real posted time. An afternoon incoming row is fewer *hours* from the next
+    # day's midnight than from its own day's, so timestamp distance would pick the wrong day.
+    incoming_day = Time.zone.parse("2026-04-15 14:00:00")
+
+    same_day = create_aggregator_orphan(
+      remote_id: "granularity_same_day", description: "RECURRING VENDOR CHARGE",
+      transacted_at: Time.zone.parse("2026-04-15 00:00:00")
+    )
+    create_aggregator_orphan(
+      remote_id: "granularity_next_day", description: "RECURRING VENDOR CHARGE",
+      transacted_at: Time.zone.parse("2026-04-16 00:00:00")
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: "RECURRING VENDOR CHARGE"
+    )
+
+    assert_equal same_day, candidate
+  end
+
+  test "abstains for a same-day cluster at differing times (#197)" do
+    # Same calendar day means equidistant, so the cluster stays as ambiguous as it was before
+    # the tie-break existed.
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+
+    create_aggregator_orphan(
+      remote_id: "cluster_early", description: "RECURRING VENDOR CHARGE",
+      transacted_at: Time.zone.parse("2026-04-15 01:00:00")
+    )
+    create_aggregator_orphan(
+      remote_id: "cluster_late", description: "RECURRING VENDOR CHARGE",
+      transacted_at: Time.zone.parse("2026-04-15 05:00:00")
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: "RECURRING VENDOR CHARGE"
+    )
+
+    assert_nil candidate
+  end
+
+  test "abstains when a manual entry is in the running, even as the nearest (#197)" do
+    # Adopting a hand-entered row on date proximity alone is a call for a human to confirm, so
+    # the pair goes to the suggestion surface (#223) rather than being attached here.
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+    description = "RECURRING VENDOR CHARGE"
+
+    Transaction.create!(
+      user: @user, src_account: @ledger_account, dest_account: @counterpart,
+      amount_minor: 5000, currency: @currency, description: description,
+      transacted_at: incoming_day
+    )
+    create_aggregator_orphan(
+      remote_id: "manual_competitor", description: description, transacted_at: incoming_day + 2.days
+    )
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: description
+    )
+
+    assert_nil candidate
+  end
+
+  test "abstains when a live orphan and a merged original sit at different distances (#158/#197)" do
+    # The #158 carve-out: date proximity must not resolve this shape, because hiding a merged
+    # event is a different kind of damage from picking the wrong one of two equals. The existing
+    # #158 test is equidistant and so cannot detect a regression here.
+    bank_b = accounts(:asset_account)
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+    description = "RECURRING VENDOR CHARGE"
+
+    create_aggregator_orphan(
+      remote_id: "distance_live", description: description, transacted_at: incoming_day
+    )
+
+    merged_day = incoming_day + 2.days
+    original = create_aggregator_orphan(
+      remote_id: "distance_merged", description: description, transacted_at: merged_day
+    )
+    counterpart_side = Transaction.create!(
+      user: @user, src_account: accounts(:revenue_account), dest_account: bank_b,
+      amount_minor: 5000, currency: @currency, description: description,
+      transacted_at: merged_day
+    )
+    assert Transaction::Merge.new(original, counterpart_side, user: @user).call
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: description
+    )
+
+    assert_nil candidate
+  end
+
+  test "abstains when the candidate set fills the tie-break fetch limit (#197)" do
+    # One candidate is uniquely nearest, so without the cap guard the tie-break would attach.
+    # At this much ambiguity we cannot be sure the true nearest was even fetched.
+    incoming_day = Time.zone.parse("2026-04-15 12:00:00")
+    description = "RECURRING VENDOR CHARGE"
+
+    create_aggregator_orphan(
+      remote_id: "cap_nearest", description: description, transacted_at: incoming_day
+    )
+    (Transaction::Reconcile::RECONCILE_TIE_BREAK_CANDIDATE_LIMIT - 1).times do |index|
+      create_aggregator_orphan(
+        remote_id: "cap_filler_#{index}", description: description,
+        transacted_at: incoming_day + 2.days
+      )
+    end
+
+    candidate = Transaction::Reconcile.call(
+      ledger_account: @ledger_account,
+      ledger_side: :src,
+      amount_minor: 5000,
+      currency_id: @currency.id,
+      transacted_at: incoming_day,
+      description: description
+    )
+
+    assert_nil candidate
+  end
+
+  test "pairs each of two incoming rows with its own same-day candidate (#197)" do
+    # The shape observed on a live account: two equal-amount charges on consecutive days, each
+    # reported by both aggregators. Counting candidates abstains on both; proximity resolves a
+    # clean 1:1 pairing.
+    first_day = Time.zone.parse("2026-04-15 12:00:00")
+    second_day = first_day + 1.day
+    description = "RECURRING VENDOR CHARGE"
+
+    first_orphan = create_aggregator_orphan(
+      remote_id: "pairing_first", description: description, transacted_at: first_day
+    )
+    second_orphan = create_aggregator_orphan(
+      remote_id: "pairing_second", description: description, transacted_at: second_day
+    )
+
+    reconcile_on = ->(day) do
+      Transaction::Reconcile.call(
+        ledger_account: @ledger_account,
+        ledger_side: :src,
+        amount_minor: 5000,
+        currency_id: @currency.id,
+        transacted_at: day,
+        description: description
+      )
+    end
+
+    assert_equal first_orphan, reconcile_on.call(first_day)
+    assert_equal second_orphan, reconcile_on.call(second_day)
+  end
+
   private
 
-    def create_masked_orphan(remote_id:, description:, amount_minor: 5000, transacted_at: 2.days.ago)
+    def create_aggregator_orphan(remote_id:, description:, amount_minor: 5000, transacted_at: 2.days.ago)
       # Derive the aggregator amount from amount_minor rather than hard-coding it, so a caller
       # that varies amount_minor cannot silently create a source/ledger amount mismatch.
       source_amount = -(amount_minor.to_d / 10**@currency.decimal_places)


### PR DESCRIPTION
Closes #197

## Problem

`Transaction::Reconcile` abstains whenever two or more candidates match, since attaching to the wrong row is worse than a duplicate. #195 widened the aggregator window to ±3 days, which makes that abstention fire on clusters of equal-amount, same-merchant charges even when the intended match is unambiguous by date proximity. The matcher only *counts* candidates — it has no notion of how far away they are.

Confirmed live after #221 merged. On one ledger account all 16 incoming SimpleFIN rows now attach and 13 reconcile, but two duplicate purely because of this:

| incoming | candidate A (07-14) | candidate B (07-13) | unique nearest |
|---|---|---|---|
| row on 07-14 | 0 days | 1 day | A |
| row on 07-13 | 1 day | 0 days | B |

A clean 1:1 pairing the current rule cannot see. #221 got these rows as far as the matcher; this is the only thing still blocking them.

## Approach

Take the candidate that is **strictly** nearest to the incoming date. Anything equidistant keeps abstaining — the previous behaviour for the whole set. The old `limit(2)` becomes `RECONCILE_TIE_BREAK_CANDIDATE_LIMIT` (10), since picking the nearest means seeing the whole set; hitting that cap abstains, because at that much ambiguity we cannot be sure the true nearest was even fetched.

### Distance is calendar days, not raw timestamps

This is the part worth reviewing closely. The two feeds disagree on time-of-day precision:

| | midnight | non-midnight |
|---|---|---|
| ledger transactions on the affected account | 329 | 11 |
| SimpleFIN `posted` (all rows) | **0** | 692 (210 after noon) |

Lunch Flow stores a `DATE`, so its ledger rows sit at midnight, while SimpleFIN carries a real posted time. Under timestamp distance an incoming row at 14:00 on day X measures **14h** from the same-day candidate but only **10h** from the next-day one — systematically picking the wrong day for every after-noon row.

Day distance also keeps a same-day cluster equidistant, which is ambiguity the count-based rule already declined to resolve.

I verified this by mutation: swapping `day_distance` for timestamp distance fails **four** tests, two of them pre-existing (`abstains when two stale-aggregator orphans both prefix-match` and the #221 masked-digits abstain) — both same-day clusters that stop being equidistant. Day granularity is required here, not merely preferred.

### Two shapes deliberately excluded

- **Manual entries.** `manual_entry_clause` is same-day only, so a manual candidate is always distance 0 and would win every tie-break it entered. Adopting a hand-entered row on proximity alone is a call for a human to confirm, so a candidate set containing any manual entry abstains and the pair belongs in #223's suggestion surface (which already lists #197 among the abstentions whose fallout it should catch). A *lone* manual candidate never reaches the tie-break and is still adopted as before, per #117.
- **Live + auto-merged collisions.** #158 abstained on this shape itself, not merely on the count, and hiding a merged event is a different kind of damage from picking the wrong one of two equals. Kept as an explicit early return with a comment recording that it is a carve-out, so revisiting it is a deliberate decision rather than an accident. The existing #158 test is equidistant (−1/+1) and so could not have caught a regression here; a new test covers the unequal-distance case.

## Test plan

Eight tests added to `test/services/transaction/reconcile_test.rb`:

- [x] Adopts the strictly nearest candidate when several match
- [x] Abstains when two candidates are equidistant
- [x] Measures distance in calendar days rather than raw timestamps
- [x] Abstains for a same-day cluster at differing times
- [x] Abstains when a manual entry is in the running, even as the nearest
- [x] Abstains when a live orphan and a merged original sit at different distances (#158 carve-out)
- [x] Abstains when the candidate set fills the tie-break fetch limit
- [x] Pairs each of two incoming rows with its own same-day candidate (the observed shape)

A ninth case from the plan — a lone manual candidate still being adopted — is already pinned by the existing `manual-entry orphans match case-insensitively on exact description`, so no duplicate was added.

Mutation-verified rather than assumed: disabling the tie-break fails exactly the three positive tests, and timestamp distance fails the four listed above.

- [x] `bin/rails test` — 936 runs, 0 failures
- [x] `bin/rails test:system` — 69 runs, 0 failures
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings

Also renames the test helper `create_masked_orphan` to `create_aggregator_orphan`; it was never specific to masking and the tie-break tests reuse it.

## Not addressed

- #223 / #145 — surfacing the abstentions that remain (manual pairs, equidistant clusters) for review.
- Revisiting the #158 live-vs-merged carve-out, now recorded in a comment for a later deliberate call.
- `Csv::ImportTransactionsJob#find_merged_duplicate_target`, which has its own within-aggregator matching path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)