### PR TITLE
Fix validation error card layout in transactions table

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -205,13 +205,17 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* Error messages */
+/* Error messages
+   Kept in normal flow: .transactions is a scroll container (overflow-x: auto forces
+   overflow-y to compute to auto), so an absolutely positioned card hanging below the
+   form row becomes scrollable overflow instead of painted content. position: relative
+   is still needed as the containing block for .close below. */
 .transactions form .error {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
+  position: relative;
   width: 280px;
-  z-index: 10;
+  max-width: calc(100% - 16px);
+  box-sizing: border-box;
+  margin: 8px 8px 8px auto;
 
   background-color: var(--bg-error);
   color: var(--text-error);

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -73,7 +73,7 @@
 
   <% if transaction.errors.any? %>
     <div class="error" role="alert" data-controller="error" data-transactions--form-target="error">
-      <button data-action="error#close" class="close">&times;</button>
+      <button type="button" aria-label="Dismiss error" data-action="error#close" class="close">&times;</button>
       <h4>Transaction could not be saved:</h4>
       <ul>
         <% transaction.errors.full_messages.each do |message| %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -68,18 +68,18 @@
         <%= form.submit "Save" %>
         <a href="#" data-action="transactions--row#cancelEdit transactions--form#clearError">Cancel</a>
       <% end %>
-
-      <% if transaction.errors.any? %>
-        <div class="error" data-controller="error" data-transactions--form-target="error">
-          <button data-action="error#close" class="close">&times;</button>
-          <h4>Transaction could not be saved:</h4>
-          <ul>
-            <% transaction.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
     </div>
   </div>
+
+  <% if transaction.errors.any? %>
+    <div class="error" role="alert" data-controller="error" data-transactions--form-target="error">
+      <button data-action="error#close" class="close">&times;</button>
+      <h4>Transaction could not be saved:</h4>
+      <ul>
+        <% transaction.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -372,6 +372,24 @@ class TransactionsTest < ApplicationSystemTestCase
     assert_error_card_inside_table
   end
 
+  test "dismissing the error card does not resubmit the form" do
+    Transaction.where(user: @user).destroy_all
+
+    visit transactions_path
+
+    fill_in "transaction[description]", with: "No accounts picked"
+    fill_in "transaction[amount]", with: "5.00"
+    click_button "Create"
+    assert_selector ".transactions form .error"
+
+    # The close button lives inside the form, so it must not act as a submit button.
+    find(".transactions form .error .close").click
+
+    assert_no_selector ".transactions form .error"
+    assert_field "transaction[description]", with: "No accounts picked"
+    assert_equal 0, Transaction.where(user: @user).count
+  end
+
   test "validation error on the last row stays inside the transactions table" do
     Transaction.where(user: @user).destroy_all
     transaction = manual_transaction("Editable row", 1234)
@@ -403,8 +421,10 @@ class TransactionsTest < ApplicationSystemTestCase
         return error.getBoundingClientRect().bottom - table.getBoundingClientRect().bottom;
       })()
     JS
-    assert overhang <= 0,
-      "error card hangs #{overhang}px below .transactions and can only be reached by scrolling"
+    # 1px of slack absorbs sub-pixel rounding from getBoundingClientRect; a genuinely
+    # clipped card overhangs by tens of pixels, so the guard stays sharp.
+    assert overhang <= 1,
+      "error card hangs #{overhang.round}px below .transactions and can only be reached by scrolling"
   end
 
   def manual_transaction(description, amount_minor)

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -358,7 +358,54 @@ class TransactionsTest < ApplicationSystemTestCase
     assert_no_selector "##{ActionView::RecordIdentifier.dom_id(deposit)}"
   end
 
+  test "validation error is visible without scrolling the transactions table" do
+    # Worst case for the old absolutely positioned card: nothing below the form row.
+    Transaction.where(user: @user).destroy_all
+
+    visit transactions_path
+
+    fill_in "transaction[description]", with: "No accounts picked"
+    fill_in "transaction[amount]", with: "5.00"
+    click_button "Create"
+
+    assert_selector ".transactions form .error", text: "Transaction could not be saved:"
+    assert_error_card_inside_table
+  end
+
+  test "validation error on the last row stays inside the transactions table" do
+    Transaction.where(user: @user).destroy_all
+    transaction = manual_transaction("Editable row", 1234)
+
+    visit transactions_path
+
+    within "##{ActionView::RecordIdentifier.dom_id(transaction)}" do
+      click_link "Edit"
+      # A blank date fails the `transacted_at` presence validation.
+      find("input[name='transaction[transacted_at]']").set("")
+      click_button "Save"
+
+      assert_selector ".error", text: "Transaction could not be saved:"
+    end
+
+    assert_error_card_inside_table
+  end
+
   private
+
+  # `.transactions` sets `overflow-x: auto`, which makes it a scroll container on both
+  # axes. An error card laid out past the container's content box is clipped and only
+  # reachable by scrolling, so assert it sits inside the box.
+  def assert_error_card_inside_table
+    overhang = page.evaluate_script(<<~JS)
+      (() => {
+        const table = document.querySelector(".transactions");
+        const error = document.querySelector(".transactions .error");
+        return error.getBoundingClientRect().bottom - table.getBoundingClientRect().bottom;
+      })()
+    JS
+    assert overhang <= 0,
+      "error card hangs #{overhang}px below .transactions and can only be reached by scrolling"
+  end
 
   def manual_transaction(description, amount_minor)
     Transaction.create!(


### PR DESCRIPTION
## Summary

Fixes a layout issue where validation error cards in the transactions form could extend below the scrollable `.transactions` container, requiring users to scroll to see the error message. The error card is now kept in normal document flow and positioned inside the table.

## Changes

- **Moved error card outside form row** — The error `<div>` is now rendered after the `.transactions-row` container instead of nested inside it, preventing it from being absolutely positioned relative to the form row.

- **Changed from absolute to relative positioning** — Replaced `position: absolute` with `position: relative` and adjusted layout properties:
  - Removed `top`, `right`, and `z-index` properties
  - Added `margin: 8px 8px 8px auto` for spacing and right-alignment
  - Added `max-width: calc(100% - 16px)` and `box-sizing: border-box` to respect container bounds

- **Added `role="alert"`** — Improves accessibility for screen readers.

- **Added test coverage** — Two new system tests verify the error card stays visible without scrolling:
  - `test "validation error is visible without scrolling the transactions table"` — Tests error visibility on a new transaction form when the table is empty
  - `test "validation error on the last row stays inside the transactions table"` — Tests error visibility when editing the last row in the table
  - Helper method `assert_error_card_inside_table` uses JavaScript to verify the error card's bottom edge doesn't extend below the `.transactions` container

## Implementation Details

The `.transactions` container uses `overflow-x: auto`, which forces `overflow-y: auto` as well, making it a scroll container on both axes. An absolutely positioned card extending below the form row becomes scrollable overflow rather than visible content. By keeping the error card in normal flow with `position: relative`, it remains part of the container's content box and is always visible without scrolling.

https://claude.ai/code/session_013hFxGbpfHDXVkso79xBaPF