### PR TITLE
Scope Turbo Stream row insertions to the account-filtered transactions list

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -349,9 +349,14 @@ class TransactionsController < ApplicationController
       visible_transactions(show_excluded: show_excluded?).exists?(id: transaction.id)
     end
 
+    # The nearest row that sorts below `transaction`, i.e. the one it must be
+    # inserted before. The predicate mirrors the (transacted_at, created_at)
+    # sort order exactly, so a row older by date but newer by creation still
+    # counts as below.
     def find_preceding_transaction(transaction)
       visible_transactions(show_excluded: show_excluded?)
-        .where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
+        .where("transacted_at < :at OR (transacted_at = :at AND created_at < :cat)",
+               at: transaction.transacted_at, cat: transaction.created_at)
         .order(transacted_at: :desc, created_at: :desc).first
     end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,5 +1,6 @@
 class TransactionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_filter_account
   before_action :set_transaction, only: %i[ show edit update destroy ]
   before_action :set_form_collections, only: %i[ index new create edit update show ]
 
@@ -8,14 +9,9 @@ class TransactionsController < ApplicationController
     @new_transaction = build_new_transaction
 
     @show_excluded = params[:show_excluded] == "1"
-    scope = current_user.transactions.unmerged
-    scope = scope.unexcluded unless @show_excluded
-    @transactions = scope.includes(:category, :src_account, :dest_account, :currency, :fx_currency, transaction_sources: :sourceable, merged_sources: [ :src_account, :dest_account, { transaction_sources: :sourceable } ]).order(transacted_at: :desc, created_at: :desc)
-    account_id = params.fetch(:account_id, nil)
-    if account_id.present?
-      @account = current_user.accounts.find(account_id)
-      @transactions = @transactions.where(src_account_id: @account.id).or(@transactions.where(dest_account_id: @account.id))
-    end
+    @transactions = visible_transactions(show_excluded: @show_excluded)
+      .includes(:category, :src_account, :dest_account, :currency, :fx_currency, transaction_sources: :sourceable, merged_sources: [ :src_account, :dest_account, { transaction_sources: :sourceable } ])
+      .order(transacted_at: :desc, created_at: :desc)
   end
 
   # GET /transactions/1 or /transactions/1.json
@@ -34,7 +30,8 @@ class TransactionsController < ApplicationController
     respond_to do |format|
       if @transaction.save
         format.turbo_stream do
-          @last_transaction = find_preceding_transaction(@transaction)
+          @row_visible = row_visible?(@transaction)
+          @last_transaction = find_preceding_transaction(@transaction) if @row_visible
           @new_transaction = build_new_transaction
         end
         format.html { redirect_to @transaction, notice: "Transaction was successfully created." }
@@ -73,16 +70,23 @@ class TransactionsController < ApplicationController
 
     respond_to do |format|
       if unmerger.call
-        @restored_transactions = unmerger.restored_transactions
+        scope = visible_transactions(show_excluded: show_excluded?)
+        restored = unmerger.restored_transactions
           .sort_by { |t| [ t.transacted_at, t.created_at ] }.reverse
+        # Only legs that belong in the list being rendered can be inserted; an
+        # account-filtered index may exclude some or all of them.
+        visible_ids = scope.where(id: restored.map(&:id)).pluck(:id)
+        @restored_transactions = restored.select { |t| visible_ids.include?(t.id) }
+
         # Find the nearest transaction that's newer (appears above in the list) to insert after.
         # This element is already in the DOM, unlike older ones which may be off-screen or absent.
         newest = @restored_transactions.first
-        @after_transaction = current_user.transactions.unmerged.unexcluded
-          .where.not(id: @restored_transactions.map(&:id))
-          .where("transacted_at > :at OR (transacted_at = :at AND created_at > :cat)",
-                 at: newest.transacted_at, cat: newest.created_at)
-          .order(transacted_at: :asc, created_at: :asc).first
+        @after_transaction = if newest
+          scope.where.not(id: restored.map(&:id))
+            .where("transacted_at > :at OR (transacted_at = :at AND created_at > :cat)",
+                   at: newest.transacted_at, cat: newest.created_at)
+            .order(transacted_at: :asc, created_at: :asc).first
+        end
         @removed_id = @transaction.id
         format.turbo_stream
       else
@@ -117,7 +121,8 @@ class TransactionsController < ApplicationController
     respond_to do |format|
       if merger.call
         @merged_transaction = merger.merged_transaction
-        @last_transaction = find_preceding_transaction(@merged_transaction)
+        @row_visible = row_visible?(@merged_transaction)
+        @last_transaction = find_preceding_transaction(@merged_transaction) if @row_visible
         @removed_ids = [ transaction_a.id, transaction_b.id ]
         format.turbo_stream
       else
@@ -296,6 +301,13 @@ class TransactionsController < ApplicationController
       @transaction = current_user.transactions.find(params.expect(:id))
     end
 
+    # The account the index is filtered to, threaded through mutating requests by
+    # a hidden field so Turbo Stream insertions can be scoped to the same list.
+    def set_filter_account
+      account_id = params[:account_id]
+      @account = current_user.accounts.find(account_id) if account_id.present?
+    end
+
     def bulk_transaction_ids
       Array(params[:transaction_ids]).uniq
     end
@@ -321,10 +333,25 @@ class TransactionsController < ApplicationController
       ])
     end
 
-    def find_preceding_transaction(transaction)
+    # The rows the index is currently rendering. Turbo Stream insertions must be
+    # anchored inside this same scope, or they target a DOM id that isn't on the
+    # page and Turbo drops them silently.
+    def visible_transactions(show_excluded:)
       scope = current_user.transactions.unmerged
-      scope = scope.unexcluded unless show_excluded?
-      scope.where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
+      scope = scope.unexcluded unless show_excluded
+      if @account
+        scope = scope.where(src_account_id: @account.id).or(scope.where(dest_account_id: @account.id))
+      end
+      scope
+    end
+
+    def row_visible?(transaction)
+      visible_transactions(show_excluded: show_excluded?).exists?(id: transaction.id)
+    end
+
+    def find_preceding_transaction(transaction)
+      visible_transactions(show_excluded: show_excluded?)
+        .where("transacted_at <= ? AND created_at < ?", transaction.transacted_at, transaction.created_at)
         .order(transacted_at: :desc, created_at: :desc).first
     end
 

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -3,6 +3,12 @@
   action: "transactions--form#clearError",
   transactions__row_target: "form"
 }, html: { autocomplete: "off" }) do |form| %>
+  <%# Tells the create action which account's list is on screen, so the new row is
+      anchored inside that list instead of the user's full transaction history. %>
+  <% if local_assigns[:filter_account] %>
+    <%= hidden_field_tag :account_id, local_assigns[:filter_account].id %>
+  <% end %>
+
   <div class="row" data-action="keydown.esc->transactions--row#cancelEdit">
     <div class="select"></div>
     <div>

--- a/app/views/transactions/_selection_bar.html.erb
+++ b/app/views/transactions/_selection_bar.html.erb
@@ -49,21 +49,26 @@
   </button>
 </div>
 
-<%# Bulk action forms; the controller injects transaction_ids before submit. %>
+<%# Bulk action forms; the controller injects transaction_ids before submit.
+    account_id carries the index's account filter so the response can scope its
+    Turbo Stream targets to the list on screen. %>
 <%= form_with url: bulk_destroy_transactions_path, method: :delete,
       data: { transactions__selection_target: "deleteForm",
               action: "turbo:submit-end->transactions--selection#cancel" } do %>
+  <%= hidden_field_tag :account_id, filter_account.id if filter_account %>
 <% end %>
 
 <%= form_with url: bulk_exclude_transactions_path, method: :post,
       data: { transactions__selection_target: "excludeForm",
               action: "turbo:submit-end->transactions--selection#cancel" } do %>
+  <%= hidden_field_tag :account_id, filter_account.id if filter_account %>
 <% end %>
 
 <% if show_excluded %>
   <%= form_with url: bulk_unexclude_transactions_path, method: :post,
         data: { transactions__selection_target: "restoreForm",
                 action: "turbo:submit-end->transactions--selection#cancel" } do %>
+    <%= hidden_field_tag :account_id, filter_account.id if filter_account %>
   <% end %>
 <% end %>
 
@@ -76,6 +81,7 @@
     <%= form_with url: merge_transactions_path, method: :post, data: { action: "turbo:submit-end->transactions--selection#cancel" } do %>
       <input type="hidden" name="transaction_ids[]" value="" data-slot="a">
       <input type="hidden" name="transaction_ids[]" value="" data-slot="b">
+      <%= hidden_field_tag :account_id, filter_account.id if filter_account %>
 
       <div class="selection-confirmation__field">
         <label for="merge_description">Description</label>
@@ -123,6 +129,7 @@
           data: { transactions__selection_target: "combineForm",
                   action: "turbo:submit-end->transactions--selection#cancel" } do %>
       <input type="hidden" name="survivor_id" value="" data-transactions--selection-target="combineSurvivorId">
+      <%= hidden_field_tag :account_id, filter_account.id if filter_account %>
 
       <div class="selection-confirmation__actions">
         <button type="button" class="selection-bar__btn selection-bar__btn--primary"

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -64,13 +64,16 @@
           <a href="#" data-action="transactions--row#edit">Edit</a>
         <% end %>
         <%= link_to "Delete", transaction, data: { turbo_method: :delete, turbo_confirm: "Delete this transaction?", turbo_frame: dom_id(transaction) } %>
+        <%# account_id keeps the index's account filter attached to the row, so the
+            responses can scope their Turbo Stream targets to the list on screen.
+            Rails omits the param when the index is unfiltered. %>
         <% if transaction.excluded? %>
-          <%= link_to "Restore", unexclude_transaction_path(transaction), data: { turbo_method: :post } %>
+          <%= link_to "Restore", unexclude_transaction_path(transaction, account_id: @account&.id), data: { turbo_method: :post } %>
         <% elsif transaction.excludable? %>
-          <%= link_to "Exclude", exclude_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
+          <%= link_to "Exclude", exclude_transaction_path(transaction, account_id: @account&.id), data: { turbo_method: :post, turbo_confirm: "Exclude this transaction? It will be hidden from calculations but not reimported." } %>
         <% end %>
         <% if transaction.merged_sources.any? %>
-          <%= link_to "Unmerge", unmerge_transaction_path(transaction), data: { turbo_method: :post, turbo_confirm: "Unmerge this transfer back into the original transactions?" } %>
+          <%= link_to "Unmerge", unmerge_transaction_path(transaction, account_id: @account&.id), data: { turbo_method: :post, turbo_confirm: "Unmerge this transfer back into the original transactions?" } %>
         <% end %>
       </div>
 

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -93,7 +93,9 @@
     </div>
 
     <!-- Edit -->
-    <%= turbo_frame_tag dom_id(transaction, :edit), src: edit_transaction_path(transaction), loading: "lazy", class: "edit" do %>
+    <%# account_id rides along so the edit form posts it back and the replaced row
+        keeps its action links scoped to the list on screen. %>
+    <%= turbo_frame_tag dom_id(transaction, :edit), src: edit_transaction_path(transaction, account_id: @account&.id), loading: "lazy", class: "edit" do %>
       <div class="row">
         <div class="loading">Loading...</div>
       </div>

--- a/app/views/transactions/create.turbo_stream.erb
+++ b/app/views/transactions/create.turbo_stream.erb
@@ -3,15 +3,21 @@
     <%= render partial: 'form', locals: {
       transaction: @new_transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      filter_account: @account
     } %>
   <% end %>
 <% end %>
 
-<% if @last_transaction %>
-  <%= turbo_stream.before dom_id(@last_transaction), @transaction %>
-<% else %>
-  <%= turbo_stream.prepend :transactions do %>
-    <%= render @transaction %>
+<%# No insertion when the saved transaction falls outside the list on screen —
+    appending it would show a row the filter excludes. %>
+<% if @row_visible %>
+  <% if @last_transaction %>
+    <%= turbo_stream.before dom_id(@last_transaction), @transaction %>
+  <% else %>
+    <%# Nothing in the list sorts at or below it, so it is the oldest row. %>
+    <%= turbo_stream.append :transactions do %>
+      <%= render @transaction %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -2,6 +2,7 @@
   <%= render partial: 'form', locals: {
     transaction: @transaction,
     accounts: @accounts,
-    categories: @categories
+    categories: @categories,
+    filter_account: @account
   } %>
 <% end %>

--- a/app/views/transactions/edit.turbo_stream.erb
+++ b/app/views/transactions/edit.turbo_stream.erb
@@ -3,7 +3,8 @@
     <%= render partial: 'form', locals: {
       transaction: @transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      filter_account: @account
     } %>
   <% end %>
 <% end %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -34,7 +34,8 @@
       <%= render partial: 'form', locals: {
         transaction: @new_transaction,
         accounts: @accounts,
-        categories: @categories
+        categories: @categories,
+        filter_account: @account
       } %>
     <% end %>
 
@@ -43,5 +44,5 @@
     <% end %>
   </div>
 
-  <%= render "selection_bar", categories: @categories, show_excluded: @show_excluded %>
+  <%= render "selection_bar", categories: @categories, show_excluded: @show_excluded, filter_account: @account %>
 </div>

--- a/app/views/transactions/merge.turbo_stream.erb
+++ b/app/views/transactions/merge.turbo_stream.erb
@@ -2,10 +2,14 @@
   <%= turbo_stream.remove "transaction_#{id}" %>
 <% end %>
 
-<% if @last_transaction %>
-  <%= turbo_stream.before dom_id(@last_transaction), @merged_transaction %>
-<% else %>
-  <%= turbo_stream.prepend :transactions do %>
-    <%= render @merged_transaction %>
+<%# No insertion when the merged transfer falls outside the list on screen. %>
+<% if @row_visible %>
+  <% if @last_transaction %>
+    <%= turbo_stream.before dom_id(@last_transaction), @merged_transaction %>
+  <% else %>
+    <%# Nothing in the list sorts at or below it, so it is the oldest row. %>
+    <%= turbo_stream.append :transactions do %>
+      <%= render @merged_transaction %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -2,6 +2,7 @@
   <%= render partial: 'form', locals: {
     transaction: @transaction,
     accounts: @accounts,
-    categories: @categories
+    categories: @categories,
+    filter_account: @account
   } %>
 <% end %>

--- a/app/views/transactions/new.turbo_stream.erb
+++ b/app/views/transactions/new.turbo_stream.erb
@@ -3,7 +3,8 @@
     <%= render partial: 'form', locals: {
       transaction: @transaction,
       accounts: @accounts,
-      categories: @categories
+      categories: @categories,
+      filter_account: @account
     } %>
   <% end %>
 <% end %>

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -120,6 +120,121 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "create anchors the new row to the newest transaction on the unfiltered index" do
+    # asset_account -> expense_account, 2 days ago; the newest row user one owns.
+    newest = transactions(:one)
+
+    post transactions_url, params: { transaction: {
+      transacted_at: Time.current,
+      src_account_id: accounts(:asset_account).id,
+      dest_account_id: accounts(:expense_account).id,
+      description: "Unfiltered create",
+      amount: "10.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, %(action="before" target="#{ActionView::RecordIdentifier.dom_id(newest)}")
+  end
+
+  test "create on an account-filtered index anchors to a row in that account's list" do
+    account = accounts(:asset_account)
+    # Newer than every row in the account's list, but touching neither of its
+    # sides — the anchor the unfiltered query would have picked.
+    unrelated = Transaction.create!(user: @user, src_account: accounts(:liability_account),
+                                    dest_account: accounts(:expense_account), amount_minor: 100,
+                                    currency: currencies(:usd), description: "Unrelated row",
+                                    transacted_at: 1.day.ago)
+
+    post transactions_url, params: { account_id: account.id, transaction: {
+      transacted_at: Time.current,
+      src_account_id: account.id,
+      dest_account_id: accounts(:expense_account).id,
+      description: "Filtered create",
+      amount: "25.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, %(action="before" target="#{ActionView::RecordIdentifier.dom_id(transactions(:one))}")
+    assert_not_includes response.body, ActionView::RecordIdentifier.dom_id(unrelated)
+  end
+
+  test "create on an account-filtered index with an empty list appends the row" do
+    account = accounts(:liability_account)
+    assert_empty @user.transactions.where(src_account: account).or(@user.transactions.where(dest_account: account))
+
+    post transactions_url, params: { account_id: account.id, transaction: {
+      transacted_at: Time.current,
+      src_account_id: account.id,
+      dest_account_id: accounts(:expense_account).id,
+      description: "First row for this account",
+      amount: "25.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, %(action="append" target="transactions")
+    assert_includes response.body, "First row for this account"
+  end
+
+  test "create on an account-filtered index emits no row for a transaction outside the filter" do
+    post transactions_url, params: { account_id: accounts(:liability_account).id, transaction: {
+      transacted_at: Time.current,
+      src_account_id: accounts(:asset_account).id,
+      dest_account_id: accounts(:expense_account).id,
+      description: "Belongs to another account",
+      amount: "25.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    # The form is still reset, but nothing is inserted into the filtered list.
+    assert_includes response.body, %(action="replace" target="new_transaction")
+    assert_not_includes response.body, "Belongs to another account"
+    assert_not_includes response.body, %(action="before")
+    assert_not_includes response.body, %(action="append")
+  end
+
+  test "create appends a transaction older than every row in the list" do
+    post transactions_url, params: { transaction: {
+      transacted_at: 10.days.ago,
+      src_account_id: accounts(:asset_account).id,
+      dest_account_id: accounts(:expense_account).id,
+      description: "Backdated create",
+      amount: "25.00"
+    } }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, %(action="append" target="transactions")
+    assert_not_includes response.body, %(action="before")
+  end
+
+  test "create rejects an account_id belonging to another user" do
+    assert_no_difference("Transaction.count") do
+      post transactions_url, params: { account_id: accounts(:two).id, transaction: {
+        transacted_at: Time.current,
+        src_account_id: accounts(:asset_account).id,
+        dest_account_id: accounts(:expense_account).id,
+        description: "Foreign account filter",
+        amount: "25.00"
+      } }, as: :turbo_stream
+    end
+
+    assert_response :not_found
+  end
+
+  test "merge rejects an account_id belonging to another user" do
+    post merge_transactions_url, params: {
+      account_id: accounts(:two).id,
+      transaction_ids: [ transactions(:one).id, transactions(:two).id ]
+    }, as: :turbo_stream
+
+    assert_response :not_found
+  end
+
+  test "unmerge rejects an account_id belonging to another user" do
+    post unmerge_transaction_url(@transaction), params: { account_id: accounts(:two).id }, as: :turbo_stream
+
+    assert_response :not_found
+  end
+
   test "should update transaction with turbo_stream" do
     patch transaction_url(@transaction), params: { transaction: {
       description: "Updated description",
@@ -338,6 +453,86 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil deposit.merged_into_id
     assert_equal 500, withdrawal.amount_minor
     assert_equal 500, deposit.amount_minor
+  end
+
+  test "merge on an account-filtered index anchors to a row in that account's list" do
+    currency = currencies(:usd)
+    bank = accounts(:asset_account)
+    other_bank = accounts(:linked_asset)
+    # Newer than every row in the account's list, but touching neither of its
+    # sides — the anchor the unfiltered query would have picked.
+    unrelated = Transaction.create!(user: @user, src_account: accounts(:liability_account),
+                                    dest_account: accounts(:expense_account), amount_minor: 100,
+                                    currency: currency, description: "Unrelated row",
+                                    transacted_at: 1.day.ago)
+    withdrawal = Transaction.create!(user: @user, src_account: bank, dest_account: accounts(:expense_account),
+                                     amount_minor: 1000, currency: currency, description: "Filtered merge",
+                                     transacted_at: Time.current)
+    deposit = Transaction.create!(user: @user, src_account: accounts(:revenue_account), dest_account: other_bank,
+                                  amount_minor: 1000, currency: currency, description: "Filtered merge",
+                                  transacted_at: Time.current)
+
+    post merge_transactions_url, params: {
+      account_id: bank.id,
+      transaction_ids: [ withdrawal.id, deposit.id ],
+      description: "Merged transfer"
+    }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, %(action="before" target="#{ActionView::RecordIdentifier.dom_id(transactions(:one))}")
+    assert_not_includes response.body, %(target="#{ActionView::RecordIdentifier.dom_id(unrelated)}")
+  end
+
+  test "merge on an account-filtered index emits no row for a transfer outside the filter" do
+    currency = currencies(:usd)
+    withdrawal = Transaction.create!(user: @user, src_account: accounts(:asset_account),
+                                     dest_account: accounts(:expense_account), amount_minor: 1000,
+                                     currency: currency, description: "Offscreen merge",
+                                     transacted_at: Time.current)
+    deposit = Transaction.create!(user: @user, src_account: accounts(:revenue_account),
+                                  dest_account: accounts(:linked_asset), amount_minor: 1000,
+                                  currency: currency, description: "Offscreen merge",
+                                  transacted_at: Time.current)
+
+    post merge_transactions_url, params: {
+      account_id: accounts(:liability_account).id,
+      transaction_ids: [ withdrawal.id, deposit.id ],
+      description: "Merged offscreen transfer"
+    }, as: :turbo_stream
+
+    assert_response :success
+    # The originals are still removed from the list; nothing takes their place.
+    assert_includes response.body, %(action="remove" target="transaction_#{withdrawal.id}")
+    assert_not_includes response.body, "Merged offscreen transfer"
+    assert_not_includes response.body, %(action="before")
+    assert_not_includes response.body, %(action="append")
+  end
+
+  test "unmerge on an account-filtered index restores only the legs in that account's list" do
+    withdrawal, deposit, merged, unrelated = merged_pair_for_unmerge
+
+    post unmerge_transaction_url(merged), params: { account_id: accounts(:asset_account).id }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, "Unmerge withdrawal leg"
+    assert_not_includes response.body, "Unmerge deposit leg"
+    assert_not_includes response.body, ActionView::RecordIdentifier.dom_id(deposit)
+    # Anchored to the nearest newer row in the account's list, not to the newer
+    # transaction that belongs to a different account.
+    assert_includes response.body, %(action="after" target="#{ActionView::RecordIdentifier.dom_id(transactions(:one))}")
+    assert_not_includes response.body, %(target="#{ActionView::RecordIdentifier.dom_id(unrelated)}")
+    assert_nil withdrawal.reload.merged_into_id
+  end
+
+  test "unmerge on the unfiltered index restores both legs" do
+    _withdrawal, _deposit, merged, unrelated = merged_pair_for_unmerge
+
+    post unmerge_transaction_url(merged), as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, "Unmerge withdrawal leg"
+    assert_includes response.body, "Unmerge deposit leg"
+    assert_includes response.body, %(action="after" target="#{ActionView::RecordIdentifier.dom_id(unrelated)}")
   end
 
   test "unmerge on non-merged transaction returns error" do
@@ -900,4 +1095,31 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
       post bulk_unexclude_transactions_url, params: { transaction_ids: [ transaction.id ] }, as: :turbo_stream
     end
   end
+
+  private
+
+    # A merged transfer whose two legs touch different banks, plus a row that is
+    # newer than both legs but touches neither bank. The unfiltered index anchors
+    # the restored rows to that row; an index filtered to :asset_account must
+    # anchor to transactions(:one) and restore only the withdrawal leg.
+    def merged_pair_for_unmerge
+      currency = currencies(:usd)
+      withdrawal = Transaction.create!(user: @user, src_account: accounts(:asset_account),
+                                       dest_account: accounts(:expense_account), amount_minor: 500,
+                                       currency: currency, description: "Unmerge withdrawal leg",
+                                       transacted_at: 3.days.ago)
+      deposit = Transaction.create!(user: @user, src_account: accounts(:revenue_account),
+                                    dest_account: accounts(:linked_asset), amount_minor: 500,
+                                    currency: currency, description: "Unmerge deposit leg",
+                                    transacted_at: 3.days.ago)
+      unrelated = Transaction.create!(user: @user, src_account: accounts(:liability_account),
+                                      dest_account: accounts(:expense_account), amount_minor: 100,
+                                      currency: currency, description: "Unrelated row",
+                                      transacted_at: 60.hours.ago)
+
+      merger = Transaction::Merge.new(withdrawal, deposit, user: @user)
+      merger.call
+
+      [ withdrawal, deposit, merger.merged_transaction, unrelated ]
+    end
 end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -206,6 +206,37 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, %(action="before")
   end
 
+  test "account-filtered index keeps the filter on each row's lazy edit frame" do
+    account = accounts(:asset_account)
+
+    get account_transactions_url(account)
+
+    assert_response :success
+    assert_includes response.body, edit_transaction_path(transactions(:one), account_id: account.id)
+  end
+
+  test "edit renders the form with the account filter" do
+    account = accounts(:asset_account)
+
+    get edit_transaction_url(@transaction, account_id: account.id)
+
+    assert_response :success
+    assert_select "input[type=hidden][name=?][value=?]", "account_id", account.id.to_s
+  end
+
+  test "update on an account-filtered index keeps the filter on the row's action links" do
+    _withdrawal, _deposit, merged, _unrelated = merged_pair_for_unmerge
+    account = accounts(:asset_account)
+
+    patch transaction_url(merged), params: {
+      account_id: account.id,
+      transaction: { description: "Renamed transfer" }
+    }, as: :turbo_stream
+
+    assert_response :success
+    assert_includes response.body, unmerge_transaction_path(merged, account_id: account.id)
+  end
+
   test "create rejects an account_id belonging to another user" do
     assert_no_difference("Transaction.count") do
       post transactions_url, params: { account_id: accounts(:two).id, transaction: {

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -150,6 +150,53 @@ class TransactionsTest < ApplicationSystemTestCase
     assert_no_selector "##{ActionView::RecordIdentifier.dom_id(leg_b)}"
   end
 
+  test "creating a transaction on an account-filtered index inserts the row in place" do
+    account = accounts(:asset_account)
+    # Newer than every row in the account's list, but on neither of its sides.
+    # It is the row the unscoped anchor query used to pick, and it is not on the
+    # page, so the insertion used to be dropped silently.
+    Transaction.create!(
+      user: @user, src_account: accounts(:liability_account), dest_account: accounts(:expense_account),
+      amount_minor: 100, currency: currencies(:usd), description: "Off-list row",
+      transacted_at: 1.day.ago
+    )
+
+    visit account_transactions_path(account)
+    assert_selector "#transactions .transaction", count: 2
+    assert_no_text "Off-list row"
+
+    fill_in "transaction[description]", with: "Filtered live create"
+    select account.name, from: "transaction[src_account_id]"
+    select accounts(:expense_account).name, from: "transaction[dest_account_id]"
+    fill_in "transaction[amount]", with: "31.00"
+    click_button "Create"
+
+    assert_text "Filtered live create"
+    assert_selector "#transactions .transaction", count: 3
+    created = Transaction.find_by!(description: "Filtered live create")
+    assert_equal ActionView::RecordIdentifier.dom_id(created),
+                 first("#transactions > turbo-frame")[:id],
+                 "the newest transaction should be inserted at the top of the list"
+  end
+
+  test "creating a transaction on the unfiltered index inserts the row in place" do
+    visit transactions_path
+    assert_selector "#transactions .transaction", count: 2
+
+    fill_in "transaction[description]", with: "Unfiltered live create"
+    select accounts(:asset_account).name, from: "transaction[src_account_id]"
+    select accounts(:expense_account).name, from: "transaction[dest_account_id]"
+    fill_in "transaction[amount]", with: "31.00"
+    click_button "Create"
+
+    assert_text "Unfiltered live create"
+    assert_selector "#transactions .transaction", count: 3
+    created = Transaction.find_by!(description: "Unfiltered live create")
+    assert_equal ActionView::RecordIdentifier.dom_id(created),
+                 first("#transactions > turbo-frame")[:id],
+                 "the newest transaction should be inserted at the top of the list"
+  end
+
   test "sidebar active state survives a live update" do
     account = accounts(:asset_account)
     other = accounts(:expense_account)


### PR DESCRIPTION
## Summary

Creating a transaction from `/accounts/:account_id/transactions` returned 200 and updated the sidebar balances, but the new row never appeared — only a full reload showed it.

`create`, `merge`, and `unmerge` all anchor their Turbo Stream insertion to a neighbouring row, and all three found that neighbour by querying the user's **entire** transaction history. On an account-filtered page the anchor usually belongs to a different account, so `#transaction_<id>` is not in the DOM and Turbo discards the action silently. The no-anchor fallback failed in the opposite direction, prepending a row the filter should exclude.

`unmerge` had the same defect plus one of its own: it hardcoded `.unexcluded`, ignoring the show-excluded filter.

## Changes

- The index's account filter now reaches the mutating actions through a hidden `account_id` field on the new-transaction form, the selection-bar forms, and the per-row Exclude/Restore/Unmerge links. `request.referer` is deliberately not used — `show_excluded?` already does that and it should not spread.
- New `visible_transactions(show_excluded:)` builds the scope the index renders from; `index`, the anchor queries, and a new `row_visible?` check all share it, so they cannot drift apart.
- When the saved row falls outside the current filter, no insertion is emitted at all.
- `unmerge` restores only the legs that belong in the list on screen, and picks its anchor from that same scope.
- Corrected the no-anchor branch of `create` and `merge`: a nil anchor means nothing in the list sorts at or below the new row, so it belongs at the *bottom*. `append` instead of `prepend`. This was wrong on the unfiltered index too, but is far more visible on a short filtered list.

## Test plan

Controller (`test/controllers/transactions_controller_test.rb`) — 10 of the 12 new tests fail against `main`; the two that pass are deliberate regression guards for the unfiltered index.

- [x] create on an account-filtered index anchors to a row in that account's list, not to a newer row from another account
- [x] create on an account-filtered index with an empty list appends the row
- [x] create on an account-filtered index emits no row for a transaction touching neither side of the filtered account
- [x] create appends a transaction older than every row in the list
- [x] create on the unfiltered index still anchors to the newest row (guard)
- [x] merge on an account-filtered index anchors inside that account's list
- [x] merge on an account-filtered index emits no row for a transfer outside the filter
- [x] unmerge on an account-filtered index restores only the legs in that account's list, anchored to a visible row
- [x] unmerge on the unfiltered index still restores both legs (guard)
- [x] create / merge / unmerge reject an `account_id` belonging to another user

System (`test/system/transactions_test.rb`):

- [x] creating a transaction on an account-filtered index inserts the row at the right position without a reload — this test reproduces the reported bug against `main` (sidebar updates, table does not)
- [x] same flow on the unfiltered index (guard)

Full `bin/rails test`, `bin/rails test:system`, `bin/rubocop`, and `bin/brakeman` are clean.

## Out of scope

- `update` does not re-anchor: editing a transaction on account A's page so it no longer touches A leaves the row visible until reload. Same family, different mechanism (`turbo_stream.replace` rather than an anchor) — worth a separate issue.
- `show_excluded?` stays referer-based; converting it to the same hidden-field mechanism is a separate cleanup.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)