### PR TITLE
Sign the opening-balance walk-back by ledger direction, not feed sign

### DIFF
--- a/app/jobs/lunchflow/import_transactions_job.rb
+++ b/app/jobs/lunchflow/import_transactions_job.rb
@@ -16,7 +16,7 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
         ledger_account = lft.account.ledger_accounts.first
         next if ledger_account.nil?
 
-        description = lft.merchant.presence || lft.description
+        description = lft.resolved_description
 
         # Direction is decided once per row and drives reconciliation, kind, and
         # src/dest assignment below. Normally the sign decides it: a negative amount
@@ -25,11 +25,9 @@ class Lunchflow::ImportTransactionsJob < ApplicationJob
         # negative has its inbound leg flipped by description (#222) — only the
         # direction is overridden, the amount is stored as .abs either way and
         # Lunchflow::Transaction stays a verbatim mirror. This feed signs those rows
-        # correctly today, so the negative? gate leaves it inert.
-        direction = Transaction::InferLedgerSide.call(
-          description: description,
-          amount_minor: lft.amount_minor
-        )
+        # correctly today, so the negative? gate leaves it inert. The rule lives on
+        # the row model so the opening-balance walk-back reads the same answer (#227).
+        direction = lft.ledger_direction
         ledger_side = direction.ledger_side
 
         existing_source = TransactionSource.find_by(sourceable: lft)

--- a/app/jobs/simplefin/import_transactions_job.rb
+++ b/app/jobs/simplefin/import_transactions_job.rb
@@ -22,11 +22,9 @@ class Simplefin::ImportTransactionsJob < ApplicationJob
         # (ledger on dest). One feed signs both legs of an internal transfer
         # negative, so an inbound transfer is flipped by description (#222) — only
         # the direction is overridden, the amount is stored as .abs either way and
-        # Simplefin::Transaction stays a verbatim mirror.
-        direction = Transaction::InferLedgerSide.call(
-          description: sft.description,
-          amount_minor: sft.amount_minor
-        )
+        # Simplefin::Transaction stays a verbatim mirror. The rule lives on the row
+        # model so the opening-balance walk-back reads the same answer (#227).
+        direction = sft.ledger_direction
         ledger_side = direction.ledger_side
 
         existing_source = TransactionSource.find_by(sourceable: sft)

--- a/app/models/concerns/aggregator_sourceable.rb
+++ b/app/models/concerns/aggregator_sourceable.rb
@@ -1,0 +1,39 @@
+# = AggregatorSourceable
+#
+# Shared behaviour for the raw aggregator transaction mirrors (Simplefin::Transaction,
+# Lunchflow::Transaction): how one incoming row will be posted to the ledger.
+#
+# The direction rule itself lives in Transaction::InferLedgerSide. This concern is the
+# single place that feeds it, so an importer and a balance walk-back cannot answer
+# "which way does this row go?" differently.
+#
+# Including models must define +resolved_description+ — the string the importer will
+# store, which is not always the +description+ column (Lunch Flow prefers +merchant+).
+module AggregatorSourceable
+  extend ActiveSupport::Concern
+
+  # The side of the ledger transaction this row's account lands on, plus whether the
+  # inbound-transfer override fired. See Transaction::InferLedgerSide.
+  def ledger_direction
+    Transaction::InferLedgerSide.call(
+      description: resolved_description,
+      amount_minor: amount_minor
+    )
+  end
+
+  # This row's contribution to the ledger balance, signed by the direction the importer
+  # will actually post it in rather than by the provider's sign.
+  #
+  # The importers store amount_minor.abs and let src/dest carry the direction (#222), so
+  # a balance reconstructed from the raw feed sign disagrees with the ledger by twice the
+  # amount of every overridden row (#227).
+  def signed_ledger_amount
+    row_amount = amount.to_d
+    # amount_minor is nil when the provider sent no amount (or no currency is resolvable);
+    # InferLedgerSide would raise on nil.negative?, and nil.to_d is 0, so there is no sign
+    # to apply.
+    return row_amount if amount_minor.nil?
+
+    ledger_direction.ledger_side == :dest ? row_amount.abs : -row_amount.abs
+  end
+end

--- a/app/models/lunchflow/account.rb
+++ b/app/models/lunchflow/account.rb
@@ -28,10 +28,12 @@ class Lunchflow::Account < ApplicationRecord
     amount = balance.to_d
     oldest_date = Date.current
 
-    transactions.each do |lf_transaction|
-      date = lf_transaction.date || lf_transaction.created_at.to_date
+    transactions.each do |lunchflow_transaction|
+      date = lunchflow_transaction.date || lunchflow_transaction.created_at.to_date
       oldest_date = date if date < oldest_date
-      amount -= lf_transaction.amount.to_d
+      # Signed by the direction the importer will post the row in, not by the feed's
+      # sign — the two disagree for an inbound transfer the feed signed negative (#227).
+      amount -= lunchflow_transaction.signed_ledger_amount
     end
 
     {

--- a/app/models/lunchflow/transaction.rb
+++ b/app/models/lunchflow/transaction.rb
@@ -1,5 +1,7 @@
 class Lunchflow::Transaction < ApplicationRecord
   include Minorable
+  include AggregatorSourceable
+
   minorable :amount, with: "account.ledger_currency"
 
   belongs_to :account
@@ -7,4 +9,10 @@ class Lunchflow::Transaction < ApplicationRecord
   has_many :ledger_transactions, through: :transaction_sources
 
   validates :remote_id, uniqueness: { scope: :account_id }, allow_nil: true
+
+  # The description the importer stores. Lunch Flow's merchant is the cleaner label
+  # when present, so it wins over the raw description.
+  def resolved_description
+    merchant.presence || description
+  end
 end

--- a/app/models/simplefin/account.rb
+++ b/app/models/simplefin/account.rb
@@ -42,7 +42,9 @@ class Simplefin::Account < ApplicationRecord
       ].compact.min
 
       oldest_date = date if date < oldest_date
-      amount -= simplefin_transaction.amount.to_d
+      # Signed by the direction the importer will post the row in, not by the feed's
+      # sign — the two disagree for an inbound transfer the feed signed negative (#227).
+      amount -= simplefin_transaction.signed_ledger_amount
     end
 
     {

--- a/app/models/simplefin/transaction.rb
+++ b/app/models/simplefin/transaction.rb
@@ -1,8 +1,17 @@
 class Simplefin::Transaction < ApplicationRecord
   include Minorable
+  include AggregatorSourceable
+
   minorable :amount, with: "account.ledger_currency"
 
   belongs_to :account
   has_many :transaction_sources, as: :sourceable, dependent: :destroy
   has_many :ledger_transactions, through: :transaction_sources
+
+  # The description the importer stores. SimpleFIN sends a single description field,
+  # so this is a straight pass-through — it exists for parity with Lunch Flow, which
+  # prefers its merchant field.
+  def resolved_description
+    description
+  end
 end

--- a/test/fixtures/simplefin/transactions.yml
+++ b/test/fixtures/simplefin/transactions.yml
@@ -20,7 +20,7 @@ transaction_two:
   pending: false
   extra:
 
-# Reconciled to $50.00 with $20.00 opening balance transaction
+# Reconciled to a $50.00 balance; the rows net to +$20.00, so the suggested opening balance is $30.00
 reconciled_one:
   account: reconciled_one
   remote_id: fixture_txn_3

--- a/test/jobs/simplefin/import_transactions_job_test.rb
+++ b/test/jobs/simplefin/import_transactions_job_test.rb
@@ -1282,6 +1282,48 @@ class Simplefin::ImportTransactionsJobTest < ActiveJob::TestCase
     assert_equal bank_b, transaction.dest_account
   end
 
+  # The whole point of the suggestion: acting on it should leave the linked account
+  # agreeing with the balance the bank reports. Before #227 the override made it
+  # overshoot by twice the transfer, so this landed 40.00 high.
+  test "an opening balance taken from the suggestion lands the linked account on the reported balance (#227)" do
+    sf_account = Simplefin::Account.create!(
+      connection: simplefin_connections(:one),
+      remote_id: "acc_opening_balance",
+      name: "SF Opening Balance Checking",
+      currency: "USD",
+      balance: "100.00",
+      balance_date: Time.current
+    )
+    Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_ob_charge", amount: "-30.00",
+      description: "Coffee Shop",
+      posted: 2.days.ago, transacted_at: 2.days.ago, pending: false
+    )
+    Simplefin::Transaction.create!(
+      account: sf_account, remote_id: "sf_ob_inbound", amount: "-20.00",
+      description: "TRANSFERRED FROM ACCT ****0001",
+      posted: 1.day.ago, transacted_at: 1.day.ago, pending: false
+    )
+
+    # Exactly what AccountsController#new pre-fills the form with.
+    suggestion = sf_account.suggested_opening_balance
+    assert_equal 110.to_d, suggestion[:amount]
+
+    bank_account = Account.create!(
+      user: @user,
+      currency: @currency,
+      name: "Linked SF Opening Balance Checking",
+      kind: :asset,
+      opening_balance_amount: suggestion[:amount],
+      opening_balance_transacted_at: suggestion[:transacted_at]
+    )
+    AccountSource.create!(account: bank_account, sourceable: sf_account)
+
+    Simplefin::ImportTransactionsJob.perform_now(simplefin_account_id: sf_account.id)
+
+    assert_equal 10_000, bank_account.reload.balance_minor
+  end
+
   private
 
     def create_linked_simplefin_account(remote_id: "acc_test", name: "SF Test Checking")

--- a/test/models/lunchflow/account_test.rb
+++ b/test/models/lunchflow/account_test.rb
@@ -50,13 +50,33 @@ class Lunchflow::AccountTest < ActiveSupport::TestCase
   test "suggested_opening_balance amount aligns with Lunch Flow transactions" do
     assert_not_empty @linked_lunchflow_account.transactions
 
-    amount_sum = @linked_lunchflow_account.transactions.reduce(0.to_d) do |sum, transaction|
-      sum + transaction.amount.to_d
-    end
+    # Fixture: 2500.00 reported balance and a single -75.00 row.
     result = @linked_lunchflow_account.suggested_opening_balance
 
-    expected_amount = @linked_lunchflow_account.balance.to_d - amount_sum
-    assert_equal expected_amount, result[:amount]
+    assert_equal 2575.to_d, result[:amount]
+  end
+
+  test "suggested_opening_balance walks back a negative inbound transfer as money arriving" do
+    lunchflow_account = build_lunchflow_account(balance: "100.00")
+    build_lunchflow_transaction(lunchflow_account, amount: "-30.00", merchant: "Test Merchant")
+    build_lunchflow_transaction(lunchflow_account, amount: "-20.00", merchant: "TRANSFERRED FROM Test Savings")
+
+    # 100.00 - (-30.00 + 20.00). Subtracting the raw feed signs would return 150.00.
+    assert_equal 110.to_d, lunchflow_account.suggested_opening_balance[:amount]
+  end
+
+  test "suggested_opening_balance reads the direction from the resolved description" do
+    lunchflow_account = build_lunchflow_account(balance: "100.00")
+    # The merchant wins over the description, exactly as the importer resolves it, so
+    # the transfer wording here is not what decides the direction.
+    build_lunchflow_transaction(
+      lunchflow_account,
+      amount: "-20.00",
+      merchant: "Test Merchant",
+      description: "TRANSFERRED FROM Test Savings"
+    )
+
+    assert_equal 120.to_d, lunchflow_account.suggested_opening_balance[:amount]
   end
 
   test "creating an account_source enqueues an import" do
@@ -66,4 +86,33 @@ class Lunchflow::AccountTest < ActiveSupport::TestCase
       AccountSource.create!(account: account, sourceable: @unlinked_lunchflow_account)
     end
   end
+
+  private
+
+    # Built here rather than added to the fixtures: test/system/integrations_test.rb
+    # asserts the exact list of fixture account names on the integrations page.
+    def build_lunchflow_account(balance:)
+      Lunchflow::Account.create!(
+        connection: lunchflow_connections(:one),
+        remote_id: "opening_balance_#{balance}",
+        institution_name: "Test Bank",
+        name: "Test Checking",
+        provider: "finicity",
+        status: "ACTIVE",
+        currency: "USD",
+        balance: balance
+      )
+    end
+
+    def build_lunchflow_transaction(lunchflow_account, amount:, merchant:, description: "Test Transaction")
+      lunchflow_account.transactions.create!(
+        remote_id: "opening_balance_txn_#{merchant}",
+        amount: amount,
+        currency: "USD",
+        description: description,
+        merchant: merchant,
+        date: 1.day.ago.to_date,
+        pending: false
+      )
+    end
 end

--- a/test/models/lunchflow/transaction_test.rb
+++ b/test/models/lunchflow/transaction_test.rb
@@ -8,4 +8,54 @@ class Lunchflow::TransactionTest < ActiveSupport::TestCase
   test "belongs to account" do
     assert_equal lunchflow_accounts(:linked_one), @lunchflow_transaction.account
   end
+
+  test "resolved_description prefers the merchant" do
+    assert_equal @lunchflow_transaction.merchant, @lunchflow_transaction.resolved_description
+  end
+
+  test "resolved_description falls back to the description when merchant is blank" do
+    @lunchflow_transaction.merchant = ""
+
+    assert_equal @lunchflow_transaction.description, @lunchflow_transaction.resolved_description
+  end
+
+  test "ledger_direction puts a negative amount on src" do
+    direction = @lunchflow_transaction.ledger_direction
+
+    assert_equal :src, direction.ledger_side
+    assert_not direction.direction_overridden?
+  end
+
+  test "ledger_direction reads the transfer wording from the merchant" do
+    @lunchflow_transaction.merchant = "TRANSFERRED FROM Test Savings"
+    direction = @lunchflow_transaction.ledger_direction
+
+    assert_equal :dest, direction.ledger_side
+    assert direction.direction_overridden?
+  end
+
+  test "ledger_direction ignores transfer wording the merchant shadows" do
+    @lunchflow_transaction.merchant = "Test Merchant"
+    @lunchflow_transaction.description = "TRANSFERRED FROM Test Savings"
+
+    assert_equal :src, @lunchflow_transaction.ledger_direction.ledger_side
+  end
+
+  test "signed_ledger_amount is negative for an outflow" do
+    assert_equal(-75.to_d, @lunchflow_transaction.signed_ledger_amount)
+  end
+
+  test "signed_ledger_amount is positive for a negative inbound transfer" do
+    @lunchflow_transaction.amount = "-20.00"
+    @lunchflow_transaction.merchant = "TRANSFERRED FROM Test Savings"
+
+    assert_equal 20.to_d, @lunchflow_transaction.signed_ledger_amount
+  end
+
+  test "signed_ledger_amount is zero when the feed sent no amount" do
+    @lunchflow_transaction.amount = nil
+
+    assert_nil @lunchflow_transaction.amount_minor
+    assert_equal 0.to_d, @lunchflow_transaction.signed_ledger_amount
+  end
 end

--- a/test/models/simplefin/account_test.rb
+++ b/test/models/simplefin/account_test.rb
@@ -68,13 +68,28 @@ class Simplefin::AccountTest < ActiveSupport::TestCase
   test "suggested_opening_balance amount aligns with SimpleFIN transactions" do
     assert_not_empty @reconciled_simplefin_account.transactions
 
-    amount_sum = @reconciled_simplefin_account.transactions.reduce(0.to_d) do |sum, transaction|
-      sum + transaction.amount.to_d
-    end
+    # Fixture: 50.00 reported balance, rows of -30.00, 25.00, 10.00 and 15.00 (net +20.00).
     result = @reconciled_simplefin_account.suggested_opening_balance
 
-    expected_amount = @reconciled_simplefin_account.balance.to_d - amount_sum
-    assert_equal expected_amount, result[:amount]
+    assert_equal 30.to_d, result[:amount]
+  end
+
+  test "suggested_opening_balance walks back a negative inbound transfer as money arriving" do
+    simplefin_account = build_simplefin_account(balance: "100.00")
+    build_simplefin_transaction(simplefin_account, amount: "-30.00", description: "Test Purchase")
+    build_simplefin_transaction(simplefin_account, amount: "-20.00", description: "TRANSFERRED FROM Test Savings")
+
+    # The transfer is posted as +20.00 by the importer (#222), so the walk-back is
+    # 100.00 - (-30.00 + 20.00). Subtracting the raw feed signs would return 150.00.
+    assert_equal 110.to_d, simplefin_account.suggested_opening_balance[:amount]
+  end
+
+  test "suggested_opening_balance ignores a row the feed sent no amount for" do
+    simplefin_account = build_simplefin_account(balance: "100.00")
+    build_simplefin_transaction(simplefin_account, amount: "-30.00", description: "Test Purchase")
+    build_simplefin_transaction(simplefin_account, amount: nil, description: "Test Transaction")
+
+    assert_equal 130.to_d, simplefin_account.suggested_opening_balance[:amount]
   end
 
   test "suggested_opening_balance date aligns with SimpleFIN transactions" do
@@ -108,4 +123,30 @@ class Simplefin::AccountTest < ActiveSupport::TestCase
       linked_account.update!(name: "Updated Name")
     end
   end
+
+  private
+
+    # Built here rather than added to the fixtures: test/system/integrations_test.rb
+    # asserts the exact list of fixture account names on the integrations page.
+    def build_simplefin_account(balance:)
+      Simplefin::Account.create!(
+        connection: simplefin_connections(:one),
+        remote_id: "opening_balance_#{balance}",
+        org: { "name" => "Test Bank" },
+        name: "Test Checking",
+        currency: "USD",
+        balance: balance,
+        balance_date: Time.current
+      )
+    end
+
+    def build_simplefin_transaction(simplefin_account, amount:, description:)
+      simplefin_account.transactions.create!(
+        remote_id: "opening_balance_txn_#{description}",
+        amount: amount,
+        description: description,
+        posted: 1.day.ago,
+        pending: false
+      )
+    end
 end

--- a/test/models/simplefin/transaction_test.rb
+++ b/test/models/simplefin/transaction_test.rb
@@ -2,24 +2,59 @@ require "test_helper"
 
 class Simplefin::TransactionTest < ActiveSupport::TestCase
   setup do
-    @user = users(:one)
+    @simplefin_transaction = simplefin_transactions(:transaction_one)
+  end
 
-    @bank_account = Account.create!(
-      user: @user,
-      currency: @currency,
-      name: "Test Bank Account",
-      kind: :asset
-    )
+  test "belongs to account" do
+    assert_equal simplefin_accounts(:linked_one), @simplefin_transaction.account
+  end
 
-    @connection = simplefin_connections(:one)
+  test "resolved_description passes the description through" do
+    assert_equal @simplefin_transaction.description, @simplefin_transaction.resolved_description
+  end
 
-    @account = Simplefin::Account.create!(
-      connection: @connection,
-      ledger_account: @bank_account,
-      remote_id: "acc_test",
-      name: "Test Account",
-      currency: "USD",
-      balance: "1000.00"
-    )
+  test "ledger_direction puts a negative amount on src" do
+    direction = @simplefin_transaction.ledger_direction
+
+    assert_equal :src, direction.ledger_side
+    assert_not direction.direction_overridden?
+  end
+
+  test "ledger_direction puts a non-negative amount on dest" do
+    @simplefin_transaction.amount = "50.00"
+
+    assert_equal :dest, @simplefin_transaction.ledger_direction.ledger_side
+  end
+
+  test "ledger_direction flips a negative inbound transfer to dest" do
+    @simplefin_transaction.description = "TRANSFERRED FROM Test Savings"
+    direction = @simplefin_transaction.ledger_direction
+
+    assert_equal :dest, direction.ledger_side
+    assert direction.direction_overridden?
+  end
+
+  test "signed_ledger_amount is negative for an outflow" do
+    assert_equal(-50.to_d, @simplefin_transaction.signed_ledger_amount)
+  end
+
+  test "signed_ledger_amount is positive for an inflow" do
+    @simplefin_transaction.amount = "50.00"
+
+    assert_equal 50.to_d, @simplefin_transaction.signed_ledger_amount
+  end
+
+  test "signed_ledger_amount is positive for a negative inbound transfer" do
+    @simplefin_transaction.amount = "-20.00"
+    @simplefin_transaction.description = "TRANSFERRED FROM Test Savings"
+
+    assert_equal 20.to_d, @simplefin_transaction.signed_ledger_amount
+  end
+
+  test "signed_ledger_amount is zero when the feed sent no amount" do
+    @simplefin_transaction.amount = nil
+
+    assert_nil @simplefin_transaction.amount_minor
+    assert_equal 0.to_d, @simplefin_transaction.signed_ledger_amount
   end
 end


### PR DESCRIPTION
## Problem

`Simplefin::Account#suggested_opening_balance` walked a reported balance backwards by subtracting each row's **raw feed amount**:

```ruby
amount -= simplefin_transaction.amount.to_d
```

That was correct while the sign of a feed row always matched the direction the importer posted it in. #222 ended that: `Transaction::InferLedgerSide` flips a `TRANSFER…FROM` row that arrives negative to `:dest`, and the importers store the ledger amount as `.abs`. The walk-back never consulted the service, so every overridden row was walked in the wrong direction — overstating the suggestion by **twice** that row's absolute amount.

This is the app's own answer to "what should my opening balance be?", offered on `GET /accounts/new` exactly when a user is trying to make a linked account agree with the bank. An account that triggers the override is precisely the kind of account with an opening-balance problem worth fixing, so the two conditions coincide. Nothing is written automatically, but acting on the suggestion bakes the error into the ledger where it reads as a data-entry mistake rather than a computed one.

Two corrections to the issue's premises, found while planning:

- **`Lunchflow::Account` does have `suggested_opening_balance`**, with the same flaw. Fixed here too. That feed signs transfers correctly today so the override stays inert, but the latent bug was real.
- **The "rows created before #222" caveat does not apply to this path.** `suggested_opening_balance` is called only from `AccountsController#new`, before the source is linked and before any import job has run for it. There are no ledger rows to be inconsistent with, so re-deriving the direction is exactly right.

`Account#reset_balance` is the only other balance reconstruction, and it sums ledger transactions by side — already post-`.abs` and post-direction. It is correct, and it is the reconstruction this change makes the suggestion agree with.

## Approach

Move the "how will this row be posted" question onto the row models, so an importer and a balance walk-back cannot answer it differently.

New `AggregatorSourceable` concern, included by `Simplefin::Transaction` and `Lunchflow::Transaction`:

- `ledger_direction` — feeds `Transaction::InferLedgerSide` and returns its `Result`.
- `signed_ledger_amount` — the row's contribution to the ledger balance, signed by that direction rather than by the provider's sign. Returns `amount.to_d` untouched when `amount_minor` is nil (the provider sent no amount), where `InferLedgerSide` would raise on `nil.negative?` and there is no sign to apply anyway.

Each model defines the `resolved_description` hook. Lunch Flow's *merchant-over-description* rule moves there from inside its import job — leaving it in the job and copying it into the model would have created a second place for it to drift, which is the same failure this issue is.

Both walk-backs become `amount -= …signed_ledger_amount`; nothing else in either method changes. Both import jobs read `ledger_direction` / `resolved_description` instead of calling the service inline. That side is a pure refactor, covered by the existing #222 tests.

Out of scope, unchanged: `Csv::ImportTransactionsJob` still derives direction from the sign alone (deliberately — its descriptions are user-authored with no provider signing convention behind them), and no backfill of already-imported ledger rows.

## Test plan

| Coverage | Where |
| --- | --- |
| Balance 100.00 with rows −30.00 and a −20.00 inbound transfer suggests **110.00**, not 150.00 | `test/models/simplefin/account_test.rb` |
| Same scenario on Lunch Flow | `test/models/lunchflow/account_test.rb` |
| Direction comes from `resolved_description`: transfer wording in `merchant` fires the override, wording in `description` that the merchant shadows does not | `test/models/lunchflow/{account,transaction}_test.rb` |
| A row the feed sent no amount for contributes 0 and does not raise | both `transaction_test.rb`, `test/models/simplefin/account_test.rb` |
| `ledger_direction` / `signed_ledger_amount` per side, override and inert cases | `test/models/simplefin/transaction_test.rb`, `test/models/lunchflow/transaction_test.rb` |
| **End to end**: an opening balance taken from the suggestion lands the linked account on the balance the feed reports, after linking and importing. Pre-fix this landed 40.00 high | `test/jobs/simplefin/import_transactions_job_test.rb` |
| Existing "amount aligns with …" tests now assert explicit values instead of re-deriving `balance − Σ amount`, which mirrored the implementation and could not fail | both account tests |
| Import-job behaviour unchanged | existing #222 tests, no edits |

Fixtures deliberately gained no rows — `test/system/integrations_test.rb` asserts the exact ordered list of fixture account names, so the scenarios are built inside the tests. The stale `$20.00 opening balance` comment in the SimpleFIN transaction fixtures was corrected to match its own arithmetic.

Verified the new tests are load-bearing two ways: with `INBOUND_TRANSFER_PATTERN` neutered, exactly the six new override-dependent tests fail alongside the #222 ones while the inert-feed and explicit-value tests still pass; and with only the SimpleFIN walk-back reverted to the raw sign, the unit test and the end-to-end test fail on their own.

Local run: 958 tests / 0 failures, 69 system tests / 0 failures, RuboCop clean, Brakeman 0 warnings, bundler-audit and importmap audit clean.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)