### PR TITLE
Fix error message display on transactions table

### DIFF
--- a/app/assets/stylesheets/transactions.css
+++ b/app/assets/stylesheets/transactions.css
@@ -1,7 +1,6 @@
 /* Transactions table */
 .transactions {
   width: 100%;
-  overflow-x: auto;
   border: 1px solid var(--divider);
   border-radius: 8px;
 }


### PR DESCRIPTION
Removes the `overflow-x` rule on `.transactions` to correct the display of error messages on a transaction row. When the table had few rows, it would clip the error message and show a scroll bar on the table instead of showing it entirely.